### PR TITLE
`convertToolPrompt` Improvements: Tool Call Merging and Text Consolidation with New Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
+    "test": "turbo run test",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
@@ -15,7 +16,8 @@
     "@changesets/cli": "2.29.4",
     "prettier": "^3.5.3",
     "turbo": "^2.5.3",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "vitest": "^3.1.4"
   },
   "packageManager": "pnpm@9.14.4",
   "engines": {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest"
   },
   "keywords": [],
   "author": "",

--- a/packages/parser/src/utils/conv-tool-prompt.test.ts
+++ b/packages/parser/src/utils/conv-tool-prompt.test.ts
@@ -1,0 +1,10 @@
+import { describe, test, expect } from "vitest";
+
+describe("convertToolPrompt", () => {
+  // 1. Basic Tool Prompt Generation
+  describe("Basic Tool Prompt Generation", () => {
+    test("should generate prompt with tools for a string input prompt", () => {
+      expect("1").toBe("1");
+    });
+  });
+});

--- a/packages/parser/src/utils/conv-tool-prompt.test.ts
+++ b/packages/parser/src/utils/conv-tool-prompt.test.ts
@@ -156,5 +156,111 @@ describe("convertToolPrompt", () => {
         },
       ]);
     });
+
+    test("should convert multiple tool calls with text correctly", () => {
+      const testParamsPrompt: LanguageModelV2Prompt = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Calling tools to fetch weather information.",
+            },
+            {
+              type: "tool-call",
+              toolName: "get_weather",
+              toolCallId: "12345",
+              args: {
+                location: "San Francisco, CA",
+                unit: "celsius",
+              },
+            },
+            {
+              type: "tool-call",
+              toolName: "get_weather",
+              toolCallId: "67890",
+              args: {
+                location: "New York, NY",
+                unit: "fahrenheit",
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToolPrompt({
+        paramsPrompt: testParamsPrompt,
+        paramsTools: [],
+        toolSystemPromptTemplate: simpleToolSystemPromptTemplate,
+        ...TEST_TAGS,
+      });
+
+      expect(result[1].content).toEqual([
+        {
+          type: "text",
+          text: `Calling tools to fetch weather information.
+<TOOL_CALL>{"arguments":{"location":"San Francisco, CA","unit":"celsius"},"name":"get_weather"}</TOOL_CALL>
+<TOOL_CALL>{"arguments":{"location":"New York, NY","unit":"fahrenheit"},"name":"get_weather"}</TOOL_CALL>`,
+        },
+      ]);
+    });
+
+    test("should convert multiple tool calls with text correctly", () => {
+      const testParamsPrompt: LanguageModelV2Prompt = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "First, I will check the weather in San Francisco.",
+            },
+            {
+              type: "tool-call",
+              toolName: "get_weather",
+              toolCallId: "12345",
+              args: {
+                location: "San Francisco, CA",
+                unit: "celsius",
+              },
+            },
+            {
+              type: "text",
+              text: "Next, I will check the weather in New York.",
+            },
+            {
+              type: "tool-call",
+              toolName: "get_weather",
+              toolCallId: "67890",
+              args: {
+                location: "New York, NY",
+                unit: "fahrenheit",
+              },
+            },
+            {
+              type: "text",
+              text: "Now, I will provide an answer based on the given information.",
+            },
+          ],
+        },
+      ];
+
+      const result = convertToolPrompt({
+        paramsPrompt: testParamsPrompt,
+        paramsTools: [],
+        toolSystemPromptTemplate: simpleToolSystemPromptTemplate,
+        ...TEST_TAGS,
+      });
+
+      expect(result[1].content).toEqual([
+        {
+          type: "text",
+          text: `First, I will check the weather in San Francisco.
+<TOOL_CALL>{"arguments":{"location":"San Francisco, CA","unit":"celsius"},"name":"get_weather"}</TOOL_CALL>
+Next, I will check the weather in New York.
+<TOOL_CALL>{"arguments":{"location":"New York, NY","unit":"fahrenheit"},"name":"get_weather"}</TOOL_CALL>
+Now, I will provide an answer based on the given information.`,
+        },
+      ]);
+    });
   });
 });

--- a/packages/parser/src/utils/conv-tool-prompt.test.ts
+++ b/packages/parser/src/utils/conv-tool-prompt.test.ts
@@ -42,7 +42,7 @@ const simpleToolSystemPromptTemplate = (toolsString: string) =>
 describe("convertToolPrompt", () => {
   // 1. Basic Tool Prompt Generation
   describe("Basic Tool Prompt Generation", () => {
-    test("should generate prompt with tools for a string input prompt", () => {
+    test("generates a system prompt with tool definitions for a user text prompt", () => {
       const testParamsPrompt: LanguageModelV2Prompt = [
         {
           role: "user",
@@ -83,7 +83,7 @@ describe("convertToolPrompt", () => {
   });
 
   describe("Tool Call and Response Handling", () => {
-    test("should convert single tool call correctly", () => {
+    test("converts a single tool-call message to the expected tool call tag format", () => {
       const testParamsPrompt: LanguageModelV2Prompt = [
         {
           role: "assistant",
@@ -114,7 +114,7 @@ describe("convertToolPrompt", () => {
       });
     });
 
-    test("should convert multiple tool calls correctly", () => {
+    test("converts multiple tool-call messages into a single text block with tool call tags", () => {
       const testParamsPrompt: LanguageModelV2Prompt = [
         {
           role: "assistant",
@@ -157,7 +157,7 @@ describe("convertToolPrompt", () => {
       ]);
     });
 
-    test("should convert multiple tool calls with text correctly", () => {
+    test("combines text and multiple tool-call messages into a single text block with tool call tags", () => {
       const testParamsPrompt: LanguageModelV2Prompt = [
         {
           role: "assistant",
@@ -205,7 +205,7 @@ describe("convertToolPrompt", () => {
       ]);
     });
 
-    test("should convert multiple tool calls with text correctly", () => {
+    test("interleaves text and tool-call messages, preserving order and formatting", () => {
       const testParamsPrompt: LanguageModelV2Prompt = [
         {
           role: "assistant",

--- a/packages/parser/src/utils/conv-tool-prompt.test.ts
+++ b/packages/parser/src/utils/conv-tool-prompt.test.ts
@@ -1,10 +1,160 @@
 import { describe, test, expect } from "vitest";
 
+import {
+  LanguageModelV2FunctionTool,
+  LanguageModelV2Prompt,
+} from "@ai-sdk/provider";
+import { convertToolPrompt } from "./conv-tool-prompt";
+
+const TEST_TAGS = {
+  toolCallTag: "<TOOL_CALL>",
+  toolCallEndTag: "</TOOL_CALL>",
+  toolResponseTag: "<TOOL_RESPONSE>",
+  toolResponseEndTag: "</TOOL_RESPONSE>",
+};
+
+const TEST_TOOLS: LanguageModelV2FunctionTool[] = [
+  {
+    type: "function",
+    name: "get_weather",
+    description: "Get the current weather in a given location",
+    parameters: {
+      type: "object",
+      properties: {
+        location: {
+          type: "string",
+          description: "The city and state, e.g. San Francisco, CA",
+        },
+        unit: {
+          type: "string",
+          enum: ["celsius", "fahrenheit"],
+          description: "Unit for temperature",
+        },
+      },
+      required: ["location"],
+    },
+  },
+];
+
+const simpleToolSystemPromptTemplate = (toolsString: string) =>
+  `Tools available:\n${toolsString}`;
+
 describe("convertToolPrompt", () => {
   // 1. Basic Tool Prompt Generation
   describe("Basic Tool Prompt Generation", () => {
     test("should generate prompt with tools for a string input prompt", () => {
-      expect("1").toBe("1");
+      const testParamsPrompt: LanguageModelV2Prompt = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "What is the weather today?",
+            },
+          ],
+        },
+      ];
+
+      const result = convertToolPrompt({
+        paramsPrompt: testParamsPrompt,
+        paramsTools: TEST_TOOLS,
+        toolSystemPromptTemplate: simpleToolSystemPromptTemplate,
+        ...TEST_TAGS,
+      });
+
+      const expectedSystemPrompt = `Tools available:\n[["0",{"type":"function","name":"get_weather","description":"Get the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The city and state, e.g. San Francisco, CA"},"unit":{"type":"string","enum":["celsius","fahrenheit"],"description":"Unit for temperature"}},"required":["location"]}}]]`;
+
+      expect(result).toEqual([
+        {
+          role: "system",
+          content: expectedSystemPrompt,
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "What is the weather today?",
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe("Tool Call and Response Handling", () => {
+    test("should convert single tool call correctly", () => {
+      const testParamsPrompt: LanguageModelV2Prompt = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "get_weather",
+              toolCallId: "12345",
+              args: {
+                location: "San Francisco, CA",
+                unit: "celsius",
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToolPrompt({
+        paramsPrompt: testParamsPrompt,
+        paramsTools: [],
+        toolSystemPromptTemplate: simpleToolSystemPromptTemplate,
+        ...TEST_TAGS,
+      });
+
+      expect(result[1].content[0]).toEqual({
+        type: "text",
+        text: `<TOOL_CALL>{"arguments":{"location":"San Francisco, CA","unit":"celsius"},"name":"get_weather"}</TOOL_CALL>`,
+      });
+    });
+
+    test("should convert multiple tool calls correctly", () => {
+      const testParamsPrompt: LanguageModelV2Prompt = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolName: "get_weather",
+              toolCallId: "12345",
+              args: {
+                location: "San Francisco, CA",
+                unit: "celsius",
+              },
+            },
+            {
+              type: "tool-call",
+              toolName: "get_weather",
+              toolCallId: "67890",
+              args: {
+                location: "New York, NY",
+                unit: "fahrenheit",
+              },
+            },
+          ],
+        },
+      ];
+
+      const result = convertToolPrompt({
+        paramsPrompt: testParamsPrompt,
+        paramsTools: [],
+        toolSystemPromptTemplate: simpleToolSystemPromptTemplate,
+        ...TEST_TAGS,
+      });
+
+      expect(result[1].content).toEqual([
+        {
+          type: "text",
+          text: `<TOOL_CALL>{"arguments":{"location":"San Francisco, CA","unit":"celsius"},"name":"get_weather"}</TOOL_CALL>
+<TOOL_CALL>{"arguments":{"location":"New York, NY","unit":"fahrenheit"},"name":"get_weather"}</TOOL_CALL>`,
+        },
+      ]);
     });
   });
 });

--- a/packages/parser/src/utils/conv-tool-prompt.test.ts
+++ b/packages/parser/src/utils/conv-tool-prompt.test.ts
@@ -205,6 +205,10 @@ describe("convertToolPrompt", () => {
       ]);
     });
 
+    /**
+     * NOTE: This test covers a situation that does not commonly occur in real scenarios.
+     * It is added simply to test the safety and robustness of the code.
+     */
     test("interleaves text and tool-call messages, preserving order and formatting", () => {
       const testParamsPrompt: LanguageModelV2Prompt = [
         {

--- a/packages/parser/src/utils/conv-tool-prompt.ts
+++ b/packages/parser/src/utils/conv-tool-prompt.ts
@@ -25,7 +25,7 @@ export function convertToolPrompt({
 }): LanguageModelV2Prompt {
   const processedPrompt = paramsPrompt.map((message) => {
     if (message.role === "assistant") {
-      // tool-call과 text 타입의 content를 순서를 지켜 변환 및 머지
+      // Convert and merge tool-call and text type content while preserving order
       const mergedContents: typeof message.content = [];
       for (const content of message.content) {
         if (content.type === "tool-call") {

--- a/packages/parser/src/utils/conv-tool-prompt.ts
+++ b/packages/parser/src/utils/conv-tool-prompt.ts
@@ -40,7 +40,7 @@ export function convertToolPrompt({
           mergedContents.push(content);
         }
       }
-      // 연속된 text 블록을 하나로 합침
+      // Merge consecutive text blocks into one
       const finalContents: typeof message.content = [];
       for (const item of mergedContents) {
         if (
@@ -48,14 +48,14 @@ export function convertToolPrompt({
           item.type === "text" &&
           finalContents[finalContents.length - 1].type === "text"
         ) {
-          // 마지막 text와 합침
-          finalContents[finalContents.length - 1] = {
-            type: "text",
-            text:
-              finalContents[finalContents.length - 1].text +
-              "\n" +
-              item.text,
-          };
+          // Merge with the last text block
+          const last = finalContents[finalContents.length - 1];
+          if (last.type === "text" && item.type === "text") {
+            finalContents[finalContents.length - 1] = {
+              type: "text",
+              text: last.text + "\n" + item.text,
+            };
+          }
         } else {
           finalContents.push(item);
         }

--- a/packages/parser/src/utils/conv-tool-prompt.ts
+++ b/packages/parser/src/utils/conv-tool-prompt.ts
@@ -52,9 +52,9 @@ export function convertToolPrompt({
           finalContents[finalContents.length - 1] = {
             type: "text",
             text:
-              (finalContents[finalContents.length - 1] as any).text +
+              finalContents[finalContents.length - 1].text +
               "\n" +
-              (item as any).text,
+              item.text,
           };
         } else {
           finalContents.push(item);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.1.4
+        version: 3.1.4(@types/node@22.15.21)(tsx@4.19.4)
 
   examples/core:
     dependencies:
@@ -57,7 +60,7 @@ importers:
         version: 22.15.21
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(tsx@4.19.4)(typescript@5.8.3)
+        version: 8.5.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)
 
 packages:
 
@@ -446,6 +449,35 @@ packages:
   '@types/node@22.15.21':
     resolution: {integrity: sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==}
 
+  '@vitest/expect@3.1.4':
+    resolution: {integrity: sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==}
+
+  '@vitest/mocker@3.1.4':
+    resolution: {integrity: sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.1.4':
+    resolution: {integrity: sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==}
+
+  '@vitest/runner@3.1.4':
+    resolution: {integrity: sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==}
+
+  '@vitest/snapshot@3.1.4':
+    resolution: {integrity: sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==}
+
+  '@vitest/spy@3.1.4':
+    resolution: {integrity: sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==}
+
+  '@vitest/utils@3.1.4':
+    resolution: {integrity: sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==}
+
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
@@ -487,6 +519,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -511,8 +547,16 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
+    engines: {node: '>=12'}
+
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -553,6 +597,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -574,6 +622,9 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild@0.25.4:
     resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
     engines: {node: '>=18'}
@@ -583,6 +634,13 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+    engines: {node: '>=12.0.0'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -729,6 +787,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -763,6 +824,11 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -820,6 +886,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -859,6 +929,10 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  postcss@8.5.3:
+    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -923,6 +997,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -930,6 +1007,10 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
@@ -940,6 +1021,12 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -977,12 +1064,27 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.13:
     resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -1075,6 +1177,79 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  vite-node@3.1.4:
+    resolution: {integrity: sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@6.3.5:
+    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.1.4:
+    resolution: {integrity: sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.1.4
+      '@vitest/ui': 3.1.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
@@ -1084,6 +1259,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -1469,6 +1649,46 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@vitest/expect@3.1.4':
+    dependencies:
+      '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@22.15.21)(tsx@4.19.4))':
+    dependencies:
+      '@vitest/spy': 3.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.3.5(@types/node@22.15.21)(tsx@4.19.4)
+
+  '@vitest/pretty-format@3.1.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.1.4':
+    dependencies:
+      '@vitest/utils': 3.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.1.4':
+    dependencies:
+      '@vitest/pretty-format': 3.1.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.1.4':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@3.1.4':
+    dependencies:
+      '@vitest/pretty-format': 3.1.4
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
+
   acorn@8.14.1: {}
 
   ai@5.0.0-alpha.3(zod@3.25.16):
@@ -1498,6 +1718,8 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   balanced-match@1.0.2: {}
 
   better-path-resolve@1.0.0:
@@ -1519,7 +1741,17 @@ snapshots:
 
   cac@6.7.14: {}
 
+  chai@5.2.0:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.3
+      pathval: 2.0.0
+
   chardet@0.7.0: {}
+
+  check-error@2.1.1: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -1549,6 +1781,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   detect-indent@6.1.0: {}
 
   dir-glob@3.0.1:
@@ -1565,6 +1799,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.25.4:
     optionalDependencies:
@@ -1595,6 +1831,12 @@ snapshots:
       '@esbuild/win32-x64': 0.25.4
 
   esprima@4.0.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.7
+
+  expect-type@1.2.1: {}
 
   extendable-error@0.1.7: {}
 
@@ -1742,6 +1984,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  loupe@3.1.3: {}
+
   lru-cache@10.4.3: {}
 
   magic-string@0.30.17:
@@ -1777,6 +2021,8 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  nanoid@3.3.11: {}
 
   object-assign@4.1.1: {}
 
@@ -1819,6 +2065,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -1835,11 +2083,18 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(tsx@4.19.4):
+  postcss-load-config@6.0.1(postcss@8.5.3)(tsx@4.19.4):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
+      postcss: 8.5.3
       tsx: 4.19.4
+
+  postcss@8.5.3:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prettier@2.8.8: {}
 
@@ -1906,9 +2161,13 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
+
+  source-map-js@1.2.1: {}
 
   source-map@0.8.0-beta.0:
     dependencies:
@@ -1920,6 +2179,10 @@ snapshots:
       signal-exit: 4.1.0
 
   sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -1963,12 +2226,20 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyglobby@0.2.13:
     dependencies:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinypool@1.0.2: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   tmp@0.0.33:
     dependencies:
@@ -1986,7 +2257,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.0(tsx@4.19.4)(typescript@5.8.3):
+  tsup@8.5.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.4)
       cac: 6.7.14
@@ -1997,7 +2268,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(tsx@4.19.4)
+      postcss-load-config: 6.0.1(postcss@8.5.3)(tsx@4.19.4)
       resolve-from: 5.0.0
       rollup: 4.41.0
       source-map: 0.8.0-beta.0
@@ -2006,6 +2277,7 @@ snapshots:
       tinyglobby: 0.2.13
       tree-kill: 1.2.2
     optionalDependencies:
+      postcss: 8.5.3
       typescript: 5.8.3
     transitivePeerDependencies:
       - jiti
@@ -2055,6 +2327,79 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  vite-node@3.1.4(@types/node@22.15.21)(tsx@4.19.4):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.3.5(@types/node@22.15.21)(tsx@4.19.4)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@6.3.5(@types/node@22.15.21)(tsx@4.19.4):
+    dependencies:
+      esbuild: 0.25.4
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.3
+      rollup: 4.41.0
+      tinyglobby: 0.2.13
+    optionalDependencies:
+      '@types/node': 22.15.21
+      fsevents: 2.3.3
+      tsx: 4.19.4
+
+  vitest@3.1.4(@types/node@22.15.21)(tsx@4.19.4):
+    dependencies:
+      '@vitest/expect': 3.1.4
+      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@22.15.21)(tsx@4.19.4))
+      '@vitest/pretty-format': 3.1.4
+      '@vitest/runner': 3.1.4
+      '@vitest/snapshot': 3.1.4
+      '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.13
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.3.5(@types/node@22.15.21)(tsx@4.19.4)
+      vite-node: 3.1.4(@types/node@22.15.21)(tsx@4.19.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.15.21
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   webidl-conversions@4.0.2: {}
 
   whatwg-url@7.1.0:
@@ -2066,6 +2411,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,11 @@
     "dev": {
       "cache": false,
       "persistent": true
+    },
+    "test": {
+      "dependsOn": [
+        "^test"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Pull Request Overview

This PR enhances the `convertToolPrompt` function to merge tool-call entries into text tags and consolidate consecutive text blocks, and adds comprehensive tests for various tool-call scenarios.

- Implements a two-pass merge in `convertToolPrompt` to convert `tool-call` entries and combine adjacent text segments.
- Expands `conv-tool-prompt.test.ts` with multiple test cases covering basic, interleaved, and combined tool-call sequences.
