### PR TITLE
Fix gemma streaming matching issue

### DIFF
--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -3,7 +3,7 @@ import { createToolMiddleware } from "./tool-call-middleware";
 const gemmaToolMiddleware = createToolMiddleware({
   toolSystemPromptTemplate(tools) {
     return `You have access to functions. If you decide to invoke any of the function(s),
-you MUST put it in the format of markdown code fense block with the language name of tool_call , e.g.
+you MUST put it in the format of markdown code fence block with the language name of tool_call , e.g.
 \`\`\`tool_call
 {'name': <function-name>, 'arguments': <args-dict>}
 \`\`\`
@@ -11,7 +11,7 @@ You SHOULD NOT include any other text in the response if you call a function
 ${tools}`;
   },
   toolCallTag: "```tool_call\n",
-  toolCallEndTag: "\n``",  // two quote are more common in gemma output
+  toolCallEndTag: "\n``",  // two backticks are more common in gemma output
   toolResponseTag: "```tool_response\n",
   toolResponseEndTag: "\n```",
 });

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -3,7 +3,7 @@ import { createToolMiddleware } from "./tool-call-middleware";
 const gemmaToolMiddleware = createToolMiddleware({
   toolSystemPromptTemplate(tools) {
     return `You have access to functions. If you decide to invoke any of the function(s),
-you MUST put it in the format of
+you MUST put it in the format of markdown code fense block with the language name of tool_call , e.g.
 \`\`\`tool_call
 {'name': <function-name>, 'arguments': <args-dict>}
 \`\`\`
@@ -11,7 +11,7 @@ You SHOULD NOT include any other text in the response if you call a function
 ${tools}`;
   },
   toolCallTag: "```tool_call\n",
-  toolCallEndTag: "```",
+  toolCallEndTag: "\n``",  // two quote are more common in gemma output
   toolResponseTag: "```tool_response\n",
   toolResponseEndTag: "\n```",
 });

--- a/packages/parser/src/stream-handler.ts
+++ b/packages/parser/src/stream-handler.ts
@@ -168,7 +168,7 @@ export async function normalToolStream({
           isToolCall = !isToolCall;
           afterSwitch = true;
         } else {
-          buffer = buffer; //.slice(startIndex); DO nothing
+          // Partial match found, wait for more data to complete the tag.
           break;
         }
       } while (true);

--- a/packages/parser/src/stream-handler.ts
+++ b/packages/parser/src/stream-handler.ts
@@ -156,18 +156,19 @@ export async function normalToolStream({
           break;
         }
 
-        // publish text before the tag
-        publish(buffer.slice(0, startIndex));
 
         const foundFullMatch = startIndex + nextTag.length <= buffer.length;
 
         if (foundFullMatch) {
+          // publish text before the tag
+          publish(buffer.slice(0, startIndex));
+
           buffer = buffer.slice(startIndex + nextTag.length);
           toolCallIndex++;
           isToolCall = !isToolCall;
           afterSwitch = true;
         } else {
-          buffer = buffer.slice(startIndex);
+          buffer = buffer; //.slice(startIndex); DO nothing
           break;
         }
       } while (true);


### PR DESCRIPTION
This pull request updates the parser's tool call handling to better align with the Gemma model's output format and fixes a bug in the stream handler logic. The main changes are:

**Tool Call Format Improvements:**

* Updated the tool call prompt in `index.ts` to specify that function calls must use a markdown code fence block with the language name `tool_call`, providing an explicit example for clarity.
* Changed the `toolCallEndTag` to use two backticks (`\n```) instead of three, matching the more common output format from Gemma.

**Stream Handler Bug Fixes:**

* Fixed the tool stream handler in `stream-handler.ts` to correctly publish text before tool call tags only when a full match is found, and to avoid incorrectly slicing the buffer when the tag is incomplete.