### PR TITLE
fix: improve release workflow and changeset verification

### DIFF
--- a/.github/workflows/changeset-required.yml
+++ b/.github/workflows/changeset-required.yml
@@ -2,7 +2,7 @@ name: Changeset Required
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY_SKIP_HOOKS: 1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,6 +7,12 @@ if git rev-parse --verify MERGE_HEAD >/dev/null 2>&1; then
   exit 0
 fi
 
+# Skip for changeset version commits
+if [ -n "$HUSKY_SKIP_HOOKS" ] || [ -n "$SKIP_CHECKS" ]; then
+  echo "Skipping pre-commit checks (HUSKY_SKIP_HOOKS or SKIP_CHECKS set)"
+  exit 0
+fi
+
 echo "Running pre-commit checks..."
 
 # Check formatting


### PR DESCRIPTION
This pull request introduces improvements to the workflow automation and developer experience by updating GitHub Actions triggers and providing a mechanism to skip pre-commit hooks during automated releases. These changes help streamline CI/CD processes and prevent unnecessary checks during version bumps.

**Workflow automation improvements:**

* Expanded the `changeset-required` workflow to trigger on `labeled` and `unlabeled` pull request events, in addition to the previous events, making it more responsive to label changes.

**Developer experience and release process:**

* Added the `HUSKY_SKIP_HOOKS` environment variable to the release workflow to allow skipping Husky pre-commit hooks during automated releases.
* Updated the `.husky/pre-commit` script to exit early if either `HUSKY_SKIP_HOOKS` or `SKIP_CHECKS` is set, preventing pre-commit checks from running in automated scenarios.