### PR TITLE
Add official documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { wrapLanguageModel, stepCountIs, streamText } from "ai";
 import { gemmaToolMiddleware } from "@ai-sdk-tool/parser";
 
+// You can use any provider: ollama, vllm, etc...
 const openrouter = createOpenAICompatible({
   /* ... */
 });


### PR DESCRIPTION
This pull request updates the `README.md` to improve documentation for the AI SDK tool call parser. The changes clarify usage examples, add a reference to the official documentation, and make the example more provider-agnostic.

Documentation improvements:

* Added a link to the official Vercel AI SDK documentation for the custom tool call parser to help users find more detailed information.
* Updated the example section title to "Gemma3 Style Middleware" for consistency and clarity.
* Added a comment in the example code to clarify that any provider (e.g., `ollama`, `vllm`) can be used, making the example more broadly applicable.