### PR TITLE
Enhance turbo.json and pre-commit hook functionality

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,8 @@
-#!/bin/sh
+# Format only staged files with Prettier, re-stage them, then lint/typecheck/test
+if [ -n "$CI" ]; then
+  # Skip heavy hooks in CI (e.g., Changesets version commits)
+  exit 0
+fi
 # Format only staged files with Prettier, re-stage them, then lint/typecheck/test
 git diff -z --name-only --cached --diff-filter=ACMR | while IFS= read -r -d '' file; do
   case "$file" in

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,8 @@
       "dependsOn": ["^lint:fix"]
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["^build", "^check-types"],
+      "inputs": ["$TURBO_DEFAULT$", "dist/**"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
- Updated the `check-types` task in `turbo.json` to depend on both `build` and `check-types`, ensuring proper execution order.
- Added input specification for `check-types` to include default Turbo inputs and the `dist/**` directory, improving type checking accuracy.
- Modified the pre-commit hook to skip heavy operations in CI environments, optimizing performance during automated workflows.

These changes improve the efficiency and reliability of the build and type-checking processes.