### PR TITLE
Added debugger and documentation

### DIFF
--- a/.changeset/spotty-plums-brake.md
+++ b/.changeset/spotty-plums-brake.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+Added a debugger to check model output and parsing results.

--- a/.changeset/thirty-donuts-lead.md
+++ b/.changeset/thirty-donuts-lead.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk-tool/parser": patch
+"@ai-sdk-tool/eval": patch
+---
+
+Improved README documentation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ For single package development, run commands from within the package directory:
 
 ## Architecture Overview
 
-This project provides middleware for AI SDK v2 to enable tool calling with models that don't natively support OpenAI-style tool calling.
+This project provides middleware for AI SDK to enable tool calling with models that don't natively support OpenAI-style tool calling.
 
 ### Core Packages
 
@@ -48,7 +48,7 @@ This project provides middleware for AI SDK v2 to enable tool calling with model
 - Formatted for the model (`formatTools`, `formatToolCall`, `formatToolResponse`)
 - Parsed from model output (`parseGeneratedText`, `createStreamParser`)
 
-**Middleware Pattern**: Uses AI SDK v2 middleware to intercept and transform:
+**Middleware Pattern**: Uses AI SDK middleware to intercept and transform:
 
 - `transformParams`: Converts tool definitions to system prompts
 - `wrapStream`: Handles streaming responses with tool call detection

--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 [![npm - parser](https://img.shields.io/npm/v/@ai-sdk-tool/parser)](https://www.npmjs.com/package/@ai-sdk-tool/parser)
 [![npm downloads - parser](https://img.shields.io/npm/dt/@ai-sdk-tool/parser)](https://www.npmjs.com/package/@ai-sdk-tool/parser)
+[![npm - eval](https://img.shields.io/npm/v/@ai-sdk-tool/eval)](https://www.npmjs.com/package/@ai-sdk-tool/eval)
+[![npm downloads - eval](https://img.shields.io/npm/dt/@ai-sdk-tool/eval)](https://www.npmjs.com/package/@ai-sdk-tool/eval)
 [![codecov](https://codecov.io/gh/minpeter/ai-sdk-tool-call-middleware/branch/main/graph/badge.svg)](https://codecov.io/gh/minpeter/ai-sdk-tool-call-middleware)
 
-Monorepo of tooling around AI SDK to enable tool calling and evaluation.
+Tooling for Vercel AI SDK: enable tool calling with models lacking native `tools`, plus evaluation utilities.
 
-- **@ai-sdk-tool/parser**: middleware to parse tool calls for models without native `tools` support. Works with any provider.
+- **@ai-sdk-tool/parser**: add tool-calling via middleware; works with any provider supported by AI SDK `wrapLanguageModel`.
 - **@ai-sdk-tool/eval**: benchmarks and evaluation helpers (BFCL, JSON generation).
+
+Note: Requires AI SDK v5. For AI SDK v4, use `@ai-sdk-tool/parser@1.0.0`.
 
 ## Packages
 
@@ -17,11 +21,44 @@ Monorepo of tooling around AI SDK to enable tool calling and evaluation.
 - `packages/eval` — evaluation utilities (BFCL, JSON generation).  
   – Quickstarts: [packages/eval/README.md](packages/eval/README.md)
 
+### Choose a middleware (at a glance)
+
+- **gemmaToolMiddleware**: JSON tool calls inside markdown fences. Best for Gemma-like models.
+- **xmlToolMiddleware**: Plain XML tool calls. Good fit for GLM/GLM-like models.
+- **hermesToolMiddleware**: JSON payload wrapped in `<tool_call>` XML tags. Hermes/Llama-style prompts.
+
 ## Install (per package)
 
 ```bash
 pnpm add @ai-sdk-tool/parser
 pnpm add @ai-sdk-tool/eval
+```
+
+## Usage at a glance
+
+```ts
+import { wrapLanguageModel, streamText } from "ai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { gemmaToolMiddleware } from "@ai-sdk-tool/parser";
+
+const client = createOpenAICompatible({
+  /* baseURL, apiKey */
+});
+
+const result = streamText({
+  model: wrapLanguageModel({
+    model: client("google/gemma-3-27b-it"),
+    middleware: gemmaToolMiddleware,
+  }),
+  tools: {
+    /* your tools */
+  },
+  prompt: "Find weather for Seoul today",
+});
+
+for await (const part of result.fullStream) {
+  // handle text and tool events
+}
 ```
 
 ## Examples
@@ -36,7 +73,7 @@ cd examples/parser-core && pnpm dlx tsx src/00-stream-tool-call.ts
 cd examples/eval-core && pnpm dlx tsx src/bfcl-simple.ts
 ```
 
-## Development (monorepo)
+## [dev] Development (monorepo)
 
 This is a pnpm workspace managed by Turborepo.
 
@@ -57,13 +94,22 @@ pnpm fmt:fix
 pnpm dev
 ```
 
-Single‑package development:
+### [dev] Requirements
+
+- Node >= 18
+- pnpm 9.x (repo sets `packageManager`)
+
+### Single‑package development
 
 ```bash
 cd packages/parser && pnpm test:watch
 cd packages/eval && pnpm dev
 ```
 
-## Contributing
+## [dev] Contributing
 
 Issues and PRs are welcome. See `CONTRIBUTING.md` and `AGENTS.md` for architecture and workflow.
+
+---
+
+Full docs: [docs/index.md](docs/index.md)

--- a/README.md
+++ b/README.md
@@ -1,79 +1,69 @@
-# Custom tool call parser for AI SDK
+# `@ai-sdk-tool/` monorepo
 
-▲ Also available in the Vercel AI SDK official documentation: [Custom tool call parser](https://ai-sdk.dev/docs/ai-sdk-core/middleware#custom-tool-call-parser)
-
-[![npm](https://img.shields.io/npm/v/@ai-sdk-tool/parser)](https://www.npmjs.com/package/@ai-sdk-tool/parser)
-[![npm](https://img.shields.io/npm/dt/@ai-sdk-tool/parser)](https://www.npmjs.com/package/@ai-sdk-tool/parser)
+[![npm - parser](https://img.shields.io/npm/v/@ai-sdk-tool/parser)](https://www.npmjs.com/package/@ai-sdk-tool/parser)
+[![npm downloads - parser](https://img.shields.io/npm/dt/@ai-sdk-tool/parser)](https://www.npmjs.com/package/@ai-sdk-tool/parser)
 [![codecov](https://codecov.io/gh/minpeter/ai-sdk-tool-call-middleware/branch/main/graph/badge.svg)](https://codecov.io/gh/minpeter/ai-sdk-tool-call-middleware)
 
-> [!NOTE]
-> Depends on AI SDK v5 release, if you wish to use it on v4, please pin the package version to 1.0.0
+Monorepo of tooling around AI SDK to enable tool calling and evaluation.
 
-Allows tool calls to be used in the AI ​​SDK framework regardless of the model.
+- **@ai-sdk-tool/parser**: middleware to parse tool calls for models without native `tools` support. Works with any provider.
+- **@ai-sdk-tool/eval**: benchmarks and evaluation helpers (BFCL, JSON generation).
 
-## Why This Exists
+## Packages
 
-Many self‑hosted or third‑party model endpoints (vLLM, MLC‑LLM, Ollama, OpenRouter, etc.) don’t yet expose the OpenAI‑style `tools` parameter, forcing you to hack together tool parsing.  
-This project provides a flexible middleware that:
+- `packages/parser` — core tool‑call parsing middleware and prebuilt middlewares (`gemmaToolMiddleware`, `hermesToolMiddleware`, `xmlToolMiddleware`).
+  - Quickstarts: [packages/parser/README.md](packages/parser/README.md)
+  - Official docs reference: [Custom tool call parser](https://ai-sdk.dev/docs/ai-sdk-core/middleware#custom-tool-call-parser)
+- `packages/eval` — evaluation utilities (BFCL, JSON generation).  
+  – Quickstarts: [packages/eval/README.md](packages/eval/README.md)
 
-- Parses tool calls from streaming or batch responses
-- Supports Hermes and Gemma formats
-- Llama, Mistral, and JSON formats are coming soon
-- Gain complete control over the tool call system prompt.
-
-## Installation
+## Install (per package)
 
 ```bash
-pnpm install @ai-sdk-tool/parser
+pnpm add @ai-sdk-tool/parser
+pnpm add @ai-sdk-tool/eval
 ```
 
----
+## Examples
 
-## Example: Gemma3 Style Middleware
+- Parser examples: `examples/parser-core/src/` (streaming/non‑streaming, tool choice variants)
+- Eval examples: `examples/eval-core/src/`
 
-See `examples/parser-core/src/00-stream-tool-call.ts` for the full demo:
+Run examples locally (after `pnpm install` at repo root):
 
-```typescript
-// filepath: examples/parser-core/src/00-stream-tool-call.ts
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import { wrapLanguageModel, stepCountIs, streamText } from "ai";
-import { gemmaToolMiddleware } from "@ai-sdk-tool/parser";
-
-// You can use any provider: ollama, vllm, etc...
-const openrouter = createOpenAICompatible({
-  /* ... */
-});
-
-async function main() {
-  const result = streamText({
-    model: wrapLanguageModel({
-      model: openrouter("google/gemma-3-27b-it"),
-      middleware: gemmaToolMiddleware,
-    }),
-    system: "You are a helpful assistant.",
-    prompt: "What is the weather in my city?",
-    stopWhen: stepCountIs(4),
-    tools: {
-      get_location: {
-        /* ... */
-      },
-      get_weather: {
-        /* ... */
-      },
-    },
-  });
-
-  for await (const part of result.fullStream) {
-    // ...handling text-delta and tool-result...
-  }
-}
-
-main().catch(console.error);
+```bash
+cd examples/parser-core && pnpm dlx tsx src/00-stream-tool-call.ts
+cd examples/eval-core && pnpm dlx tsx src/bfcl-simple.ts
 ```
 
----
+## Development (monorepo)
 
-## 🤝 Contributing
+This is a pnpm workspace managed by Turborepo.
 
-• Feel free to open issues or PRs—especially for new model formats.  
-• See `CONTRIBUTING.md` for guidelines.
+```bash
+# install deps
+pnpm install
+
+# build/lint/test all packages
+pnpm build
+pnpm test
+pnpm check-types
+pnpm lint
+pnpm lint:fix
+pnpm fmt
+pnpm fmt:fix
+
+# develop (watch builds)
+pnpm dev
+```
+
+Single‑package development:
+
+```bash
+cd packages/parser && pnpm test:watch
+cd packages/eval && pnpm dev
+```
+
+## Contributing
+
+Issues and PRs are welcome. See `CONTRIBUTING.md` and `AGENTS.md` for architecture and workflow.

--- a/docs/concepts/coercion.md
+++ b/docs/concepts/coercion.md
@@ -1,0 +1,55 @@
+# [dev] Argument Coercion
+
+The middleware coerces `tool-call.input` to match the tool JSON Schema so tools receive correct types (numbers, booleans, arrays/objects) even when models emit strings or XML-like shapes.
+
+## Where it runs
+
+- Generate mode:
+  - After `parseGeneratedText`, each `tool-call` passes through `coerceToolCallInput` (schema-based coercion, then `input` is `JSON.stringify`-ed).
+- Stream mode:
+  - Protocol-dependent. The XML protocol coerces during both `parseGeneratedText` and `createStreamParser`. The JSON-mix protocol does not coerce in stream (only generate’s global pass applies).
+- Tool-choice mode (provider-native):
+  - Coercion is skipped. The model-provided arguments are forwarded as-is.
+
+## Schema selection
+
+- XML protocol prefers provider-original schemas when available:
+  - `providerOptions.toolCallMiddleware.originalToolSchemas` (internal plumbing) → best fidelity.
+  - Fallback to the transformed `inputSchema` passed to the provider.
+
+## Coercion rules (coercion.ts)
+
+- Unwrap schema: `{ jsonSchema: ... }` is unwrapped recursively.
+- Type detection (`getSchemaType`): resolves to `object`/`array` even when `type` is omitted (via `properties`, `items`, `prefixItems`).
+- Strings:
+  - Parse booleans (`"true"|"false"`) and numbers (int/float/scientific).
+  - JSON-like strings parsed even when schema is absent.
+  - For `object`/`array` schemas, normalize and parse strings (single quotes → double quotes; handle empty `{}`).
+- Objects (value is object or object-like string):
+  - Recursively coerce properties using their schemas; unknown properties are preserved.
+- Arrays:
+  - Respect `prefixItems` (tuples) and `items`. If length equals `prefixItems.length`, coerce per index; otherwise use `items`.
+  - If a string fails JSON parse, fall back to CSV or newline splitting; trim and coerce each element.
+  - XML-aware shapes:
+    - `{ item: [...] }` → `[...]`
+    - Objects with all numeric keys (e.g., `{ "0": ..., "1": ... }`) → tuple/array (sorted by index)
+    - Single-key objects whose value is an array → that array
+  - If schema is `array` and value is scalar/null/boolean, wrap into a single-element array and coerce the element.
+
+## Helpers
+
+- `coerceBySchema(value, schema)` — main coercion routine.
+- `coerceToolCallInput(part, tools)` — applies `coerceBySchema` using the matched tool’s `inputSchema`, then serializes `input` as JSON.
+
+See `packages/parser/src/utils/coercion.ts`.
+
+## Tips
+
+- For streaming XML, set `providerOptions.toolCallMiddleware.originalToolSchemas` so the stream parser can coerce with the provider’s unmodified schemas.
+- If your provider uses tool-choice, ensure the model arguments are already schema-conformant (coercion is not run in that path).
+
+## Quick examples
+
+- number schema + value `"42"` → `42`
+- `array<number>` schema + value `"1, 2, 3"` → `[1, 2, 3]`
+- object schema `{ a: number, b: boolean }` + value `'{"a":"1","b":"true"}'` → `{ a: 1, b: true }`

--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -62,9 +62,9 @@ See `packages/parser/src/tool-call-middleware.ts` and `packages/parser/src/proto
 
 ## Debugging
 
-- Set `DEBUG_PASER_MW` to control logging:
+- Set `DEBUG_PARSER_MW` to control logging:
   - `off` (default), `stream` (raw + normalized chunks), `parse` (parsed summary with origin highlights)
-- Optional style for origin highlighting: `DEBUG_PASER_MW_STYLE` = `bg` | `inverse` | `underline` | `bold`
+- Optional style for origin highlighting: `DEBUG_PARSER_MW_STYLE` = `bg` | `inverse` | `underline` | `bold`
 
 ## Protocol API (what a protocol must provide)
 

--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -1,0 +1,97 @@
+# [dev] Middleware Architecture
+
+The middleware composes with AI SDK `LanguageModelV2Middleware` to provide tool calling for models without native support.
+
+## Responsibilities
+
+- Inject the tool system prompt and tool signatures (`transformParams`)
+- Parse model output for tool calls in both streaming and non-streaming modes (`wrapStream`, `wrapGenerate`)
+- Surface parsed tool calls to the application, and format tool results back to the model
+- Support tool choice fast-paths for structured JSON responses when requested
+
+## Key modules
+
+- `createToolMiddleware` — factory to assemble a middleware with a given protocol
+- `transformParams` — injects system prompt, normalizes prompt, sets tool-choice fast path
+- `wrapStream` — streams provider output and emits normalized tool-call parts
+- `wrapGenerate` — parses batch outputs into normalized content (incl. tool-calls)
+- `ToolCallProtocol` — pluggable protocol interface (JSON-mix, Morph-XML, etc.)
+
+See `packages/parser/src/tool-call-middleware.ts` and `packages/parser/src/protocols/*`.
+
+## How it works (end-to-end)
+
+1. `transformParams`
+   - Extracts custom function tools (`type: "function"`) and renders a system prompt via `protocol.formatTools` and a provided `toolSystemPromptTemplate`.
+   - Normalizes the existing prompt:
+     - Assistant tool-call parts are converted to provider-friendly text with `protocol.formatToolCall`.
+     - Tool result messages (`role: "tool"`) are mapped to `role: "user"` text via `protocol.formatToolResponse`.
+     - Condenses multiple text parts into a single text block and merges consecutive user text messages.
+   - Clears `params.tools` (providers may drop/alter them) and propagates tool names internally to `providerOptions.toolCallMiddleware.toolNames` for downstream parsing.
+   - Tool choice handling:
+     - `toolChoice: { type: "tool", toolName }`: sets `responseFormat` to a strict JSON schema for the selected tool and enables the fast-path.
+     - `toolChoice: { type: "required" }`: sets a dynamic JSON schema that requires exactly one of the provided tools and enables the fast-path.
+     - `toolChoice: { type: "none" }`: not supported (throws). Use `auto` (default) instead.
+
+2. `wrapStream`
+   - If tool-choice fast-path is active, performs a single `generate` call and emits a synthetic `tool-call` followed by `finish`.
+   - Otherwise, pipes provider stream through `protocol.createStreamParser`, emitting normalized `tool-call` parts as they arrive.
+
+3. `wrapGenerate`
+   - If tool-choice fast-path is active, parses the first text block as JSON `{ name, arguments }` and returns a single `tool-call` content item.
+   - Otherwise, runs `protocol.parseGeneratedText` over text parts and returns normalized content (tool-calls + remaining text).
+
+## Tool choice (fast-path)
+
+- Supported: `auto` (default), `tool`, `required`.
+- Unsupported: `none` (throws at `transformParams`).
+- Behavior:
+  - `tool` — forces the model to return a JSON body for that tool; the middleware converts it directly to a tool-call.
+  - `required` — forces a JSON body that must match one of the provided tools; converted to a tool-call.
+- Implementation details:
+  - Activation is internal via `providerOptions.toolCallMiddleware.toolChoice`.
+  - Stream and batch paths both parse the JSON body and emit a normalized `tool-call`.
+
+## Provider options and error reporting
+
+- `providerOptions.toolCallMiddleware.onError?: (message, metadata) => void`
+  - Non-fatal parse/format issues are surfaced here (e.g., failed JSON parse on fast-path).
+- `providerOptions.toolCallMiddleware.toolNames?: string[]`
+  - Internal: automatically set by `transformParams` to propagate tool names when providers strip `params.tools`.
+- These are internal wiring details used by the middleware; user-facing configuration is through `tools`, `toolChoice`, and the chosen protocol.
+
+## Debugging
+
+- Set `DEBUG_PASER_MW` to control logging:
+  - `off` (default), `stream` (raw + normalized chunks), `parse` (parsed summary with origin highlights)
+- Optional style for origin highlighting: `DEBUG_PASER_MW_STYLE` = `bg` | `inverse` | `underline` | `bold`
+
+## Protocol API (what a protocol must provide)
+
+- `formatTools({ tools, toolSystemPromptTemplate }) => string` — renders the tool system prompt.
+- `formatToolCall(toolCall) => string` — renders an assistant tool-call part as text for provider compatibility.
+- `formatToolResponse(toolResult) => string` — renders a tool result as text for the next turn.
+- `parseGeneratedText({ text, tools, options }) => ContentPart[]` — parses batch text into normalized content.
+- `createStreamParser({ tools, options }) => TransformStream` — parses streamed deltas into normalized parts.
+- Optional: `extractToolCallSegments({ text, tools }) => string[]` — used only for debug summaries.
+
+See concrete implementations in `packages/parser/src/protocols/json-mix-protocol.ts` and `packages/parser/src/protocols/morph-xml-protocol.ts`.
+
+## Exports and preconfigured middlewares
+
+- `createToolMiddleware` — compose your own middleware with any `ToolCallProtocol`.
+- Preconfigured:
+  - `gemmaToolMiddleware` — JSON-mix with fenced code blocks for Gemma-style models.
+  - `hermesToolMiddleware` — JSON-mix with XML-tag wrapping of tool calls.
+  - `xmlToolMiddleware` — Morph-XML protocol for XML-native formats.
+- Protocol factories: `jsonMixProtocol`, `morphXmlProtocol`.
+
+Defined in `packages/parser/src/index.ts`.
+
+## Limitations and gotchas
+
+- Provider-defined tools (non `type: "function"`) are not supported by this middleware.
+  - If `toolChoice.type === "tool"` references a provider-defined tool, an error is thrown.
+- `toolChoice: { type: "none" }` is not supported.
+- `transformParams` clears `params.tools` to avoid provider interference; tool names are propagated internally for parsing.
+- Arguments are coerced to strings for transport when necessary; protocol implementations define exact formatting.

--- a/docs/concepts/protocols.md
+++ b/docs/concepts/protocols.md
@@ -42,7 +42,7 @@ Protocols are wired through the middleware created by `createToolMiddleware` (se
 
 Preconfigured middlewares exported from `packages/parser/src/index.ts`:
 
-- `gemmaToolMiddleware` — `jsonMixProtocol` with markdown fences labeled `tool_call` / `tool_response` and a Gemma-friendly prompt.
+- `gemmaToolMiddleware` — Uses `jsonMixProtocol` with markdown code fences labeled `tool_call` and a prompt tailored for Gemma.
 - `hermesToolMiddleware` — `jsonMixProtocol` with `<tool_call>` tags and a Hermes-style prompt.
 - `xmlToolMiddleware` — `morphXmlProtocol` with an XML-oriented prompt.
 

--- a/docs/concepts/protocols.md
+++ b/docs/concepts/protocols.md
@@ -1,0 +1,58 @@
+# [dev] Protocols
+
+A `ToolCallProtocol` defines the wire format for tool calling: how tools are shown to the model, how the model should return a tool call, and how output is parsed back into AI SDK content/stream parts.
+
+- Format tools: `formatTools` — how to present tool signatures to the model
+- Format tool call: `formatToolCall` — how a single invocation is rendered
+- Format tool response: `formatToolResponse` — how tool results are echoed back
+- Parse generation: `parseGeneratedText` — parse non-streamed output
+- Stream parser: `createStreamParser` — parse streamed output incrementally
+- Debug helper (optional): `extractToolCallSegments` — return substrings that would be parsed as tool calls
+
+See the interface in `packages/parser/src/protocols/tool-call-protocol.ts`.
+
+## Built-in Protocols
+
+- `jsonMixProtocol` — JSON payloads wrapped in simple tags; can be retargeted to markdown code fences.
+  - Default delimiters: `<tool_call>...</tool_call>` for calls and `<tool_response>...</tool_response>` for results.
+  - `formatTools` serializes tools to JSON and injects them via your `toolSystemPromptTemplate`.
+  - `parseGeneratedText` and `createStreamParser` detect the wrapped JSON and emit `{ type: "tool-call", toolName, input }` parts. Non-tool text is passed through as `{ type: "text" }`.
+  - You can customize delimiters (e.g., triple-fenced blocks) when creating the middleware. Example: the prebuilt Gemma middleware uses markdown fences labeled `tool_call`.
+
+- `morphXmlProtocol` — one XML element per call with the tag equal to the tool name (e.g., `<get_weather>...</get_weather>`).
+  - Strong streaming support: the stream parser buffers text, recognizes start/end tags, and emits a `tool-call` when a full element arrives.
+  - Argument parsing: XML content is converted to an object with heuristics for text nodes, repeated tags (arrays), `item` lists, and tuple-like indexed objects.
+  - Type coercion: values are coerced using the tool's JSON schema via `coerceBySchema` (original provider schemas are used when available).
+  - `formatTools` emits tool signatures as JSON (using `unwrapJsonSchema`) inside your system prompt template. `formatToolResponse` returns a `<tool_response>` XML block.
+
+Implementations live in `packages/parser/src/protocols/`.
+
+## Choosing a Protocol
+
+- Prefer `jsonMixProtocol` when the model tends to output JSON reliably or when you can guide it with fences (e.g., Gemma/Hermes-style prompts).
+- Prefer `morphXmlProtocol` when you need robust streaming detection and schema-aware argument coercion, or when XML-style tags work better for the model.
+
+## Using Protocols via Middleware
+
+Protocols are wired through the middleware created by `createToolMiddleware` (see `packages/parser/src/tool-call-middleware.ts`). The middleware:
+
+- Injects tool signatures into the system prompt using `protocol.formatTools` in `transformParams`.
+- Parses non-stream outputs with `protocol.parseGeneratedText` in `wrapGenerate`.
+- Parses stream deltas with `protocol.createStreamParser` in `wrapStream`.
+
+Preconfigured middlewares exported from `packages/parser/src/index.ts`:
+
+- `gemmaToolMiddleware` — `jsonMixProtocol` with markdown fences labeled `tool_call` / `tool_response` and a Gemma-friendly prompt.
+- `hermesToolMiddleware` — `jsonMixProtocol` with `<tool_call>` tags and a Hermes-style prompt.
+- `xmlToolMiddleware` — `morphXmlProtocol` with an XML-oriented prompt.
+
+## Implementing a Custom Protocol
+
+Provide an object that satisfies `ToolCallProtocol`:
+
+- Implement the five required methods: `formatTools`, `formatToolCall`, `formatToolResponse`, `parseGeneratedText`, `createStreamParser`.
+- Ensure `parseGeneratedText` emits `text` parts for non-tool content and `tool-call` parts for recognized calls; call `options.onError` and pass through original text on parse failures.
+- Ensure `createStreamParser` emits `text-start` / `text-delta` / `text-end` events around regular text and `tool-call` events when a full call is recognized; treat partial/incomplete segments conservatively and report non-fatal errors via `options.onError`.
+- Optionally implement `extractToolCallSegments` to return the exact substrings that would be interpreted as tool calls (useful for debugging/telemetry).
+
+Tip: Keep the call/result formats symmetric so `formatToolResponse` mirrors the call format the model sees. This makes multi-turn tool usage more reliable.

--- a/docs/concepts/provider-options.md
+++ b/docs/concepts/provider-options.md
@@ -1,0 +1,67 @@
+# [dev] Provider Options Surface
+
+The middleware reads options from `params.providerOptions.toolCallMiddleware`.
+
+## Public (user-provided)
+
+- `onError?: (message, metadata) => void`
+  - Non-fatal reporting hook during parsing (generate/stream) and prompt transform.
+  - Plumbed into handlers and forwarded to protocols.
+  - Source: `utils/on-error.ts`; used by `transform-handler.ts`, `stream-handler.ts`, `generate-handler.ts`, and protocol parsers.
+
+Example:
+
+```ts
+const result = await model.generateText({
+  prompt,
+  tools,
+  providerOptions: {
+    toolCallMiddleware: {
+      onError: (message, metadata) => console.warn(message, metadata),
+      // You may add protocol-specific options here (see below)
+    },
+  },
+});
+```
+
+## Internal (not public API; subject to change)
+
+- `toolNames: string[]`
+  - Set by `transformParams` to propagate function tool names when providers strip `params.tools`.
+  - Read by `getFunctionTools` as a fallback.
+  - Source: `transform-handler.ts`, `utils/tools.ts`.
+
+- `toolChoice: { type: "required" } | { type: "tool", toolName }`
+  - Injected by `transformParams` when emulating AI SDK tool choice.
+  - Checked via `isToolChoiceActive` to trigger the tool-choice fast-path in handlers.
+  - Source: `transform-handler.ts`, `utils/tools.ts`, `stream-handler.ts`, `generate-handler.ts`.
+  - Note: `type: "none"` is not supported by this middleware.
+
+- `originalToolSchemas: Record<string, unknown>`
+  - Optional. If supplied, protocols may use the original provider schemas to coerce argument types.
+  - Currently consumed by `morphXmlProtocol` in both generate and stream paths.
+  - Source: `protocols/morph-xml-protocol.ts`.
+
+## Protocol options passthrough
+
+- All fields under `providerOptions.toolCallMiddleware` are forwarded to protocol parsers as `options` in both generate and stream flows.
+- Reserved/internal keys include: `onError`, `toolNames`, and `toolChoice`.
+- Protocols may read additional keys. Today, `morphXmlProtocol` supports `originalToolSchemas`.
+
+Example (XML coercion using original schemas):
+
+```ts
+await model.generateText({
+  tools,
+  providerOptions: {
+    toolCallMiddleware: {
+      onError: (m, meta) => console.debug(m, meta),
+      originalToolSchemas: {
+        get_weather: openAIStyleJsonSchemaForGetWeather,
+      },
+    },
+  },
+});
+```
+
+Note: Internal options exist only to carry state between transform and parsing phases and may change without notice.

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -1,0 +1,83 @@
+# [dev] Streaming Algorithms
+
+This page summarizes how streaming tool-call parsing works inside the protocols. The parsers transform a stream of `text-delta` parts into structured `tool-call` parts while preserving regular text via `text-start`/`text-delta`/`text-end` events.
+
+Notes common to both protocols:
+
+- Emitted parts: `text-start` → `text-delta` → `text-end` for text, `tool-call` when a call completes, `finish` at the end.
+- Errors do not throw: the original text for the failed segment is emitted, and `options.onError` is invoked if provided.
+- A debugging summary is available when parse debug is enabled; it uses `extractToolCallSegments` to show original matched segments.
+
+## JSON-mix protocol
+
+Defaults and configuration:
+
+- Tags: `toolCallStart = "<tool_call>"`, `toolCallEnd = "</tool_call>"`. Tool responses (`<tool_response>...</tool_response>`) can be formatted but are not parsed in streaming.
+- Arguments parsing: uses relaxed JSON (`RJSON.parse`) allowing unquoted keys, comments, and trailing commas.
+
+State:
+
+- `isInsideToolCall: boolean`
+- `buffer: string`
+- `currentToolCallJson: string`
+- `currentTextId: string | null`
+- `hasEmittedTextStart: boolean`
+
+Algorithm (simplified):
+
+1. Append each `text-delta` to `buffer`.
+2. While a complete start/end tag is available:
+   - If outside a call, emit the safe prefix as text and on `<tool_call>` enter call, reset `currentToolCallJson`.
+   - If inside a call and `</tool_call>` is found, parse `currentToolCallJson` with `RJSON.parse` and emit a `tool-call` (closing any open text first). On parse failure, emit the original `"<tool_call>... </tool_call>"` as text and call `options.onError`.
+3. When outside a call, avoid leaking partial start tags by keeping a possible suffix using `getPotentialStartIndex`; emit only the safe prefix.
+4. On `finish`:
+   - If inside a call, emit the leftover as text (prefixed with `<tool_call>`), then close any open text.
+   - If not inside a call, flush remaining `buffer` as text and close any open text.
+
+Resilience:
+
+- `getPotentialStartIndex` prevents emitting partial start tags.
+- `RJSON.parse` accepts relaxed JSON commonly produced by models.
+- `options.onError` receives a message and the original segment on failures.
+
+Source: `packages/parser/src/protocols/json-mix-protocol.ts`.
+
+## Morph-XML protocol
+
+Detection and schemas:
+
+- Only known tool names are considered: the parser scans for the earliest `<name>` where `name ∈ tools.map(t => t.name)`.
+- Arguments are parsed with `fast-xml-parser`, then coerced with `coerceBySchema` using provider-original schemas when available (via `options.originalToolSchemas`), otherwise the transformed `inputSchema`.
+
+State:
+
+- `buffer: string`
+- `currentToolCall: { name, content } | null`
+- `currentTextId: string | null`
+
+Algorithm (simplified):
+
+1. Append each `text-delta` to `buffer`.
+2. If inside a call, search for its closing tag `</name>`; when found, slice the content, parse XML, coerce by schema, emit `tool-call`. On failure, emit the original `<name>... </name>` text and call `options.onError`.
+3. If not inside a call, find the earliest `<name>` across known tools, flush preceding text, enter that call and continue.
+4. On `flush`/`finish`, any unfinished call is emitted as original text; otherwise flush remaining text and close open text blocks.
+
+Coercion heuristics (pre-schema):
+
+- Text nodes: unwrap `#text`.
+- Repeated tags: become arrays.
+- `<item>` lists: become arrays; numeric-looking strings are converted to numbers when safe.
+- Numeric-keyed objects (`{"0":..., "1":...}`): become tuples/arrays in index order.
+
+Source: `packages/parser/src/protocols/morph-xml-protocol.ts`.
+
+## Tool-choice streaming path
+
+When explicit tool choice is active, the normal streaming parser is bypassed. The system performs a non-stream generate, parses a single JSON object `{ name, arguments }` from the first text block, then emits:
+
+1. one `tool-call` part with `input = JSON.stringify(arguments)`
+2. a `finish` part with `finishReason = "tool-calls"`
+
+Errors parsing this JSON call `options.onError` and default to `{}`.
+
+Source: `packages/parser/src/stream-handler.ts` (`toolChoiceStream`).

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,0 +1,74 @@
+# Evaluation
+
+Use `@ai-sdk-tool/eval` to benchmark AI SDK-compatible models.
+
+## Quick Start
+
+```ts
+import { evaluate, bfclSimpleBenchmark } from "@ai-sdk-tool/eval";
+import { openrouter } from "ai/providers/openrouter";
+
+const modelA = openrouter("google/gemma-3-9b-it");
+const modelB = openrouter("google/gemma-3-27b-it");
+
+// You can pass an array of models …
+await evaluate({
+  models: [modelA, modelB],
+  benchmarks: [bfclSimpleBenchmark],
+  reporter: "console",
+});
+
+// …or a keyed map to label results per model
+await evaluate({
+  models: { small: modelA, large: modelB },
+  benchmarks: [bfclSimpleBenchmark],
+  reporter: "json",
+});
+```
+
+## Built-in Benchmarks
+
+- `bfclSimpleBenchmark`, `bfclParallelBenchmark`, `bfclMultipleBenchmark`, `bfclParallelMultipleBenchmark`
+- `jsonGenerationBenchmark`, `jsonGenerationSchemaOnlyBenchmark`
+
+See runnable examples in `examples/eval-core/src/*`.
+
+## Reporters and Returns
+
+- `reporter`: `"console" | "json" | "console.debug"` (default: `"console"`)
+- Returns: `EvaluationResult[]` with per model/benchmark `score`, `success`, and `metrics`.
+
+## [dev] Create a Custom Benchmark
+
+Implement `LanguageModelV2Benchmark` and pass it to `evaluate`.
+
+```ts
+import { generateText } from "ai";
+import type {
+  LanguageModelV2Benchmark,
+  BenchmarkResult,
+} from "@ai-sdk-tool/eval";
+
+export const myBenchmark: LanguageModelV2Benchmark = {
+  name: "my-benchmark",
+  version: "1.0.0",
+  description: "Minimal example",
+  async run(model): Promise<BenchmarkResult> {
+    const { text } = await generateText({
+      model,
+      messages: [{ role: "user", content: "Say 'ok'" }],
+    });
+    const pass = text.trim().toLowerCase().includes("ok");
+    return {
+      score: pass ? 1 : 0,
+      success: pass,
+      metrics: { accuracy: pass ? 1 : 0 },
+    };
+  },
+};
+```
+
+## [dev] BFCL Runtime Controls
+
+- `BFCL_LIMIT`: limit number of BFCL test cases (e.g., `BFCL_LIMIT=50`).
+- `BFCL_CONCURRENCY`: parallel case runner (default `4`).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,43 @@
+## Examples
+
+- **Parser**
+  - `examples/parser-core/src/00-tool-call.ts`
+  - `examples/parser-core/src/00-stream-tool-call.ts`
+  - `examples/parser-core/src/01-reasoning-tool-call.ts`
+  - `examples/parser-core/src/01-stream-reasoning-tool-call.ts`
+  - `examples/parser-core/src/02-choice-required.ts`
+  - `examples/parser-core/src/02-choice-toolname.ts`
+  - `examples/parser-core/src/02-stream-choice-required.ts`
+  - `examples/parser-core/src/02-stream-choice-toolname.ts`
+
+Run (from repo root after `pnpm install`):
+
+```bash
+cd examples/parser-core && pnpm dlx tsx src/00-stream-tool-call.ts
+```
+
+- **Eval**
+  - `examples/eval-core/src/bfcl-simple.ts`
+  - `examples/eval-core/src/json-generation.ts`
+
+Run:
+
+```bash
+cd examples/eval-core && pnpm dlx tsx src/bfcl-simple.ts
+cd examples/eval-core && pnpm dlx tsx src/json-generation.ts
+```
+
+### Prerequisites
+
+- **Install**: from repo root, run `pnpm install`.
+- **Node**: v18+ recommended.
+- **Provider credentials**: set env vars as needed before running examples.
+  - `OPENROUTER_API_KEY`: required for examples using OpenRouter.
+  - `OPENAI_API_KEY`: used by `json-generation.ts` for `gpt-4.1-nano`.
+  - `FRIENDLI_TOKEN`: used by `bfcl-simple.ts` with Friendli serverless API.
+
+### [dev] Notes
+
+- **Middleware switch**: parser examples show how to swap between `xmlToolMiddleware` and `gemmaToolMiddleware` via commented lines. Choose a provider/model your account can access.
+- **Providers**: OpenRouter base URL is `https://openrouter.ai/api/v1`. Friendli serverless base URL is `https://api.friendli.ai/serverless/v1`.
+- **Streaming vs non‑streaming**: `00-stream-tool-call.ts` uses streaming (`streamText`), while `00-tool-call.ts` is non‑streaming (`generateText`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,152 @@
+# Getting Started
+
+This monorepo contains two packages:
+
+- `@ai-sdk-tool/parser`: tool-call parsing middleware for AI SDK
+- `@ai-sdk-tool/eval`: evaluation utilities and benchmarks
+
+> Note: Requires AI SDK v5. For AI SDK v4, pin `@ai-sdk-tool/parser@1.0.0`.
+
+## Install
+
+```bash
+pnpm add @ai-sdk-tool/parser ai @ai-sdk/openai-compatible zod
+# Optional: only if you plan to run benchmarks
+pnpm add @ai-sdk-tool/eval
+```
+
+### Env setup (example provider)
+
+```bash
+export OPENROUTER_API_KEY=your_key
+```
+
+## Minimal example (generate)
+
+```ts
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { wrapLanguageModel, generateText } from "ai";
+import { gemmaToolMiddleware } from "@ai-sdk-tool/parser";
+import { z } from "zod";
+
+const openrouter = createOpenAICompatible({
+  name: "openrouter",
+  apiKey: process.env.OPENROUTER_API_KEY,
+  baseURL: "https://openrouter.ai/api/v1",
+});
+
+async function main() {
+  const { text } = await generateText({
+    model: wrapLanguageModel({
+      model: openrouter("google/gemma-3-27b-it"),
+      middleware: gemmaToolMiddleware,
+    }),
+    prompt: "What is the weather in my city?",
+    tools: {
+      get_location: {
+        description: "Get the user's city",
+        inputSchema: z.object({}),
+        execute: async () => ({ city: "New York" }),
+      },
+      get_weather: {
+        description: "Return weather for a city",
+        inputSchema: z.object({ city: z.string() }),
+        execute: async ({ city }) => ({
+          city,
+          temperature: 25,
+          condition: "sunny",
+        }),
+      },
+    },
+  });
+
+  console.log(text);
+}
+
+main().catch(console.error);
+```
+
+## Minimal example (stream)
+
+```ts
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { wrapLanguageModel, stepCountIs, streamText } from "ai";
+import { gemmaToolMiddleware } from "@ai-sdk-tool/parser";
+import { z } from "zod";
+
+const openrouter = createOpenAICompatible({
+  name: "openrouter",
+  apiKey: process.env.OPENROUTER_API_KEY,
+  baseURL: "https://openrouter.ai/api/v1",
+});
+
+async function main() {
+  const result = streamText({
+    model: wrapLanguageModel({
+      model: openrouter("google/gemma-3-27b-it"),
+      middleware: gemmaToolMiddleware,
+    }),
+    system: "You are a helpful assistant.",
+    prompt: "What is the weather in my city?",
+    stopWhen: stepCountIs(4),
+    tools: {
+      get_location: {
+        description: "Get the user's city",
+        inputSchema: z.object({}),
+        execute: async () => ({ city: "New York" }),
+      },
+      get_weather: {
+        description: "Return weather for a city",
+        inputSchema: z.object({ city: z.string() }),
+        execute: async ({ city }) => ({
+          city,
+          temperature: 25,
+          condition: "sunny",
+        }),
+      },
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === "text-delta") process.stdout.write(part.text);
+    if (part.type === "tool-result") console.log(part.output);
+  }
+}
+
+main().catch(console.error);
+```
+
+## Choose a middleware (protocol)
+
+- **gemmaToolMiddleware**: JSON tool calls inside markdown fences. Best for Gemma-like models.
+- **xmlToolMiddleware**: XML tool calls. Works well with GLM-style models.
+- **hermesToolMiddleware**: JSON payload wrapped in XML tags. For Hermes/Llama-style prompts.
+
+Swap by importing a different middleware; your tool definitions stay the same.
+
+## Tips and limits
+
+- **Tool choice**: supports `required` and `tool` (specific tool). `none` is not supported.
+- **Provider-defined tools**: not supported. Pass only custom function tools.
+- **Streaming**: you'll receive `text-delta` and `tool-result` parts; the middleware parses calls automatically.
+
+## [dev] Customize or add a protocol
+
+````ts
+import { createToolMiddleware, jsonMixProtocol } from "@ai-sdk-tool/parser";
+
+export const customMiddleware = createToolMiddleware({
+  protocol: jsonMixProtocol({
+    toolCallStart: "```tool_call\n",
+    toolCallEnd: "\n```",
+    toolResponseStart: "```tool_response\n",
+    toolResponseEnd: "\n```",
+  }),
+  toolSystemPromptTemplate(tools) {
+    return `You have access to functions. Return only a fenced tool_call block. ${tools}`;
+  },
+});
+````
+
+- **[dev] Build/test**: `pnpm build`, `pnpm test`, `pnpm dev`
+- **[dev] Debug logs**: `DEBUG_PASER_MW=stream` or `DEBUG_PASER_MW=parse`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,4 +149,4 @@ export const customMiddleware = createToolMiddleware({
 ````
 
 - **[dev] Build/test**: `pnpm build`, `pnpm test`, `pnpm dev`
-- **[dev] Debug logs**: `DEBUG_PASER_MW=stream` or `DEBUG_PASER_MW=parse`
+- **[dev] Debug logs**: `DEBUG_PARSER_MW=stream` or `DEBUG_PARSER_MW=parse`

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -4,14 +4,14 @@ Enable middleware debug logs via environment variables.
 
 ## Levels
 
-- `DEBUG_PASER_MW=off` (default): no logs
-- `DEBUG_PASER_MW=stream`: logs raw provider output and the normalized parts the middleware emits
-- `DEBUG_PASER_MW=parse`: after parsing completes, logs a highlighted view of detected tool-call source text (origin) and a JSON summary of tool-calls
+- `DEBUG_PARSER_MW=off` (default): no logs
+- `DEBUG_PARSER_MW=stream`: logs raw provider output and the normalized parts the middleware emits
+- `DEBUG_PARSER_MW=parse`: after parsing completes, logs a highlighted view of detected tool-call source text (origin) and a JSON summary of tool-calls
 
 Aliases:
 
-- `DEBUG_PASER_MW=1`, `true`, `yes` → treated as `stream`
-- `DEBUG_PASER_MW=2` → treated as `parse`
+- `DEBUG_PARSER_MW=1`, `true`, `yes` → treated as `stream`
+- `DEBUG_PARSER_MW=2` → treated as `parse`
 
 When it logs:
 
@@ -25,7 +25,7 @@ When it logs:
 
 ## Styles (parse summary)
 
-- `DEBUG_PASER_MW_STYLE=bg` (default), `inverse` (or `invert`), `underline` (or `ul`), `bold`
+- `DEBUG_PARSER_MW_STYLE=bg` (default), `inverse` (or `invert`), `underline` (or `ul`), `bold`
 - Truthy values (e.g., `1`, `true`, `yes`) map to `bg`
 - Origin lines are highlighted using the selected style; the summary is printed with a distinct background for readability.
 
@@ -39,14 +39,14 @@ When it logs:
 ## How to use
 
 - macOS/Linux (one-off):
-  - `DEBUG_PASER_MW=stream node your-app.js`
-  - `DEBUG_PASER_MW=parse node your-app.js`
-- With pnpm scripts: `DEBUG_PASER_MW=parse pnpm dev`
+  - `DEBUG_PARSER_MW=stream node your-app.js`
+  - `DEBUG_PARSER_MW=parse node your-app.js`
+- With pnpm scripts: `DEBUG_PARSER_MW=parse pnpm dev`
 - Numeric/boolean shorthands:
-  - `DEBUG_PASER_MW=1` → stream, `DEBUG_PASER_MW=2` → parse
+  - `DEBUG_PARSER_MW=1` → stream, `DEBUG_PARSER_MW=2` → parse
 
 Notes:
 
-- Variable name is intentionally `DEBUG_PASER_MW` (no extra “R”).
+- Variable name is intentionally `DEBUG_PARSER_MW` (no extra “R”).
 - ANSI colors render best in TTY; collectors may strip styling.
 - Origin highlighting uses each protocol’s optional `extractToolCallSegments`.

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -1,0 +1,52 @@
+# [dev] Debugging
+
+Enable middleware debug logs via environment variables.
+
+## Levels
+
+- `DEBUG_PASER_MW=off` (default): no logs
+- `DEBUG_PASER_MW=stream`: logs raw provider output and the normalized parts the middleware emits
+- `DEBUG_PASER_MW=parse`: after parsing completes, logs a highlighted view of detected tool-call source text (origin) and a JSON summary of tool-calls
+
+Aliases:
+
+- `DEBUG_PASER_MW=1`, `true`, `yes` → treated as `stream`
+- `DEBUG_PASER_MW=2` → treated as `parse`
+
+When it logs:
+
+- `stream`:
+  - Streaming: `[debug:mw:raw]` per provider part, `[debug:mw:out]` per normalized part
+  - Generate: `[debug:mw:raw]` before parse, then `[debug:mw:out]`
+- `parse`:
+  - Streaming: on finish → `[debug:mw:origin]`, `[debug:mw:summary]`
+  - Generate: after parse → `[debug:mw:origin]`, `[debug:mw:summary]`
+  - ToolChoice: generate logs raw once + summary; stream logs summary
+
+## Styles (parse summary)
+
+- `DEBUG_PASER_MW_STYLE=bg` (default), `inverse` (or `invert`), `underline` (or `ul`), `bold`
+- Truthy values (e.g., `1`, `true`, `yes`) map to `bg`
+- Origin lines are highlighted using the selected style; the summary is printed with a distinct background for readability.
+
+## Outputs (tags)
+
+- `[debug:mw:raw]` — provider output (string text or stream parts)
+- `[debug:mw:out]` — normalized parts emitted by the middleware
+- `[debug:mw:origin]` — highlighted source segments recognized as tool-calls
+- `[debug:mw:summary]` — JSON summary of emitted tool-calls
+
+## How to use
+
+- macOS/Linux (one-off):
+  - `DEBUG_PASER_MW=stream node your-app.js`
+  - `DEBUG_PASER_MW=parse node your-app.js`
+- With pnpm scripts: `DEBUG_PASER_MW=parse pnpm dev`
+- Numeric/boolean shorthands:
+  - `DEBUG_PASER_MW=1` → stream, `DEBUG_PASER_MW=2` → parse
+
+Notes:
+
+- Variable name is intentionally `DEBUG_PASER_MW` (no extra “R”).
+- ANSI colors render best in TTY; collectors may strip styling.
+- Origin highlighting uses each protocol’s optional `extractToolCallSegments`.

--- a/docs/guides/handlers.md
+++ b/docs/guides/handlers.md
@@ -1,0 +1,51 @@
+# [dev] Handlers Overview
+
+Middleware integrates at three points of AI SDK:
+
+- `transformParams` — Converts `tools` into a system prompt and remaps prompt content
+- `wrapStream` — Parses streaming deltas; can switch to toolChoice fast-path
+- `wrapGenerate` — Parses non-stream output; can switch to toolChoice fast-path
+
+## transformParams
+
+- Resolves protocol (factory or instance) and serializes only function tools via `protocol.formatTools({ tools, toolSystemPromptTemplate })`.
+- Prepends/merges the system prompt. Disables provider-native tools by setting `params.tools = []` and clears `params.toolChoice`.
+- Stores `toolNames` in `providerOptions.toolCallMiddleware` for downstream handlers. This is INTERNAL state propagation (not public API).
+- Remaps prompt via `convertToolPrompt` (provider-safe):
+  - Assistant `tool-call` → `text` using `protocol.formatToolCall`.
+  - Assistant unknown parts are stringified; warnings go to `onError` if provided.
+  - Assistant `reasoning` parts are preserved as-is.
+  - Tool messages (`role: "tool"`) become `user` text via `protocol.formatToolResponse` (then condensed to one text block).
+  - Any multi-text message is condensed; adjacent `user` text messages are merged.
+- Tool choice handling:
+  - `tool` → sets `responseFormat` to JSON with `{ name: const <tool>, arguments: <inputSchema> }`, forwards INTERNAL `providerOptions.toolCallMiddleware.toolChoice` for fast-path.
+    - If a provider-defined tool (non-function) matches the requested name/id, throws (provider-defined tools are not supported).
+  - `required` → sets dynamic JSON schema via `createDynamicIfThenElseSchema(tools)`, forwards INTERNAL `toolChoice: { type: "required" }`.
+  - `none` → not supported (throws). See [Tool Choice](./tool-choice.md).
+
+## wrapStream
+
+- If `isToolChoiceActive(params)` → switches to `toolChoiceStream` (runs `doGenerate`, emits a single `tool-call` then `finish`).
+- Otherwise:
+  - Calls provider `doStream()`; in debug `stream` logs raw parts; in debug `parse` accumulates raw text for summary.
+  - Pipes through `protocol.createStreamParser({ tools, options })` where:
+    - `tools` are filtered function tools.
+    - `options` includes public `onError` and INTERNAL `providerOptions.toolCallMiddleware` fields.
+  - In debug `parse`, on `finish`, logs `extractToolCallSegments` (if implemented by protocol) and a summary of parsed `tool-call`s.
+
+## wrapGenerate
+
+- If `isToolChoiceActive(params)` → runs `doGenerate()`, parses `content[0].text` as JSON `{ name, arguments }`, returns `[ { type: "tool-call", ... } ]` and logs summary in debug `parse`.
+- Otherwise:
+  - For each `text` content, runs `protocol.parseGeneratedText({ text, tools, options })`.
+    - `tools` are function tools, `options` includes public `onError` and INTERNAL `providerOptions.toolCallMiddleware`.
+  - Coerces each `tool-call.input` with `coerceToolCallInput` using the tool's `inputSchema`.
+  - Debug: `stream` logs raw and parsed parts; `parse` logs `extractToolCallSegments` (if available) and a parsed summary.
+
+Additional dev notes (high-signal):
+
+- `isToolChoiceActive(params)` checks INTERNAL `providerOptions.toolCallMiddleware.toolChoice` set by `transformParams`.
+- Only function-type tools participate in prompts/parsing; provider-native tools are disabled to avoid conflicts.
+- Providers that strip `params.tools` are handled by propagating `toolNames` internally to downstream handlers.
+
+See `packages/parser/src/transform-handler.ts`, `stream-handler.ts`, `generate-handler.ts` for exact behavior. Provider options breakdown: `docs/concepts/provider-options.md` (Public vs INTERNAL).

--- a/docs/guides/tool-calling.md
+++ b/docs/guides/tool-calling.md
@@ -4,8 +4,8 @@ Use the middleware to enable tool calls on models without native `tools` support
 
 ## Prebuilt middlewares
 
-- `gemmaToolMiddleware` — JSON-mix in markdown fences (`tool_call / `tool_response)
-- `hermesToolMiddleware` — JSON-mix with XML wrappers (<tool_call>)
+- `gemmaToolMiddleware` — JSON-mix in markdown fences (`tool_call`)
+- `hermesToolMiddleware` — JSON-mix with XML wrappers (`<tool_call>`)
 - `xmlToolMiddleware` — Morph-XML protocol (native XML elements per tool name)
 
 ## Generate mode

--- a/docs/guides/tool-calling.md
+++ b/docs/guides/tool-calling.md
@@ -1,0 +1,116 @@
+# [dev] Tool Calling Guide
+
+Use the middleware to enable tool calls on models without native `tools` support.
+
+## Prebuilt middlewares
+
+- `gemmaToolMiddleware` — JSON-mix in markdown fences (`tool_call / `tool_response)
+- `hermesToolMiddleware` — JSON-mix with XML wrappers (<tool_call>)
+- `xmlToolMiddleware` — Morph-XML protocol (native XML elements per tool name)
+
+## Generate mode
+
+```ts
+import { wrapLanguageModel, generateText } from "ai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { hermesToolMiddleware } from "@ai-sdk-tool/parser";
+
+const openrouter = createOpenAICompatible({
+  /* ... */
+});
+
+const { text, toolCalls } = await generateText({
+  model: wrapLanguageModel({
+    model: openrouter("nousresearch/hermes-3-llama-3.1-70b"),
+    middleware: hermesToolMiddleware,
+  }),
+  prompt: "Find weather for Seoul today",
+  tools: {
+    get_weather: {
+      description: "Get weather by city",
+      parameters: z.object({ city: z.string() }),
+      execute: async ({ city }) => {
+        /* ... */
+      },
+    },
+  },
+});
+```
+
+## Streaming mode
+
+```ts
+import { wrapLanguageModel, stepCountIs, streamText } from "ai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { gemmaToolMiddleware } from "@ai-sdk-tool/parser";
+
+const openrouter = createOpenAICompatible({
+  /* ... */
+});
+
+const result = streamText({
+  model: wrapLanguageModel({
+    model: openrouter("google/gemma-3-27b-it"),
+    middleware: gemmaToolMiddleware,
+  }),
+  system: "You are a helpful assistant.",
+  prompt: "What is the weather in my city?",
+  stopWhen: stepCountIs(4),
+  tools: {
+    get_location: {
+      /* ... */
+    },
+    get_weather: {
+      /* ... */
+    },
+  },
+});
+```
+
+## Tool choice
+
+- `toolChoice: "required"` forces a call. The middleware injects a dynamic JSON schema to guide the model.
+- `toolChoice: { type: "tool", toolName: "get_weather" }` forces a specific tool. The middleware injects a fixed schema for that tool.
+- `toolChoice: "none"` is not supported and will throw.
+
+## Provider options (advanced)
+
+Pass via `providerOptions.toolCallMiddleware`:
+
+- `onError(message, metadata)` — receive non-fatal parsing/coercion warnings.
+- `originalToolSchemas` — for XML protocol to coerce arguments using provider-original schemas during generate/stream.
+
+Example:
+
+```ts
+const result = await generateText({
+  /* ... */,
+  providerOptions: {
+    toolCallMiddleware: {
+      onError: (msg, meta) => console.warn(msg, meta),
+      originalToolSchemas: {/* name->schema map */},
+    },
+  },
+});
+```
+
+## Debugging
+
+Set env variables:
+
+- `DEBUG_PASER_MW=stream` — log raw/normalized stream events
+- `DEBUG_PASER_MW=parse` — log parsed summary and original text highlighting
+- `DEBUG_PASER_MW_STYLE=bg|inverse|underline|bold` — tweak summary style
+
+## Protocol specifics
+
+- `gemmaToolMiddleware` (JSON-mix):
+  - Emits/consumes tool calls inside markdown fences: `tool_call ... `
+  - Tool responses are formatted with ```tool_response fences.
+- `hermesToolMiddleware` (JSON-mix with `<tool_call>`):
+  - System prompt describes `<tools>` block and requires returning JSON inside `<tool_call> ... </tool_call>` tags.
+- `xmlToolMiddleware` (Morph-XML):
+  - Tool call must be an XML element named after the tool (e.g., `<get_weather>...</get_weather>`).
+  - Arguments parsed via `fast-xml-parser`, then coerced using JSON Schema.
+
+See runnable examples in `examples/parser-core/src/*`.

--- a/docs/guides/tool-calling.md
+++ b/docs/guides/tool-calling.md
@@ -98,9 +98,9 @@ const result = await generateText({
 
 Set env variables:
 
-- `DEBUG_PASER_MW=stream` — log raw/normalized stream events
-- `DEBUG_PASER_MW=parse` — log parsed summary and original text highlighting
-- `DEBUG_PASER_MW_STYLE=bg|inverse|underline|bold` — tweak summary style
+- `DEBUG_PARSER_MW=stream` — log raw/normalized stream events
+- `DEBUG_PARSER_MW=parse` — log parsed summary and original text highlighting
+- `DEBUG_PARSER_MW_STYLE=bg|inverse|underline|bold` — tweak summary style
 
 ## Protocol specifics
 

--- a/docs/guides/tool-choice.md
+++ b/docs/guides/tool-choice.md
@@ -1,0 +1,88 @@
+# [dev] Tool Choice
+
+The middleware emulates tool choice by shaping `responseFormat` and parsing model output.
+
+## Modes
+
+- `required`: model must return a single call to any tool.
+- `tool`: model must return a call to the specific tool `toolName`.
+- `none`: not supported (error thrown).
+- `auto`: pass-through (middleware does not activate tool-choice fast-path).
+
+## How it works
+
+When `toolChoice` is present, `transformParams` constructs a JSON schema and sets `responseFormat`:
+
+- `tool`: schema:
+
+  ```json
+  {
+    "type": "object",
+    "properties": {
+      "name": { "const": "<toolName>" },
+      "arguments": {
+        /* tool.inputSchema */
+      }
+    },
+    "required": ["name", "arguments"]
+  }
+  ```
+
+- `required`: schema is a dynamic `if/then/else` across all tools (see `createDynamicIfThenElseSchema`).
+
+Additionally:
+
+- For `tool`, `responseFormat` includes `name` and `description` of the tool (hints for some providers).
+- `tools` are cleared in the outgoing params; tool names are propagated via `providerOptions.toolCallMiddleware.toolNames` for downstream parsing when providers strip `params.tools`.
+- Internal activation flag: `providerOptions.toolCallMiddleware.toolChoice` is set to `{ type: "tool" | "required", ... }` to enable the fast-path in stream/generate handlers.
+
+`wrapStream`/`wrapGenerate` in tool-choice mode parse the provider output as raw JSON text `{ name, arguments }` and synthesize a `tool-call` part.
+
+- Generate mode: replaces first text item with a single `tool-call` content.
+- Stream mode: internally calls generate once and returns a short stream: one `tool-call` chunk followed by `finish`.
+
+## Usage (AI SDK parameter)
+
+- Force any tool to be called:
+
+  ```ts
+  const result = await generateText({
+    model,
+    prompt: "...",
+    tools: {
+      get_weather: {
+        /* ... */
+      },
+      get_location: {
+        /* ... */
+      },
+    },
+    toolChoice: { type: "required" },
+  });
+  ```
+
+- Force a specific tool to be called:
+
+  ```ts
+  const result = await generateText({
+    model,
+    prompt: "...",
+    tools: {
+      get_weather: {
+        /* ... */
+      },
+    },
+    toolChoice: { type: "tool", toolName: "get_weather" },
+  });
+  ```
+
+Note: Provider-defined tools are not supported in this middleware; define custom function tools. If a provider tool matches the requested `toolName`, an error is thrown during `transformParams`.
+
+See `packages/parser/src/transform-handler.ts` and `packages/parser/src/utils/dynamic-tool-schema.ts` for the exact behavior.
+
+## Errors & limitations
+
+- `tool`: throws if the named tool is missing from `params.tools`, or if any provider-defined tool matches the requested identifier.
+- `required`: throws if `params.tools` is empty; provider-defined tools are not supported (rejected during schema build).
+- Model output must be a pure JSON object with fields `name` and `arguments` in the first text item; non-JSON is reported via `onError` and coerced to an empty call.
+- Only a single tool call is supported per response in tool-choice mode; parallel/multiple calls are not yet supported.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# `@ai-sdk-tool/` documentation
+
+Monorepo documentation for AI SDK tool-calling middleware and evaluation utilities.
+
+- Getting Started: [getting-started.md](getting-started.md)
+- Prebuilt Middlewares (choose one):
+  - **gemmaToolMiddleware**: JSON tool calls in markdown fences — Gemma-like models
+  - **hermesToolMiddleware**: JSON payload wrapped in XML tags — Hermes/Llama-style
+  - **xmlToolMiddleware**: XML elements per tool — GLM/XML-friendly models
+- Guides
+  - [dev] Tool Calling: [guides/tool-calling.md](guides/tool-calling.md)
+  - [dev] Handlers Overview: [guides/handlers.md](guides/handlers.md)
+  - [dev] Tool Choice: [guides/tool-choice.md](guides/tool-choice.md)
+  - [dev] Debugging: [guides/debugging.md](guides/debugging.md)
+- Concepts
+  - [dev] Protocols: [concepts/protocols.md](concepts/protocols.md)
+  - [dev] Middleware Architecture: [concepts/middleware.md](concepts/middleware.md)
+  - [dev] Argument Coercion: [concepts/coercion.md](concepts/coercion.md)
+  - [dev] Streaming Algorithms: [concepts/streaming.md](concepts/streaming.md)
+  - [dev] Provider Options: [concepts/provider-options.md](concepts/provider-options.md)
+- Evaluation: [evaluation.md](evaluation.md)
+- Examples: [examples.md](examples.md)

--- a/examples/eval-core/README.md
+++ b/examples/eval-core/README.md
@@ -1,0 +1,19 @@
+# Eval Core Examples
+
+Runnable examples for `@ai-sdk-tool/eval`.
+
+## Files
+
+- `src/bfcl-simple.ts` — run BFCL simple benchmark across models
+- `src/json-generation.ts` — run JSON generation benchmark
+
+## Run
+
+From repo root after `pnpm install`:
+
+```bash
+cd examples/eval-core && pnpm dlx tsx src/bfcl-simple.ts
+cd examples/eval-core && pnpm dlx tsx src/json-generation.ts
+```
+
+Configure your model provider credentials as needed.

--- a/examples/parser-core/README.md
+++ b/examples/parser-core/README.md
@@ -1,0 +1,24 @@
+# Parser Core Examples
+
+Runnable examples for `@ai-sdk-tool/parser`.
+
+## Files
+
+- `src/00-tool-call.ts` — basic non‑streaming tool call
+- `src/00-stream-tool-call.ts` — streaming tool call
+- `src/01-reasoning-tool-call.ts` — reasoning + tool call (non‑streaming)
+- `src/01-stream-reasoning-tool-call.ts` — reasoning + tool call (streaming)
+- `src/02-choice-required.ts` — tool choice: required
+- `src/02-choice-toolname.ts` — tool choice: specific tool name
+- `src/02-stream-choice-required.ts` — streaming + required tool
+- `src/02-stream-choice-toolname.ts` — streaming + specific tool
+
+## Run
+
+From repo root after `pnpm install`:
+
+```bash
+cd examples/parser-core && pnpm dlx tsx src/00-stream-tool-call.ts
+```
+
+Configure your model provider credentials as needed (e.g., OpenRouter key/base URL).

--- a/examples/parser-core/src/00-stream-tool-call.ts
+++ b/examples/parser-core/src/00-stream-tool-call.ts
@@ -1,4 +1,4 @@
-import { gemmaToolMiddleware } from "@ai-sdk-tool/parser";
+import { xmlToolMiddleware } from "@ai-sdk-tool/parser";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { stepCountIs, streamText, wrapLanguageModel } from "ai";
 import { z } from "zod";
@@ -11,15 +11,15 @@ const openrouter = createOpenAICompatible({
 
 async function main() {
   const result = streamText({
-    // model: wrapLanguageModel({
-    //   model: openrouter("z-ai/glm-4.5-air"),
-    //   middleware: xmlToolMiddleware,
-    // }),
-
     model: wrapLanguageModel({
-      model: openrouter("google/gemma-3-27b-it"),
-      middleware: gemmaToolMiddleware,
+      model: openrouter("z-ai/glm-4.5-air"),
+      middleware: xmlToolMiddleware,
     }),
+
+    // model: wrapLanguageModel({
+    //   model: openrouter("google/gemma-3-27b-it"),
+    //   middleware: gemmaToolMiddleware,
+    // }),
 
     temperature: 0.0,
     system: "You are a helpful assistant.",

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -1,4 +1,7 @@
-# Vercel AI SDK - Evaluation Tool (`@ai-sdk-tool/eval`)
+# AI SDK - evaluation tool
+
+[![npm](https://img.shields.io/npm/v/@ai-sdk-tool/eval)](https://www.npmjs.com/package/@ai-sdk-tool/eval)
+[![npm](https://img.shields.io/npm/dt/@ai-sdk-tool/eval)](https://www.npmjs.com/package/@ai-sdk-tool/eval)
 
 This package provides a standardized, extensible, and reproducible way to benchmark and evaluate the performance of Language Models (`LanguageModel` instances) within the Vercel AI SDK ecosystem.
 
@@ -18,9 +21,7 @@ It allows developers to:
 ## Installation
 
 ```bash
-# This package is currently local within the monorepo.
-# In the future, it would be published to npm:
-# npm install @ai-sdk-tool/eval
+pnpm add @ai-sdk-tool/eval
 ```
 
 ## Quick Start
@@ -52,6 +53,12 @@ async function runMyEvaluation() {
 runMyEvaluation();
 ```
 
+Run the example from this repo:
+
+```bash
+cd examples/eval-core && pnpm dlx tsx src/bfcl-simple.ts
+```
+
 ## Built-in Benchmarks
 
 This package includes several pre-built benchmarks.
@@ -60,7 +67,13 @@ This package includes several pre-built benchmarks.
 - `bfclParallelBenchmark`: Evaluates parallel (multi-tool) function calls.
 - `bfclMultipleBenchmark`: Evaluates multiple calls to the same function.
 - `bfclParallelMultipleBenchmark`: A combination of parallel and multiple function calls.
-- `jsonGenerationBenchmark`: Evaluates the model's ability to generate schema-compliant JSON. _(Note: This benchmark is temporarily disabled due to a TypeScript compilation issue)._
+- `jsonGenerationBenchmark`: Evaluates the model's ability to generate schema-compliant JSON.
+
+To try a JSON generation run locally:
+
+```bash
+cd examples/eval-core && pnpm dlx tsx src/json-generation.ts
+```
 
 ## Creating a Custom Benchmark
 

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -1,0 +1,112 @@
+# AI SDK - tool call parser middleware
+
+▲ Also available in the Vercel AI SDK official documentation: [Custom tool call parser](https://ai-sdk.dev/docs/ai-sdk-core/middleware#custom-tool-call-parser)
+
+[![npm](https://img.shields.io/npm/v/@ai-sdk-tool/parser)](https://www.npmjs.com/package/@ai-sdk-tool/parser)
+[![npm](https://img.shields.io/npm/dt/@ai-sdk-tool/parser)](https://www.npmjs.com/package/@ai-sdk-tool/parser)
+[![codecov](https://codecov.io/gh/minpeter/ai-sdk-tool-call-middleware/branch/main/graph/badge.svg)](https://codecov.io/gh/minpeter/ai-sdk-tool-call-middleware)
+
+> [!NOTE]
+> Depends on AI SDK v5. For AI SDK v4, pin `@ai-sdk-tool/parser@1.0.0`.
+
+Middleware that enables tool calling with models that don’t natively support OpenAI‑style `tools`. Works with any provider (OpenRouter, vLLM, Ollama, etc.) via AI SDK v2 middleware.
+
+## Why This Exists
+
+Many self‑hosted or third‑party model endpoints (vLLM, MLC‑LLM, Ollama, OpenRouter, etc.) don’t yet expose the OpenAI‑style `tools` parameter, forcing you to hack together tool parsing.  
+This project provides a flexible middleware that:
+
+- Parses tool calls from streaming or batch responses
+- Supports Hermes and Gemma formats
+- Llama, Mistral, and JSON formats are coming soon
+- Gain complete control over the tool call system prompt.
+
+## Installation
+
+```bash
+pnpm add @ai-sdk-tool/parser
+```
+
+## Quickstart (streaming)
+
+```typescript
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { wrapLanguageModel, stepCountIs, streamText } from "ai";
+import { gemmaToolMiddleware } from "@ai-sdk-tool/parser";
+
+const openrouter = createOpenAICompatible({
+  /* ... */
+});
+
+async function main() {
+  const result = streamText({
+    model: wrapLanguageModel({
+      model: openrouter("google/gemma-3-27b-it"),
+      middleware: gemmaToolMiddleware,
+    }),
+    system: "You are a helpful assistant.",
+    prompt: "What is the weather in my city?",
+    stopWhen: stepCountIs(4),
+    tools: {
+      get_location: {
+        /* ... */
+      },
+      get_weather: {
+        /* ... */
+      },
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    // handle text/tool events
+  }
+}
+
+main().catch(console.error);
+```
+
+## Quickstart (generate)
+
+```typescript
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { wrapLanguageModel, generateText } from "ai";
+import { hermesToolMiddleware } from "@ai-sdk-tool/parser";
+
+const openrouter = createOpenAICompatible({
+  /* ... */
+});
+
+async function main() {
+  const { text } = await generateText({
+    model: wrapLanguageModel({
+      model: openrouter("nousresearch/hermes-3-llama-3.1-70b"),
+      middleware: hermesToolMiddleware,
+    }),
+    prompt: "Find weather for Seoul today",
+    tools: {
+      get_weather: {
+        /* ... */
+      },
+    },
+  });
+
+  console.log(text);
+}
+
+main().catch(console.error);
+```
+
+## Prebuilt middlewares
+
+- `gemmaToolMiddleware` — JSON‑mix format inside markdown fences (`tool_call/`tool_response).
+- `hermesToolMiddleware` — JSON‑mix format with XML wrappers (`<tool_call>` tags).
+- `xmlToolMiddleware` — XML format (Morph‑XML protocol).
+
+## Protocols
+
+- `jsonMixProtocol` — JSON function calls in flexible text wrappers.
+- `morphXmlProtocol` — XML element per call, robust to streaming.
+
+## Examples
+
+See `examples/parser-core/src/*` for runnable demos (streaming/non‑streaming, tool choice).

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -7,9 +7,9 @@
 [![codecov](https://codecov.io/gh/minpeter/ai-sdk-tool-call-middleware/branch/main/graph/badge.svg)](https://codecov.io/gh/minpeter/ai-sdk-tool-call-middleware)
 
 > [!NOTE]
-> Depends on AI SDK v5. For AI SDK v4, pin `@ai-sdk-tool/parser@1.0.0`.
+> Requires AI SDK v5. For AI SDK v4, pin `@ai-sdk-tool/parser@1.0.0`.
 
-Middleware that enables tool calling with models that don’t natively support OpenAI‑style `tools`. Works with any provider (OpenRouter, vLLM, Ollama, etc.) via AI SDK v2 middleware.
+Middleware that enables tool calling with models that don’t natively support OpenAI‑style `tools`. Works with any provider (OpenRouter, vLLM, Ollama, etc.) via AI SDK middleware.
 
 ## Why This Exists
 
@@ -17,9 +17,8 @@ Many self‑hosted or third‑party model endpoints (vLLM, MLC‑LLM, Ollama, Op
 This project provides a flexible middleware that:
 
 - Parses tool calls from streaming or batch responses
-- Supports Hermes and Gemma formats
-- Llama, Mistral, and JSON formats are coming soon
-- Gain complete control over the tool call system prompt.
+- Prebuilt protocols: JSON‑mix (Gemma/Hermes‑style) and Morph‑XML
+- Full control over the tool call system prompt
 
 ## Installation
 
@@ -98,8 +97,8 @@ main().catch(console.error);
 
 ## Prebuilt middlewares
 
-- `gemmaToolMiddleware` — JSON‑mix format inside markdown fences (`tool_call/`tool_response).
-- `hermesToolMiddleware` — JSON‑mix format with XML wrappers (`<tool_call>` tags).
+- `gemmaToolMiddleware` — JSON‑mix format inside markdown fences (`tool_call` / ```tool_response").
+- `hermesToolMiddleware` — JSON‑mix format wrapped in `<tool_call>` XML tags.
 - `xmlToolMiddleware` — XML format (Morph‑XML protocol).
 
 ## Protocols
@@ -107,6 +106,24 @@ main().catch(console.error);
 - `jsonMixProtocol` — JSON function calls in flexible text wrappers.
 - `morphXmlProtocol` — XML element per call, robust to streaming.
 
+## Tool choice support
+
+- `toolChoice: { type: "required" }`: forces one tool call. Middleware sets a JSON response schema to validate calls.
+- `toolChoice: { type: "tool", toolName }`: forces a specific tool. Provider‑defined tools are not supported; pass only custom function tools.
+- `toolChoice: { type: "none" }` is not supported and will throw.
+
 ## Examples
 
 See `examples/parser-core/src/*` for runnable demos (streaming/non‑streaming, tool choice).
+
+## [dev] Contributor notes
+
+- Exported API: `createToolMiddleware`, `gemmaToolMiddleware`, `hermesToolMiddleware`, `xmlToolMiddleware`, `jsonMixProtocol`, `morphXmlProtocol`.
+- Debugging:
+  - Set `DEBUG_PASER_MW=stream` to log raw/parsed chunks during runs.
+  - Set `DEBUG_PASER_MW=parse` to log original matched text and parsed summary.
+  - Optional `DEBUG_PASER_MW_STYLE=bg|inverse|underline|bold` to change highlight style.
+- Provider options passthrough: `providerOptions.toolCallMiddleware` fields are merged into protocol options. Internal fields used:
+  - `toolNames`: internal propagation of custom tool names.
+  - `toolChoice`: internal fast‑path activation for required/specific tool modes.
+- Transform details: `transformParams` injects a system message built from protocol `formatTools` and clears `tools` since many providers strip/ignore them.

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -120,9 +120,9 @@ See `examples/parser-core/src/*` for runnable demos (streaming/non‑streaming, 
 
 - Exported API: `createToolMiddleware`, `gemmaToolMiddleware`, `hermesToolMiddleware`, `xmlToolMiddleware`, `jsonMixProtocol`, `morphXmlProtocol`.
 - Debugging:
-  - Set `DEBUG_PASER_MW=stream` to log raw/parsed chunks during runs.
-  - Set `DEBUG_PASER_MW=parse` to log original matched text and parsed summary.
-  - Optional `DEBUG_PASER_MW_STYLE=bg|inverse|underline|bold` to change highlight style.
+  - Set `DEBUG_PARSER_MW=stream` to log raw/parsed chunks during runs.
+  - Set `DEBUG_PARSER_MW=parse` to log original matched text and parsed summary.
+  - Optional `DEBUG_PARSER_MW_STYLE=bg|inverse|underline|bold` to change highlight style.
 - Provider options passthrough: `providerOptions.toolCallMiddleware` fields are merged into protocol options. Internal fields used:
   - `toolNames`: internal propagation of custom tool names.
   - `toolChoice`: internal fast‑path activation for required/specific tool modes.

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -97,7 +97,7 @@ main().catch(console.error);
 
 ## Prebuilt middlewares
 
-- `gemmaToolMiddleware` — JSON‑mix format inside markdown fences (`tool_call` / ```tool_response").
+- `gemmaToolMiddleware` — JSON‑mix format inside markdown fences (markdown code fences)
 - `hermesToolMiddleware` — JSON‑mix format wrapped in `<tool_call>` XML tags.
 - `xmlToolMiddleware` — XML format (Morph‑XML protocol).
 

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -6,7 +6,9 @@ const gemmaToolMiddleware = createToolMiddleware({
     // Customize the tool call delimiters to use markdown code fences
     {
       toolCallStart: "```tool_call\n",
-      toolCallEnd: "\n``", // two backticks are more common in gemma output @
+      // TODO: Support specifying multiple possible tags,
+      // e.g., for gemma, it would be nice to be able to set both `` and ``` at the same time.
+      toolCallEnd: "\n```",
       toolResponseStart: "```tool_response\n",
       toolResponseEnd: "\n```",
     }

--- a/packages/parser/src/protocols/json-mix-protocol.ts
+++ b/packages/parser/src/protocols/json-mix-protocol.ts
@@ -285,4 +285,16 @@ export const jsonMixProtocol = ({
       },
     });
   },
+
+  extractToolCallSegments({ text }) {
+    const startEsc = escapeRegExp(toolCallStart);
+    const endEsc = escapeRegExp(toolCallEnd);
+    const regex = new RegExp(`${startEsc}([\u0000-\uFFFF]*?)${endEsc}`, "gs");
+    const segments: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(text)) != null) {
+      segments.push(m[0]);
+    }
+    return segments;
+  },
 });

--- a/packages/parser/src/protocols/morph-xml-protocol.ts
+++ b/packages/parser/src/protocols/morph-xml-protocol.ts
@@ -569,4 +569,18 @@ export const morphXmlProtocol = (): ToolCallProtocol => ({
       },
     });
   },
+
+  extractToolCallSegments({ text, tools }) {
+    const toolNames = tools.map(t => t.name).filter(Boolean) as string[];
+    if (toolNames.length === 0) return [];
+    const names = toolNames.map(n => escapeRegExp(String(n))).join("|");
+    if (!names) return [];
+    const regex = new RegExp(`<(${names})>[\\s\\S]*?<\\/\\1>`, "g");
+    const segments: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(text)) != null) {
+      segments.push(m[0]);
+    }
+    return segments;
+  },
 });

--- a/packages/parser/src/protocols/morph-xml-protocol.ts
+++ b/packages/parser/src/protocols/morph-xml-protocol.ts
@@ -236,6 +236,8 @@ export const morphXmlProtocol = (): ToolCallProtocol => ({
         }
 
         // Use original schema if available, fallback to transformed schema
+        // INTERNAL: `originalToolSchemas` is used to propagate the provider's
+        // untouched tool schemas for better coercion. Not part of public API.
         const originalSchema = originalSchemas[toolName];
         const fallbackSchema = tools.find(t => t.name === toolName)
           ?.inputSchema as unknown;

--- a/packages/parser/src/protocols/tool-call-protocol.ts
+++ b/packages/parser/src/protocols/tool-call-protocol.ts
@@ -121,4 +121,17 @@ export interface ToolCallProtocol {
       onError?: (message: string, metadata?: Record<string, unknown>) => void;
     };
   }): TransformStream<LanguageModelV2StreamPart, LanguageModelV2StreamPart>;
+
+  /**
+   * Optionally returns the exact substrings that would be parsed as tool-calls
+   * from the provided text for this protocol.
+   * Used for debug logging in parse mode.
+   */
+  extractToolCallSegments?: ({
+    text,
+    tools,
+  }: {
+    text: string;
+    tools: LanguageModelV2FunctionTool[];
+  }) => string[];
 }

--- a/packages/parser/src/stream-handler.ts
+++ b/packages/parser/src/stream-handler.ts
@@ -1,5 +1,6 @@
 import type {
   LanguageModelV2,
+  LanguageModelV2Content,
   LanguageModelV2FinishReason,
   LanguageModelV2FunctionTool,
   LanguageModelV2StreamPart,
@@ -13,6 +14,12 @@ import {
   getFunctionTools,
   isToolChoiceActive,
 } from "./utils";
+import {
+  getDebugLevel,
+  logParsedChunk,
+  logParsedSummary,
+  logRawChunk,
+} from "./utils/debug";
 
 type WrapStreamParams = Parameters<typeof isToolChoiceActive>[0] & {
   tools?: Array<LanguageModelV2FunctionTool | { type: string }>;
@@ -38,20 +45,93 @@ export async function wrapStream({
   }
 
   const { stream, ...rest } = await doStream();
+
+  const debugLevel = getDebugLevel();
+  let fullRawText = "";
+  const withRawTap = stream.pipeThrough(
+    new TransformStream<LanguageModelV2StreamPart, LanguageModelV2StreamPart>({
+      transform(part, controller) {
+        if (debugLevel === "stream") {
+          logRawChunk(part);
+        }
+        if (debugLevel === "parse" && part.type === "text-delta") {
+          const delta = (
+            part as Extract<LanguageModelV2StreamPart, { type: "text-delta" }>
+          ).delta as string | undefined;
+          if (typeof delta === "string" && delta.length > 0)
+            fullRawText += delta;
+        }
+        controller.enqueue(part);
+      },
+    })
+  );
+
+  const parsed = withRawTap.pipeThrough(
+    protocol.createStreamParser({
+      tools: getFunctionTools(params),
+      options: {
+        ...extractOnErrorOption(params.providerOptions),
+        ...((
+          params.providerOptions as { toolCallMiddleware?: unknown } | undefined
+        )?.toolCallMiddleware as Record<string, unknown>),
+      },
+    })
+  );
+
+  const withParsedTap = parsed.pipeThrough(
+    new TransformStream<LanguageModelV2StreamPart, LanguageModelV2StreamPart>({
+      start() {
+        /* noop */
+      },
+      transform(part, controller) {
+        if (debugLevel === "stream") {
+          logParsedChunk(part);
+        }
+        controller.enqueue(part);
+      },
+    })
+  );
+
+  // For parse mode, emit summary after finish
+  const withSummary = withParsedTap.pipeThrough(
+    new TransformStream<LanguageModelV2StreamPart, LanguageModelV2StreamPart>({
+      start() {
+        /* noop */
+      },
+      transform: (() => {
+        const parsedToolCalls: LanguageModelV2StreamPart[] = [];
+        return (
+          part: LanguageModelV2StreamPart,
+          controller: TransformStreamDefaultController<LanguageModelV2StreamPart>
+        ) => {
+          if (debugLevel === "parse" && part.type === "tool-call") {
+            parsedToolCalls.push(part);
+          }
+          if (debugLevel === "parse" && part.type === "finish") {
+            try {
+              const segments = protocol.extractToolCallSegments
+                ? protocol.extractToolCallSegments({
+                    text: fullRawText,
+                    tools: getFunctionTools(params),
+                  })
+                : [];
+              const origin = segments.join("\n\n");
+              logParsedSummary({
+                toolCalls: parsedToolCalls,
+                originalText: origin,
+              });
+            } catch {
+              // ignore logging failures
+            }
+          }
+          controller.enqueue(part);
+        };
+      })(),
+    })
+  );
+
   return {
-    stream: stream.pipeThrough(
-      protocol.createStreamParser({
-        tools: getFunctionTools(params),
-        options: {
-          ...extractOnErrorOption(params.providerOptions),
-          ...((
-            params.providerOptions as
-              | { toolCallMiddleware?: unknown }
-              | undefined
-          )?.toolCallMiddleware as Record<string, unknown>),
-        },
-      })
-    ),
+    stream: withSummary,
     ...rest,
   };
 }
@@ -116,9 +196,43 @@ export async function toolChoiceStream({
     },
   });
 
+  const debugLevel = getDebugLevel();
+  const firstText =
+    (result?.content &&
+      result.content[0] &&
+      (result.content[0] as Extract<LanguageModelV2Content, { type: "text" }>)
+        .type === "text" &&
+      (result.content[0] as Extract<LanguageModelV2Content, { type: "text" }>)
+        .text) ||
+    "";
+  const streamWithSummary =
+    debugLevel === "parse"
+      ? stream.pipeThrough(
+          new TransformStream<
+            LanguageModelV2StreamPart,
+            LanguageModelV2StreamPart
+          >({
+            transform(part, controller) {
+              if (part.type === "finish") {
+                try {
+                  logParsedSummary({
+                    toolCalls: [toolCallChunk],
+                    originalText:
+                      typeof firstText === "string" ? firstText : "",
+                  });
+                } catch {
+                  // ignore logging failures
+                }
+              }
+              controller.enqueue(part);
+            },
+          })
+        )
+      : stream;
+
   return {
     request: result?.request || {},
     response: result?.response || {},
-    stream,
+    stream: streamWithSummary,
   };
 }

--- a/packages/parser/src/transform-handler.ts
+++ b/packages/parser/src/transform-handler.ts
@@ -80,6 +80,9 @@ export async function transformParams({
           (params.providerOptions as { toolCallMiddleware?: unknown })
             .toolCallMiddleware) ||
           {}),
+        // INTERNAL: used by the middleware to propagate the names of custom
+        // function tools into downstream handlers (stream/generate) when
+        // providers strip or ignore `params.tools`. Not a stable public API.
         toolNames: functionTools.map(t => t.name),
       },
     },
@@ -151,6 +154,8 @@ export async function transformParams({
               }
             ).toolCallMiddleware) ||
             {}),
+          // INTERNAL: used by the middleware to activate the tool-choice
+          // fast-path in handlers. Not a stable public API.
           toolChoice: params.toolChoice,
         },
       },
@@ -181,6 +186,8 @@ export async function transformParams({
               }
             ).toolCallMiddleware) ||
             {}),
+          // INTERNAL: used by the middleware to activate the tool-choice
+          // fast-path in handlers. Not a stable public API.
           toolChoice: { type: "required" },
         },
       },

--- a/packages/parser/src/utils/debug.ts
+++ b/packages/parser/src/utils/debug.ts
@@ -15,7 +15,7 @@ export function getDebugLevel(): DebugLevel {
   const envVal =
     (typeof process !== "undefined" &&
       process.env &&
-      process.env.AI_TOOL_MW_DEBUG) ||
+      process.env.DEBUG_PASER_MW) ||
     "off";
   const envLower = String(envVal).toLowerCase();
   if (envLower === "stream" || envLower === "parse" || envLower === "off") {
@@ -70,10 +70,9 @@ export function logParsedSummary({
       const envVal =
         (typeof process !== "undefined" &&
           process.env &&
-          (process.env.AI_TOOL_MW_DEBUG_STYLE ||
-            process.env.AI_TOOL_MW_DEBUG_HIGHLIGHT ||
-            process.env.AI_TOOL_MW_DEBUG_BG)) ||
-        "";
+          process.env.DEBUG_PASER_MW_STYLE) ||
+        "bg";
+
       const normalized = String(envVal).trim().toLowerCase();
       if (normalized === "inverse" || normalized === "invert")
         return "inverse" as const;

--- a/packages/parser/src/utils/debug.ts
+++ b/packages/parser/src/utils/debug.ts
@@ -1,0 +1,122 @@
+export type DebugLevel = "off" | "stream" | "parse";
+
+function normalizeBooleanString(value: string): boolean | undefined {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "1" || normalized === "true" || normalized === "yes") {
+    return true;
+  }
+  if (normalized === "0" || normalized === "false" || normalized === "no") {
+    return false;
+  }
+  return undefined;
+}
+
+export function getDebugLevel(): DebugLevel {
+  const envVal =
+    (typeof process !== "undefined" &&
+      process.env &&
+      process.env.AI_TOOL_MW_DEBUG) ||
+    "off";
+  const envLower = String(envVal).toLowerCase();
+  if (envLower === "stream" || envLower === "parse" || envLower === "off") {
+    return envLower as DebugLevel;
+  }
+  const boolEnv = normalizeBooleanString(envLower);
+  if (boolEnv === true) return "stream";
+  if (envLower === "2") return "parse";
+  return "off";
+}
+
+function color(code: number) {
+  return (text: string) => `\u001b[${code}m${text}\u001b[0m`;
+}
+
+const cGray = color(90);
+const cYellow = color(33);
+const cCyan = color(36);
+const cBgBlue = color(44);
+const cBgGreen = color(42);
+const cInverse = color(7);
+const cUnderline = color(4);
+const cBold = color(1);
+
+function safeStringify(value: unknown): string {
+  try {
+    return `\n${typeof value === "string" ? value : JSON.stringify(value, null, 2)}`;
+  } catch {
+    return String(value);
+  }
+}
+
+export function logRawChunk(part: unknown) {
+  // Raw provider stream/generate output
+  console.log(cGray("[debug:mw:raw]"), cYellow(safeStringify(part)));
+}
+
+export function logParsedChunk(part: unknown) {
+  // Normalized middleware output
+  console.log(cGray("[debug:mw:out]"), cCyan(safeStringify(part)));
+}
+
+export function logParsedSummary({
+  toolCalls,
+  originalText,
+}: {
+  toolCalls: unknown[];
+  originalText: string;
+}) {
+  if (originalText) {
+    const style = (() => {
+      const envVal =
+        (typeof process !== "undefined" &&
+          process.env &&
+          (process.env.AI_TOOL_MW_DEBUG_STYLE ||
+            process.env.AI_TOOL_MW_DEBUG_HIGHLIGHT ||
+            process.env.AI_TOOL_MW_DEBUG_BG)) ||
+        "";
+      const normalized = String(envVal).trim().toLowerCase();
+      if (normalized === "inverse" || normalized === "invert")
+        return "inverse" as const;
+      if (normalized === "underline" || normalized === "ul")
+        return "underline" as const;
+      if (normalized === "bold") return "bold" as const;
+      if (normalized === "bg" || normalized === "background")
+        return "bg" as const;
+      const asBool = normalizeBooleanString(normalized);
+      if (asBool === true) return "bg" as const;
+      return "bg" as const; // default: background highlight
+    })();
+
+    const highlight =
+      style === "inverse"
+        ? cInverse
+        : style === "underline"
+          ? cUnderline
+          : style === "bold"
+            ? cBold
+            : style === "bg"
+              ? cBgGreen
+              : cYellow;
+
+    const rendered =
+      style === "bg" ||
+      style === "inverse" ||
+      style === "underline" ||
+      style === "bold"
+        ? originalText
+            .split(/\r?\n/)
+            .map(line => (line.length ? highlight(line) : line))
+            .join("\n")
+        : highlight(originalText);
+
+    console.log(cGray("[debug:mw:origin]"), `\n${rendered}`);
+  }
+
+  if (toolCalls.length > 0) {
+    const styledSummary = safeStringify(toolCalls)
+      .split(/\r?\n/)
+      .map(line => (line.length ? cBgBlue(line) : line))
+      .join("\n");
+    console.log(cGray("[debug:mw:summary]"), styledSummary);
+  }
+}

--- a/packages/parser/src/utils/debug.ts
+++ b/packages/parser/src/utils/debug.ts
@@ -15,7 +15,7 @@ export function getDebugLevel(): DebugLevel {
   const envVal =
     (typeof process !== "undefined" &&
       process.env &&
-      process.env.DEBUG_PASER_MW) ||
+      process.env.DEBUG_PARSER_MW) ||
     "off";
   const envLower = String(envVal).toLowerCase();
   if (envLower === "stream" || envLower === "parse" || envLower === "off") {
@@ -70,7 +70,7 @@ export function logParsedSummary({
       const envVal =
         (typeof process !== "undefined" &&
           process.env &&
-          process.env.DEBUG_PASER_MW_STYLE) ||
+          process.env.DEBUG_PARSER_MW_STYLE) ||
         "bg";
 
       const normalized = String(envVal).trim().toLowerCase();

--- a/packages/parser/src/utils/index.ts
+++ b/packages/parser/src/utils/index.ts
@@ -3,6 +3,7 @@ import { getPotentialStartIndex } from "./get-potential-start-index";
 import { escapeRegExp } from "./regex";
 import * as RJSON from "./relaxed-json";
 export * from "./coercion";
+export * from "./debug";
 export * from "./on-error";
 export * from "./protocol";
 export * from "./tools";

--- a/packages/parser/src/utils/tools.ts
+++ b/packages/parser/src/utils/tools.ts
@@ -2,8 +2,11 @@ import type { LanguageModelV2FunctionTool } from "@ai-sdk/provider";
 
 type ProviderOptionsWithToolNames = {
   toolCallMiddleware?: {
+    // INTERNAL: set by transform-handler to propagate tool names when providers
+    // strip `params.tools`. Used as a fallback in downstream handlers.
     toolNames?: string[];
     onError?: (message: string, metadata?: Record<string, unknown>) => void;
+    // INTERNAL: set by transform-handler to activate tool-choice fast-path.
     toolChoice?: { type: string };
   };
 };


### PR DESCRIPTION
This pull request introduces significant improvements to the documentation, clarifies the architecture, and refines the README for the `@ai-sdk-tool/` monorepo. The changes focus on making the project easier to understand and use, especially for developers integrating custom tool call middleware with the Vercel AI SDK. The documentation now includes detailed conceptual guides for middleware, protocols, argument coercion, and provider options, while the README has been restructured for clarity and discoverability.

**Documentation enhancements:**

* Added comprehensive conceptual docs:
  - [`docs/concepts/middleware.md`](diffhunk://#diff-cb7ef3597fffdb8fe2bdf714405be5722f3d941389633f2de360be28d902cedcR1-R97): Explains the middleware architecture, responsibilities, key modules, tool choice fast-path, debugging, exports, and limitations.
  - [`docs/concepts/protocols.md`](diffhunk://#diff-b224d9c40a2a349dc7cee7a7ca402512e3b1a52677a233438ada44cf3092d2caR1-R58): Details protocol design, built-in protocols, usage, and guidance for implementing custom protocols.
  - [`docs/concepts/coercion.md`](diffhunk://#diff-75be6da137930bbffd2284afcff5d5810c75fdc278ba1e7896d606b4d52e7cfeR1-R55): Describes schema-based argument coercion, its rules, helpers, and practical tips for robust tool call parsing.
  - [`docs/concepts/provider-options.md`](diffhunk://#diff-db0321b50a45588d4a49f9208b7499387c9e90e5649c17cf22a209b775c30ae6R1-R67): Outlines the provider options surface, including public hooks and internal wiring for advanced use cases.

**README improvements:**

* Reorganized and clarified the README:
  - Updated project description, npm badges, and package overview.
  - Added clear installation, usage, and example sections.
  - Provided quickstart and development instructions for the monorepo and individual packages.
  - Linked to full docs and contributing guidelines for easier onboarding.

**Architecture and terminology updates:**

* Updated references to "AI SDK v2" to "AI SDK" in architecture docs for future-proofing and clarity. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L26-R26) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L51-R51)

---

These changes make the project more accessible and maintainable for both new and experienced contributors, and provide a solid foundation for future development.