### PR TITLE
Morph-XML: preserve raw inner strings by schema; add tests

### DIFF
--- a/.changeset/breezy-hats-eat.md
+++ b/.changeset/breezy-hats-eat.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/eval": patch
+---
+
+Added option to control temperature parameter.

--- a/.changeset/morph-xml-raw-string.md
+++ b/.changeset/morph-xml-raw-string.md
@@ -1,0 +1,8 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+Preserve raw inner text for string-typed arguments in Morph-XML protocol; add tests; adjust examples.
+
+- XML parser now prefers raw inner content for properties typed as string
+- Adds unit tests for parse and streaming cases

--- a/docs/concepts/protocols.md
+++ b/docs/concepts/protocols.md
@@ -25,6 +25,14 @@ See the interface in `packages/parser/src/protocols/tool-call-protocol.ts`.
   - Type coercion: values are coerced using the tool's JSON schema via `coerceBySchema` (original provider schemas are used when available).
   - `formatTools` emits tool signatures as JSON (using `unwrapJsonSchema`) inside your system prompt template. `formatToolResponse` returns a `<tool_response>` XML block.
 
+### morph-xml: Duplicate string tag handling
+
+Some models may mistakenly emit multiple tags for a property whose schema type is `string`, e.g. `<content>part1</content><content>part2</content>`. This is considered malformed output. The `morphXmlProtocol` handles this strictly:
+
+- If duplicate tags are detected for a `string` field, the entire tool call is cancelled and emitted as text. A warning is reported via `options.onError` when provided.
+
+This behavior is consistent in both non-stream (`parseGeneratedText`) and stream (`createStreamParser`) paths; no tool-call part is emitted in this case.
+
 Implementations live in `packages/parser/src/protocols/`.
 
 ## Choosing a Protocol

--- a/examples/eval-core/src/bfcl-simple.ts
+++ b/examples/eval-core/src/bfcl-simple.ts
@@ -79,6 +79,7 @@ async function main() {
       bfclParallelMultipleBenchmark,
     ],
     reporter: "console",
+    temperature: 0.0,
   });
 
   console.log("Evaluation complete!");

--- a/examples/eval-core/src/bfcl-simple.ts
+++ b/examples/eval-core/src/bfcl-simple.ts
@@ -45,19 +45,19 @@ Available functions are listed inside <tools></tools>.
 });
 
 const xmlGemma27b = wrapLanguageModel({
-  model: friendli("skt/A.X-3.1"),
+  model: friendli("google/gemma-3-27b-it"),
   // model: openrouter("z-ai/glm-4.5-air"),
   middleware: xmlToolMiddleware,
 });
 
 const jsonGemma27b = wrapLanguageModel({
-  model: friendli("skt/A.X-3.1"),
+  model: friendli("google/gemma-3-27b-it"),
   // model: openrouter("z-ai/glm-4.5-air"),
   middleware: gemmaToolMiddleware,
 });
 
 const morphExpGemma27b = wrapLanguageModel({
-  model: friendli("skt/A.X-3.1"),
+  model: friendli("google/gemma-3-27b-it"),
   // model: openrouter("z-ai/glm-4.5-air"),
   middleware: morphExpToolMiddleware,
 });

--- a/examples/eval-core/src/bfcl-simple.ts
+++ b/examples/eval-core/src/bfcl-simple.ts
@@ -1,3 +1,4 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import {
   bfclMultipleBenchmark,
   bfclParallelBenchmark,
@@ -11,7 +12,6 @@ import {
   morphXmlProtocol,
   xmlToolMiddleware,
 } from "@ai-sdk-tool/parser";
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { wrapLanguageModel } from "ai";
 
 const friendli = createOpenAICompatible({
@@ -45,19 +45,19 @@ Available functions are listed inside <tools></tools>.
 });
 
 const xmlGemma27b = wrapLanguageModel({
-  model: friendli("google/gemma-3-27b-it"),
+  model: friendli("skt/A.X-3.1"),
   // model: openrouter("z-ai/glm-4.5-air"),
   middleware: xmlToolMiddleware,
 });
 
 const jsonGemma27b = wrapLanguageModel({
-  model: friendli("google/gemma-3-27b-it"),
+  model: friendli("skt/A.X-3.1"),
   // model: openrouter("z-ai/glm-4.5-air"),
   middleware: gemmaToolMiddleware,
 });
 
 const morphExpGemma27b = wrapLanguageModel({
-  model: friendli("google/gemma-3-27b-it"),
+  model: friendli("skt/A.X-3.1"),
   // model: openrouter("z-ai/glm-4.5-air"),
   middleware: morphExpToolMiddleware,
 });
@@ -78,7 +78,7 @@ async function main() {
       bfclParallelBenchmark,
       bfclParallelMultipleBenchmark,
     ],
-    reporter: "console.debug",
+    reporter: "console",
   });
 
   console.log("Evaluation complete!");

--- a/examples/eval-core/src/json-generation.ts
+++ b/examples/eval-core/src/json-generation.ts
@@ -1,11 +1,11 @@
+import { openai } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import {
   evaluate,
   jsonGenerationBenchmark,
   jsonGenerationSchemaOnlyBenchmark,
 } from "@ai-sdk-tool/eval";
 import { gemmaToolMiddleware } from "@ai-sdk-tool/parser";
-import { openai } from "@ai-sdk/openai";
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { wrapLanguageModel } from "ai";
 
 const gemma27b = wrapLanguageModel({

--- a/packages/eval/src/benchmarks/bfcl.ts
+++ b/packages/eval/src/benchmarks/bfcl.ts
@@ -116,7 +116,10 @@ function createBfclBenchmark(
     name,
     version: "1.0.0",
     description,
-    async run(model: LanguageModel): Promise<BenchmarkResult> {
+    async run(
+      model: LanguageModel,
+      config?: Record<string, unknown>
+    ): Promise<BenchmarkResult> {
       const logs: string[] = [];
       let correctCount = 0;
       let testCases: TestCase[] = [];
@@ -200,6 +203,10 @@ function createBfclBenchmark(
         ): Promise<{ valid: boolean; logs: string[] }> => {
           const caseLogs: string[] = [];
           const { function: tools, question: messages } = testCase;
+          const temperature =
+            typeof (config?.temperature as unknown) === "number"
+              ? (config?.temperature as number)
+              : undefined;
 
           try {
             // Flatten BFCL message shape [[{role, content}], ...] to [{role, content}, ...]
@@ -276,6 +283,7 @@ function createBfclBenchmark(
               messages: flatMessages as unknown as any,
               tools: toolsMap,
               toolChoice: "auto",
+              ...(temperature !== undefined ? { temperature } : {}),
               // Pass original schema information to middleware
               providerOptions: {
                 toolCallMiddleware: {

--- a/packages/eval/src/benchmarks/bfcl.ts
+++ b/packages/eval/src/benchmarks/bfcl.ts
@@ -203,10 +203,8 @@ function createBfclBenchmark(
         ): Promise<{ valid: boolean; logs: string[] }> => {
           const caseLogs: string[] = [];
           const { function: tools, question: messages } = testCase;
-          const temperature =
-            typeof (config?.temperature as unknown) === "number"
-              ? (config?.temperature as number)
-              : undefined;
+          const temp = config?.temperature;
+          const temperature = typeof temp === "number" ? temp : undefined;
 
           try {
             // Flatten BFCL message shape [[{role, content}], ...] to [{role, content}, ...]

--- a/packages/eval/src/benchmarks/json-generation.ts
+++ b/packages/eval/src/benchmarks/json-generation.ts
@@ -169,10 +169,8 @@ export const jsonGenerationBenchmark: LanguageModelV2Benchmark = {
           },
         ];
 
-        const temperature =
-          typeof (config?.temperature as unknown) === "number"
-            ? (config?.temperature as number)
-            : undefined;
+        const temp = config?.temperature;
+        const temperature = typeof temp === "number" ? temp : undefined;
         const { text } = await generateText({
           model,
           messages,
@@ -310,10 +308,8 @@ export const jsonGenerationSchemaOnlyBenchmark: LanguageModelV2Benchmark = {
           },
         ];
 
-        const temperature =
-          typeof (config?.temperature as unknown) === "number"
-            ? (config?.temperature as number)
-            : undefined;
+        const temp = config?.temperature;
+        const temperature = typeof temp === "number" ? temp : undefined;
         const { text } = await generateText({
           model,
           messages,

--- a/packages/eval/src/benchmarks/json-generation.ts
+++ b/packages/eval/src/benchmarks/json-generation.ts
@@ -102,7 +102,10 @@ export const jsonGenerationBenchmark: LanguageModelV2Benchmark = {
   description:
     "Evaluates schema-compliant JSON generation from natural language using JSON Schema prompts.",
 
-  async run(model: LanguageModel): Promise<BenchmarkResult> {
+  async run(
+    model: LanguageModel,
+    config?: Record<string, unknown>
+  ): Promise<BenchmarkResult> {
     const logs: string[] = [];
     const ajv = new Ajv({ allErrors: true, strict: false });
 
@@ -166,7 +169,15 @@ export const jsonGenerationBenchmark: LanguageModelV2Benchmark = {
           },
         ];
 
-        const { text } = await generateText({ model, messages });
+        const temperature =
+          typeof (config?.temperature as unknown) === "number"
+            ? (config?.temperature as number)
+            : undefined;
+        const { text } = await generateText({
+          model,
+          messages,
+          ...(temperature !== undefined ? { temperature } : {}),
+        });
 
         let parsed: Json | undefined;
         try {
@@ -245,7 +256,10 @@ export const jsonGenerationSchemaOnlyBenchmark: LanguageModelV2Benchmark = {
   description:
     "Evaluates whether model outputs strictly conform to the provided JSON Schema (structure only).",
 
-  async run(model: LanguageModel): Promise<BenchmarkResult> {
+  async run(
+    model: LanguageModel,
+    config?: Record<string, unknown>
+  ): Promise<BenchmarkResult> {
     const logs: string[] = [];
     const ajv = new Ajv({ allErrors: true, strict: false });
 
@@ -296,7 +310,15 @@ export const jsonGenerationSchemaOnlyBenchmark: LanguageModelV2Benchmark = {
           },
         ];
 
-        const { text } = await generateText({ model, messages });
+        const temperature =
+          typeof (config?.temperature as unknown) === "number"
+            ? (config?.temperature as number)
+            : undefined;
+        const { text } = await generateText({
+          model,
+          messages,
+          ...(temperature !== undefined ? { temperature } : {}),
+        });
 
         let parsed: Json | undefined;
         try {

--- a/packages/eval/src/evaluate.ts
+++ b/packages/eval/src/evaluate.ts
@@ -86,7 +86,7 @@ export async function evaluate(
           async run(m, _config) {
             return benchmark.run(m, { temperature });
           },
-        } as typeof benchmark,
+        } as LanguageModelV2Benchmark,
         modelKey
       );
       allResults.push(evaluationResult);

--- a/packages/eval/src/evaluate.ts
+++ b/packages/eval/src/evaluate.ts
@@ -56,7 +56,7 @@ async function runSingleBenchmark(
 export async function evaluate(
   options: EvaluateOptions
 ): Promise<EvaluationResult[]> {
-  const { models, benchmarks, reporter = "console" } = options;
+  const { models, benchmarks, reporter = "console", temperature } = options;
 
   const modelEntries: Array<[string | undefined, LanguageModel]> = [];
   if (Array.isArray(models)) {
@@ -80,7 +80,13 @@ export async function evaluate(
     for (const benchmark of benchmarks) {
       const evaluationResult = await runSingleBenchmark(
         model,
-        benchmark,
+        // Wrap the benchmark to pass optional config including temperature
+        {
+          ...benchmark,
+          async run(m, _config) {
+            return benchmark.run(m, { temperature });
+          },
+        } as typeof benchmark,
         modelKey
       );
       allResults.push(evaluationResult);

--- a/packages/eval/src/evaluate.ts
+++ b/packages/eval/src/evaluate.ts
@@ -10,7 +10,8 @@ import { reporters } from "./reporters";
 async function runSingleBenchmark(
   model: LanguageModel,
   benchmark: LanguageModelV2Benchmark,
-  modelKey?: string
+  modelKey?: string,
+  config?: Record<string, unknown>
 ): Promise<EvaluationResult> {
   const modelId =
     typeof model === "object" &&
@@ -24,7 +25,7 @@ async function runSingleBenchmark(
     console.log(
       `[${modelId}]${modelKey ? ` (${modelKey})` : ""} Running benchmark: ${benchmark.name}...`
     );
-    const result = await benchmark.run(model);
+    const result = await benchmark.run(model, config);
     console.log(
       `[${modelId}]${modelKey ? ` (${modelKey})` : ""} Finished benchmark: ${benchmark.name}. Score: ${result.score}`
     );
@@ -80,14 +81,9 @@ export async function evaluate(
     for (const benchmark of benchmarks) {
       const evaluationResult = await runSingleBenchmark(
         model,
-        // Wrap the benchmark to pass optional config including temperature
-        {
-          ...benchmark,
-          async run(m, _config) {
-            return benchmark.run(m, { temperature });
-          },
-        } as LanguageModelV2Benchmark,
-        modelKey
+        benchmark,
+        modelKey,
+        temperature !== undefined ? { temperature } : undefined
       );
       allResults.push(evaluationResult);
     }

--- a/packages/eval/src/interfaces.ts
+++ b/packages/eval/src/interfaces.ts
@@ -100,4 +100,9 @@ export interface EvaluateOptions {
    * Defaults to 'console'.
    */
   reporter?: ReporterType;
+
+  /**
+   * Optional temperature setting to pass to model generation during evaluation.
+   */
+  temperature?: number;
 }

--- a/packages/parser/src/protocols/morph-xml-protocol.ts
+++ b/packages/parser/src/protocols/morph-xml-protocol.ts
@@ -48,7 +48,7 @@ function extractRawInner(
 ): string | undefined {
   // Extract inner text of the first matching tag without parsing, preserving nested markup
   const tag = escapeRegExp(tagName);
-  const regex = new RegExp(String.raw`<${tag}>([\s\S]*?)<\/${tag}>`);
+  const regex = new RegExp(String.raw`<${tag}[^>]*>([\s\S]*?)<\/${tag}>`);
   const m = regex.exec(xmlContent);
   return m ? m[1] : undefined;
 }
@@ -187,15 +187,12 @@ export function processParsedArgs(
       }
       // Check if all keys are numeric indices (0, 1, 2, ...) and consecutive
       else {
-        const isIndexedTuple =
-          keys.length > 0 &&
-          keys.every(key => /^\d+$/.test(key)) &&
-          (() => {
-            const indices = keys
-              .map(k => parseInt(k, 10))
-              .sort((a, b) => a - b);
-            return indices[0] === 0 && indices.every((val, idx) => val === idx);
-          })();
+        let isIndexedTuple = false;
+        if (keys.length > 0 && keys.every(key => /^\d+$/.test(key))) {
+          const indices = keys.map(k => parseInt(k, 10)).sort((a, b) => a - b);
+          isIndexedTuple =
+            indices[0] === 0 && indices.every((val, idx) => val === idx);
+        }
 
         if (isIndexedTuple) {
           // Convert indexed object to array (tuple)

--- a/packages/parser/src/protocols/morph-xml-protocol.ts
+++ b/packages/parser/src/protocols/morph-xml-protocol.ts
@@ -11,6 +11,9 @@ import { coerceBySchema, unwrapJsonSchema } from "@/utils/coercion";
 
 import { ToolCallProtocol } from "./tool-call-protocol";
 
+// Controls whether the parser emits warnings when duplicate string tags are detected
+const WARN_ON_DUPLICATE_STRING_TAGS: boolean = true;
+
 // Helper to get unwrapped schema type string
 function getSchemaTypeString(schema: unknown): string | undefined {
   const s = unwrapJsonSchema(schema);
@@ -107,7 +110,6 @@ export const morphXmlProtocol = (): ToolCallProtocol => ({
   },
 
   parseGeneratedText({ text, tools, options }) {
-    const warnOnDuplicate: boolean = true;
     // Get original schemas from provider options if available
     const originalSchemas =
       (options as { originalToolSchemas?: Record<string, unknown> } | undefined)
@@ -202,7 +204,7 @@ export const morphXmlProtocol = (): ToolCallProtocol => ({
                 })
                 .filter(x => typeof x === "string");
 
-              if (mapped.length > 1 && warnOnDuplicate) {
+              if (mapped.length > 1 && WARN_ON_DUPLICATE_STRING_TAGS) {
                 options?.onError?.(
                   `Duplicate string tags for <${k}> detected; cancelling tool call`,
                   {
@@ -388,7 +390,6 @@ export const morphXmlProtocol = (): ToolCallProtocol => ({
   },
 
   createStreamParser({ tools, options }) {
-    const warnOnDuplicate: boolean = true;
     // Get original schemas from options if available
     const originalSchemas =
       (options as { originalToolSchemas?: Record<string, unknown> } | undefined)
@@ -509,7 +510,7 @@ export const morphXmlProtocol = (): ToolCallProtocol => ({
                         })
                         .filter(x => typeof x === "string");
 
-                      if (mapped.length > 1 && warnOnDuplicate) {
+                      if (mapped.length > 1 && WARN_ON_DUPLICATE_STRING_TAGS) {
                         options?.onError?.(
                           `Duplicate string tags for <${k}> detected; cancelling tool call`,
                           {

--- a/packages/parser/src/protocols/morph-xml-protocol.ts
+++ b/packages/parser/src/protocols/morph-xml-protocol.ts
@@ -42,10 +42,13 @@ function getPropertySchema(toolSchema: unknown, key: string): unknown {
   return undefined;
 }
 
-function extractRawInner(
+export function extractRawInner(
   xmlContent: string,
   tagName: string
 ): string | undefined {
+  // XML Name parsing helpers (simplified per XML 1.0)
+  const isNameStartChar = (ch: string): boolean => /[A-Za-z_:]/.test(ch);
+  const isNameChar = (ch: string): boolean => /[A-Za-z0-9_.:-]/.test(ch);
   // Extract the raw inner content of the FIRST TOP-LEVEL occurrence of <tagName ...>...</tagName>
   // within xmlContent (which is expected to be the inside of the tool element).
   // This preserves raw markup and avoids accidentally matching nested same-named tags inside other fields.
@@ -110,7 +113,10 @@ function extractRawInner(
       // end tag
       // read name
       let j = i + 1;
-      while (j < len && /[-A-Za-z0-9_:\\]/.test(xmlContent[j])) j++;
+      if (j < len && isNameStartChar(xmlContent[j])) {
+        j++;
+        while (j < len && isNameChar(xmlContent[j])) j++;
+      }
       // move to '>'
       const gt = xmlContent.indexOf(">", j);
       i = gt === -1 ? len : gt + 1;
@@ -119,7 +125,10 @@ function extractRawInner(
     } else {
       // start tag
       let j = i;
-      while (j < len && /[-A-Za-z0-9_:\\]/.test(xmlContent[j])) j++;
+      if (j < len && isNameStartChar(xmlContent[j])) {
+        j++;
+        while (j < len && isNameChar(xmlContent[j])) j++;
+      }
       const name = xmlContent.slice(i, j);
 
       // skip attributes to '>' while respecting quotes
@@ -187,7 +196,10 @@ function extractRawInner(
             } else if (h === "/") {
               // end tag
               let t = nx + 1;
-              while (t < len && /[-A-Za-z0-9_:\\]/.test(xmlContent[t])) t++;
+              if (t < len && isNameStartChar(xmlContent[t])) {
+                t++;
+                while (t < len && isNameChar(xmlContent[t])) t++;
+              }
               const endName = xmlContent.slice(nx + 1, t);
               const gt2 = xmlContent.indexOf(">", t);
               if (endName === target) {
@@ -209,7 +221,10 @@ function extractRawInner(
             } else {
               // start tag
               let t = nx;
-              while (t < len && /[-A-Za-z0-9_:\\]/.test(xmlContent[t])) t++;
+              if (t < len && isNameStartChar(xmlContent[t])) {
+                t++;
+                while (t < len && isNameChar(xmlContent[t])) t++;
+              }
               const startName = xmlContent.slice(nx, t);
               // skip attributes
               let u = t;
@@ -250,10 +265,12 @@ function extractRawInner(
   return undefined;
 }
 
-function findFirstTopLevelRange(
+export function findFirstTopLevelRange(
   xmlContent: string,
   tagName: string
 ): { start: number; end: number } | undefined {
+  const isNameStartChar = (ch: string): boolean => /[A-Za-z_:]/.test(ch);
+  const isNameChar = (ch: string): boolean => /[A-Za-z0-9_.:-]/.test(ch);
   const len = xmlContent.length;
   const target = tagName;
 
@@ -305,7 +322,10 @@ function findFirstTopLevelRange(
       continue;
     } else {
       let j = i;
-      while (j < len && /[A-Za-z0-9_:\\-]/.test(xmlContent[j])) j++;
+      if (j < len && isNameStartChar(xmlContent[j])) {
+        j++;
+        while (j < len && isNameChar(xmlContent[j])) j++;
+      }
       const name = xmlContent.slice(i, j);
       let k = j;
       let isSelfClosing = false;
@@ -357,7 +377,10 @@ function findFirstTopLevelRange(
             continue;
           } else if (h === "/") {
             let t = nx + 1;
-            while (t < len && /[A-Za-z0-9_:\\-]/.test(xmlContent[t])) t++;
+            if (t < len && isNameStartChar(xmlContent[t])) {
+              t++;
+              while (t < len && isNameChar(xmlContent[t])) t++;
+            }
             const endName = xmlContent.slice(nx + 1, t);
             const gt2 = xmlContent.indexOf(">", t);
             if (endName === target) {
@@ -370,7 +393,10 @@ function findFirstTopLevelRange(
             continue;
           } else {
             let t = nx;
-            while (t < len && /[A-Za-z0-9_:\\-]/.test(xmlContent[t])) t++;
+            if (t < len && isNameStartChar(xmlContent[t])) {
+              t++;
+              while (t < len && isNameChar(xmlContent[t])) t++;
+            }
             // skip attributes
             let u = t;
             let selfClose = false;
@@ -405,12 +431,14 @@ function findFirstTopLevelRange(
   return undefined;
 }
 
-function countTagOccurrences(
+export function countTagOccurrences(
   xmlContent: string,
   tagName: string,
   excludeRanges?: Array<{ start: number; end: number }>,
   skipFirst: boolean = true
 ): number {
+  const isNameStartChar = (ch: string): boolean => /[A-Za-z_:]/.test(ch);
+  const isNameChar = (ch: string): boolean => /[A-Za-z0-9_.:-]/.test(ch);
   const len = xmlContent.length;
   const target = tagName;
 
@@ -468,7 +496,10 @@ function countTagOccurrences(
       continue;
     } else {
       let j = i;
-      while (j < len && /[-A-Za-z0-9_:\\]/.test(xmlContent[j])) j++;
+      if (j < len && isNameStartChar(xmlContent[j])) {
+        j++;
+        while (j < len && isNameChar(xmlContent[j])) j++;
+      }
       const name = xmlContent.slice(i, j);
       let k = j;
       while (k < len) {

--- a/packages/parser/src/protocols/morph-xml-protocol.ts
+++ b/packages/parser/src/protocols/morph-xml-protocol.ts
@@ -186,23 +186,19 @@ export const morphXmlProtocol = (): ToolCallProtocol => ({
           // Heuristic array parsing for multiple tags with same name
           if (Array.isArray(v)) {
             if (propType === "string") {
-              const mapped = v
-                .map(item => {
-                  if (
-                    item &&
-                    typeof item === "object" &&
-                    Object.prototype.hasOwnProperty.call(item, "#text")
-                  ) {
-                    const textVal = (item as Record<string, unknown>)?.[
-                      "#text"
-                    ];
-                    return typeof textVal === "string"
-                      ? textVal
-                      : String(textVal);
-                  }
-                  return typeof item === "string" ? item : String(item);
-                })
-                .filter(x => typeof x === "string");
+              const mapped = v.map(item => {
+                if (
+                  item &&
+                  typeof item === "object" &&
+                  Object.prototype.hasOwnProperty.call(item, "#text")
+                ) {
+                  const textVal = (item as Record<string, unknown>)?.["#text"];
+                  return typeof textVal === "string"
+                    ? textVal
+                    : String(textVal);
+                }
+                return typeof item === "string" ? item : String(item);
+              });
 
               if (mapped.length > 1 && WARN_ON_DUPLICATE_STRING_TAGS) {
                 options?.onError?.(
@@ -493,23 +489,21 @@ export const morphXmlProtocol = (): ToolCallProtocol => ({
                   // Heuristic array parsing for multiple tags with same name
                   if (Array.isArray(v)) {
                     if (propType === "string") {
-                      const mapped = v
-                        .map(item => {
-                          if (
-                            item &&
-                            typeof item === "object" &&
-                            Object.prototype.hasOwnProperty.call(item, "#text")
-                          ) {
-                            const textVal = (item as Record<string, unknown>)?.[
-                              "#text"
-                            ];
-                            return typeof textVal === "string"
-                              ? textVal
-                              : String(textVal);
-                          }
-                          return typeof item === "string" ? item : String(item);
-                        })
-                        .filter(x => typeof x === "string");
+                      const mapped = v.map(item => {
+                        if (
+                          item &&
+                          typeof item === "object" &&
+                          Object.prototype.hasOwnProperty.call(item, "#text")
+                        ) {
+                          const textVal = (item as Record<string, unknown>)?.[
+                            "#text"
+                          ];
+                          return typeof textVal === "string"
+                            ? textVal
+                            : String(textVal);
+                        }
+                        return typeof item === "string" ? item : String(item);
+                      });
 
                       if (mapped.length > 1 && WARN_ON_DUPLICATE_STRING_TAGS) {
                         options?.onError?.(

--- a/packages/parser/src/protocols/morph-xml-protocol.ts
+++ b/packages/parser/src/protocols/morph-xml-protocol.ts
@@ -218,7 +218,8 @@ export const morphXmlProtocol = (): ToolCallProtocol => ({
                 cancelToolCall = true;
                 break;
               } else {
-                val = mapped[0] ?? "";
+                args[k] = mapped[0] ?? "";
+                continue;
               }
             } else {
               val = v.map(item => {
@@ -524,7 +525,8 @@ export const morphXmlProtocol = (): ToolCallProtocol => ({
                         cancelToolCall = true;
                         break;
                       } else {
-                        val = mapped[0] ?? "";
+                        args[k] = mapped[0] ?? "";
+                        continue;
                       }
                     } else {
                       val = v.map(item => {

--- a/packages/parser/src/protocols/morph-xml-protocol.ts
+++ b/packages/parser/src/protocols/morph-xml-protocol.ts
@@ -191,13 +191,17 @@ export function processParsedArgs(
           keys.length > 0 &&
           keys.every(key => /^\d+$/.test(key)) &&
           (() => {
-            const indices = keys.map(k => parseInt(k)).sort((a, b) => a - b);
+            const indices = keys
+              .map(k => parseInt(k, 10))
+              .sort((a, b) => a - b);
             return indices[0] === 0 && indices.every((val, idx) => val === idx);
           })();
 
         if (isIndexedTuple) {
           // Convert indexed object to array (tuple)
-          const sortedKeys = keys.sort((a, b) => parseInt(a) - parseInt(b));
+          const sortedKeys = keys.sort(
+            (a, b) => parseInt(a, 10) - parseInt(b, 10)
+          );
           val = sortedKeys.map(key => {
             const item = obj[key];
             if (

--- a/packages/parser/tests/protocols/xml-protocol.helpers.test.ts
+++ b/packages/parser/tests/protocols/xml-protocol.helpers.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  countTagOccurrences,
+  extractRawInner,
+  findFirstTopLevelRange,
+} from "@/protocols/morph-xml-protocol";
+
+describe("XML helper utilities", () => {
+  describe("extractRawInner", () => {
+    it("returns inner text for simple tag", () => {
+      const xml = `<content>Hello</content>`;
+      expect(extractRawInner(xml, "content")).toBe("Hello");
+    });
+
+    it("returns empty string for self-closing tag", () => {
+      const xml = `<content/>`;
+      expect(extractRawInner(xml, "content")).toBe("");
+    });
+
+    it("prefers the shallowest top-level occurrence when nested and sibling both exist", () => {
+      const xml = `<outer><content>nested</content></outer><content>top</content>`;
+      expect(extractRawInner(xml, "content")).toBe("top");
+    });
+
+    it("handles attributes including quotes and '>' and preserves only inner raw content", () => {
+      const inner = `Some <b>text</b>`;
+      const xml = `<content data="a > b" note="it's ok">${inner}</content>`;
+      expect(extractRawInner(xml, "content")).toBe(inner);
+    });
+
+    it("preserves CDATA and ignores comments/PI around it", () => {
+      const inner = `<![CDATA[<encoding>not-sibling</encoding>]]>`;
+      const xml = `<!-- lead --?><content>${inner}</content><?pi done?>`;
+      expect(extractRawInner(xml, "content")).toBe(inner);
+    });
+
+    it("handles nested same-named tags by returning the content up to the matching close at same depth", () => {
+      const xml = `<content>a<content>b</content>c</content>`;
+      expect(extractRawInner(xml, "content")).toBe("a<content>b</content>c");
+    });
+  });
+
+  describe("findFirstTopLevelRange", () => {
+    it("returns start/end for simple tag and slices to inner", () => {
+      const inner = "Hello";
+      const xml = `<content>${inner}</content>`;
+      const r = findFirstTopLevelRange(xml, "content");
+      expect(r).toBeDefined();
+      expect(xml.slice(r!.start, r!.end)).toBe(inner);
+    });
+
+    it("returns empty range for self-closing tag", () => {
+      const xml = `<content/>`;
+      const r = findFirstTopLevelRange(xml, "content");
+      expect(r).toBeDefined();
+      expect(r!.start).toBe(r!.end);
+      expect(xml.slice(r!.start, r!.end)).toBe("");
+    });
+
+    it("ignores nested occurrence and selects top-level sibling occurrence", () => {
+      const xml = `<outer><content>nested</content></outer><content>top</content>`;
+      const r = findFirstTopLevelRange(xml, "content");
+      expect(r).toBeDefined();
+      expect(xml.slice(r!.start, r!.end)).toBe("top");
+    });
+
+    it("handles attributes with quotes and '>'", () => {
+      const inner = `X`;
+      const xml = `<content data=">" note='a > b'>${inner}</content>`;
+      const r = findFirstTopLevelRange(xml, "content");
+      expect(r).toBeDefined();
+      expect(xml.slice(r!.start, r!.end)).toBe(inner);
+    });
+
+    it("skips comments, CDATA, and processing instructions while searching", () => {
+      const inner = `Y`;
+      const xml = `<!-- c --><![CDATA[ z ]]><?pi?> <content>${inner}</content>`;
+      const r = findFirstTopLevelRange(xml, "content");
+      expect(r).toBeDefined();
+      expect(xml.slice(r!.start, r!.end)).toBe(inner);
+    });
+  });
+
+  describe("countTagOccurrences", () => {
+    it("counts additional occurrences after the first (default skipFirst=true)", () => {
+      const xml = `<content>a</content><content>b</content><content/>`;
+      // First occurrence is skipped, so we count the remaining 2
+      expect(countTagOccurrences(xml, "content")).toBe(2);
+    });
+
+    it("counts all occurrences when skipFirst=false", () => {
+      const xml = `<content>a</content><content>b</content><content/>`;
+      expect(countTagOccurrences(xml, "content", undefined, false)).toBe(3);
+    });
+
+    it("excludes ranges, ignoring nested occurrence inside excluded sibling", () => {
+      const xml = `<other><content>nested</content></other><content>one</content><content>two</content>`;
+      const other = findFirstTopLevelRange(xml, "other");
+      const excluded = other ? [other] : [];
+      // With exclusion, the first non-excluded occurrence is <content>one</content> which gets skipped, so only "two" remains
+      expect(countTagOccurrences(xml, "content", excluded, true)).toBe(1);
+      // Without exclusion, first occurrence is the nested one; skip it, count both top-level ones
+      expect(countTagOccurrences(xml, "content", undefined, true)).toBe(2);
+    });
+
+    it("ignores occurrences inside comments and CDATA", () => {
+      const xml = `<!-- <content>x</content> --><![CDATA[ <content>y</content> ]]><content>z</content>`;
+      // skipFirst=true: the only counted after skipping the first (which is the top-level one) would be 0
+      expect(countTagOccurrences(xml, "content", undefined, true)).toBe(0);
+      // skipFirst=false: count only the real element occurrence
+      expect(countTagOccurrences(xml, "content", undefined, false)).toBe(1);
+    });
+
+    it("handles attributes with quotes and angle brackets in values", () => {
+      const xml = `<content data=">" note='a > b'>x</content><content data="<tag>">y</content>`;
+      // skipFirst=true: only the second occurrence should be counted
+      expect(countTagOccurrences(xml, "content", undefined, true)).toBe(1);
+      // skipFirst=false: both should be counted
+      expect(countTagOccurrences(xml, "content", undefined, false)).toBe(2);
+    });
+  });
+});

--- a/packages/parser/tests/protocols/xml-protocol.process-args.test.ts
+++ b/packages/parser/tests/protocols/xml-protocol.process-args.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { processParsedArgs } from "@/protocols/morph-xml-protocol";
+
+describe("processParsedArgs unit tests", () => {
+  it("preserves raw inner content for string-typed scalar (including whitespace and nested tags)", () => {
+    const toolSchema = {
+      type: "object",
+      properties: { content: { type: "string" } },
+    } as const;
+    const inner = `\n  <b>Bold</b> and  <i>italic</i>  \n`;
+    const toolContent = `<write_text><content>${inner}</content></write_text>`;
+    const parsedArgs = { content: { "#text": "IGNORED" } } as Record<
+      string,
+      unknown
+    >;
+
+    const { args, cancelToolCall } = processParsedArgs(
+      parsedArgs,
+      toolSchema,
+      toolContent,
+      "write_text"
+    );
+    expect(cancelToolCall).toBe(false);
+    expect(args.content).toBe(inner);
+  });
+
+  it("cancels and calls onError when duplicate string-typed scalar tags are present", () => {
+    const toolSchema = {
+      type: "object",
+      properties: { content: { type: "string" } },
+    } as const;
+    const toolContent =
+      `<write_text>` +
+      `<content>A</content>` +
+      `<content>B</content>` +
+      `</write_text>`;
+    const parsedArgs = { content: ["A", "B"] } as Record<string, unknown>;
+    const onError = vi.fn();
+
+    const { cancelToolCall } = processParsedArgs(
+      parsedArgs,
+      toolSchema,
+      toolContent,
+      "write_text",
+      { onError }
+    );
+    expect(cancelToolCall).toBe(true);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("trims string items in arrays when schema expects array of strings (multiple same-named tags)", () => {
+    const toolSchema = {
+      type: "object",
+      properties: { values: { type: "array", items: { type: "string" } } },
+    } as const;
+    const toolContent = `<format_list><values></values></format_list>`;
+    const parsedArgs = { values: ["  a  ", "b  c"] } as Record<string, unknown>;
+
+    const { args, cancelToolCall } = processParsedArgs(
+      parsedArgs,
+      toolSchema,
+      toolContent,
+      "format_list"
+    );
+    expect(cancelToolCall).toBe(false);
+    expect(args.values).toEqual(["a", "b  c"]);
+  });
+
+  it("coerces numeric-like strings inside item arrays to numbers (including scientific notation)", () => {
+    const toolSchema = {
+      type: "object",
+      properties: { data: { type: "array", items: { type: "number" } } },
+    } as const;
+    const toolContent = `<nums><data></data></nums>`;
+    const parsedArgs = {
+      data: { item: ["1", "2.5", "1.23e3", "-4.56E-2"] },
+    } as Record<string, unknown>;
+
+    const { args, cancelToolCall } = processParsedArgs(
+      parsedArgs,
+      toolSchema,
+      toolContent,
+      "nums"
+    );
+    expect(cancelToolCall).toBe(false);
+    expect(args.data).toEqual([1, 2.5, 1230, -0.0456]);
+  });
+
+  it("coerces numeric-like #text objects inside item arrays to numbers", () => {
+    const toolSchema = {
+      type: "object",
+      properties: { data: { type: "array", items: { type: "number" } } },
+    } as const;
+    const toolContent = `<nums><data></data></nums>`;
+    const parsedArgs = {
+      data: {
+        item: [{ "#text": " 10.5 " }, { "#text": "3" }, { "#text": "1e2" }],
+      },
+    } as Record<string, unknown>;
+
+    const { args, cancelToolCall } = processParsedArgs(
+      parsedArgs,
+      toolSchema,
+      toolContent,
+      "nums"
+    );
+    expect(cancelToolCall).toBe(false);
+    expect(args.data).toEqual([10.5, 3, 100]);
+  });
+
+  it("converts consecutive numeric-keyed objects to arrays (tuple heuristic) without number coercion", () => {
+    const toolSchema = {
+      type: "object",
+      properties: { coords: { type: "array", items: { type: "number" } } },
+    } as const;
+    const toolContent = `<tuple><coords></coords></tuple>`;
+    const parsedArgs = {
+      coords: { "0": "10", "1": "20", "2": "30" },
+    } as Record<string, unknown>;
+
+    const { args, cancelToolCall } = processParsedArgs(
+      parsedArgs,
+      toolSchema,
+      toolContent,
+      "tuple"
+    );
+    expect(cancelToolCall).toBe(false);
+    // tuple path trims but does not coerce to numbers
+    expect(args.coords).toEqual(["10", "20", "30"]);
+  });
+
+  it("does not convert non-consecutive numeric-keyed objects (keeps object)", () => {
+    const toolSchema = {
+      type: "object",
+      properties: { values: { type: "object" } },
+    } as const;
+    const toolContent = `<nonconsecutive></nonconsecutive>`;
+    const parsedArgs = { values: { "0": "x", "2": "y" } } as Record<
+      string,
+      unknown
+    >;
+
+    const { args, cancelToolCall } = processParsedArgs(
+      parsedArgs,
+      toolSchema,
+      toolContent,
+      "nonconsecutive"
+    );
+    expect(cancelToolCall).toBe(false);
+    expect(args.values).toEqual({ "0": "x", "2": "y" });
+  });
+
+  it("keeps nested object structure when no #text and no array/tuple heuristics apply", () => {
+    const toolSchema = {
+      type: "object",
+      properties: { settings: { type: "object" } },
+    } as const;
+    const toolContent = `<config></config>`;
+    const parsedArgs = {
+      settings: { theme: { dark: "true" } },
+    } as Record<string, unknown>;
+
+    const { args, cancelToolCall } = processParsedArgs(
+      parsedArgs,
+      toolSchema,
+      toolContent,
+      "config"
+    );
+    expect(cancelToolCall).toBe(false);
+    expect(typeof args.settings).toBe("object");
+    expect((args.settings as any).theme.dark).toBe("true");
+  });
+
+  it("maps arrays of objects with #text to trimmed values when prop is not string-typed", () => {
+    const toolSchema = {
+      type: "object",
+      properties: { labels: { type: "array", items: { type: "string" } } },
+    } as const;
+    const toolContent = `<tags></tags>`;
+    const parsedArgs = {
+      labels: [{ "#text": "  a  " }, { "#text": "b" }],
+    } as Record<string, unknown>;
+
+    const { args, cancelToolCall } = processParsedArgs(
+      parsedArgs,
+      toolSchema,
+      toolContent,
+      "tags"
+    );
+    expect(cancelToolCall).toBe(false);
+    expect(args.labels).toEqual(["a", "b"]);
+  });
+});

--- a/packages/parser/tests/protocols/xml-protocol.raw-string.stream.test.ts
+++ b/packages/parser/tests/protocols/xml-protocol.raw-string.stream.test.ts
@@ -20,6 +20,7 @@ async function collect(stream: ReadableStream<LanguageModelV2StreamPart>) {
 
 describe("morphXmlProtocol raw string handling in streaming", () => {
   it("captures raw inner XML for string-typed arg during streaming", async () => {
+    const CHUNK_SIZE = 7;
     const protocol = morphXmlProtocol();
     const tools: LanguageModelV2FunctionTool[] = [
       {
@@ -53,11 +54,11 @@ describe("morphXmlProtocol raw string handling in streaming", () => {
         ];
         // emit in small chunks to simulate streaming
         for (const p of parts) {
-          for (let i = 0; i < p.length; i += 7) {
+          for (let i = 0; i < p.length; i += CHUNK_SIZE) {
             ctrl.enqueue({
               type: "text-delta",
               id: "t",
-              delta: p.slice(i, i + 7),
+              delta: p.slice(i, i + CHUNK_SIZE),
             });
           }
         }

--- a/packages/parser/tests/protocols/xml-protocol.raw-string.stream.test.ts
+++ b/packages/parser/tests/protocols/xml-protocol.raw-string.stream.test.ts
@@ -1,0 +1,82 @@
+import type {
+  LanguageModelV2FunctionTool,
+  LanguageModelV2StreamPart,
+} from "@ai-sdk/provider";
+import { describe, expect, it } from "vitest";
+
+import { morphXmlProtocol } from "@/protocols/morph-xml-protocol";
+
+async function collect(stream: ReadableStream<LanguageModelV2StreamPart>) {
+  const out: LanguageModelV2StreamPart[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    out.push(value);
+  }
+  reader.releaseLock();
+  return out;
+}
+
+describe("morphXmlProtocol raw string handling in streaming", () => {
+  it("captures raw inner XML for string-typed arg during streaming", async () => {
+    const protocol = morphXmlProtocol();
+    const tools: LanguageModelV2FunctionTool[] = [
+      {
+        type: "function",
+        name: "write_file",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+            encoding: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      },
+    ];
+
+    const transformer = protocol.createStreamParser({ tools });
+    const html = `<html><body><h1>Hi</h1><p>World</p></body></html>`;
+    const rs = new ReadableStream<LanguageModelV2StreamPart>({
+      start(ctrl) {
+        const parts = [
+          `<write_file>`,
+          `<file_path>/home/username/myfile.html</file_path>`,
+          `<content>`,
+          html,
+          `</content>`,
+          `<encoding>utf-8</encoding>`,
+          `</write_file>`,
+        ];
+        // emit in small chunks to simulate streaming
+        for (const p of parts) {
+          for (let i = 0; i < p.length; i += 7) {
+            ctrl.enqueue({
+              type: "text-delta",
+              id: "t",
+              delta: p.slice(i, i + 7),
+            });
+          }
+        }
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await collect(rs.pipeThrough(transformer));
+
+    const tool = out.find(p => p.type === "tool-call") as any;
+    expect(tool?.toolName).toBe("write_file");
+    const args = JSON.parse(tool.input);
+    expect(args.file_path).toBe("/home/username/myfile.html");
+    expect(args.content).toBe(html);
+    expect(args.encoding).toBe("utf-8");
+  });
+});

--- a/packages/parser/tests/protocols/xml-protocol.raw-string.stream.test.ts
+++ b/packages/parser/tests/protocols/xml-protocol.raw-string.stream.test.ts
@@ -80,4 +80,62 @@ describe("morphXmlProtocol raw string handling in streaming", () => {
     expect(args.content).toBe(html);
     expect(args.encoding).toBe("utf-8");
   });
+
+  it("error policy cancels the tool call and emits original text in streaming", async () => {
+    const CHUNK_SIZE = 5;
+    const protocol = morphXmlProtocol();
+    const tools: LanguageModelV2FunctionTool[] = [
+      {
+        type: "function",
+        name: "write_file",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      },
+    ];
+    const transformer = protocol.createStreamParser({ tools });
+    const rs = new ReadableStream<LanguageModelV2StreamPart>({
+      start(ctrl) {
+        const parts = [
+          `<write_file>`,
+          `<file_path>/tmp/file.txt</file_path>`,
+          `<content>part1</content>`,
+          `<content>part2</content>`,
+          `</write_file>`,
+        ];
+        for (const p of parts) {
+          for (let i = 0; i < p.length; i += CHUNK_SIZE) {
+            ctrl.enqueue({
+              type: "text-delta",
+              id: "t",
+              delta: p.slice(i, i + CHUNK_SIZE),
+            });
+          }
+        }
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: "stop",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        });
+        ctrl.close();
+      },
+    });
+    const out = await collect(rs.pipeThrough(transformer));
+    // Entire tool call is cancelled and returned as text stream
+    const textParts = out.filter(p => p.type === "text-delta") as any[];
+    const combined = textParts.map(p => p.delta).join("");
+    expect(combined).toContain("<write_file>");
+    expect(combined).toContain(
+      "<content>part1</content><content>part2</content>"
+    );
+    expect(combined).toContain("</write_file>");
+    const hasToolCall = out.some(p => p.type === "tool-call");
+    expect(hasToolCall).toBe(false);
+  });
 });

--- a/packages/parser/tests/protocols/xml-protocol.raw-string.test.ts
+++ b/packages/parser/tests/protocols/xml-protocol.raw-string.test.ts
@@ -79,4 +79,308 @@ describe("morphXmlProtocol raw string handling by schema", () => {
     const only = out.find(isText);
     expect(only?.text).toBe(text);
   });
+
+  it("supports attributes on string-typed tag and preserves only inner raw content (no sibling bleed)", () => {
+    const protocol = morphXmlProtocol();
+    const tools: LanguageModelV2FunctionTool[] = [
+      {
+        type: "function",
+        name: "write_file",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+            encoding: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      },
+    ];
+
+    const htmlInner = `<div><h1>Title</h1><p>Para</p><em>italic</em></div>`;
+    const text =
+      `<write_file>` +
+      `<file_path>/home/u/file.html</file_path>` +
+      // Attribute on the string-typed tag
+      `<content type="html">${htmlInner}</content>` +
+      `<encoding>utf-8</encoding>` +
+      `</write_file>`;
+
+    const out = protocol.parseGeneratedText({ text, tools, options: {} });
+    const tc = out.find(isToolCallContent);
+    expect(tc?.toolName).toBe("write_file");
+    const args =
+      typeof tc?.input === "string" ? JSON.parse(tc.input) : tc?.input;
+    // Raw inner content preserved exactly
+    expect(args.content).toBe(htmlInner);
+    // Sibling fields parsed as usual
+    expect(args.file_path).toBe("/home/u/file.html");
+    expect(args.encoding).toBe("utf-8");
+    // Ensure we did not include sibling markup in content
+    expect(String(args.content)).not.toContain("<file_path>");
+    expect(String(args.content)).not.toContain("<encoding>");
+  });
+
+  it("preserves nested markup inside string-typed tag even if it looks like sibling tags", () => {
+    const protocol = morphXmlProtocol();
+    const tools: LanguageModelV2FunctionTool[] = [
+      {
+        type: "function",
+        name: "write_file",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+            encoding: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      },
+    ];
+
+    const htmlInner =
+      `<html lang="en" encoding="utf-8">` +
+      ` <head>` +
+      `   <title>Title</title>` +
+      ` </head>` +
+      ` <body>` +
+      `   <h1>Title</h1>` +
+      `   <p>Para</p>` +
+      `   <em>italic</em>` +
+      ` </body>` +
+      `</html>`;
+
+    const text =
+      `<write_file>` +
+      `<file_path>/home/u/file.html</file_path>` +
+      `<content>${htmlInner}</content>` +
+      `<encoding>utf-8</encoding>` +
+      `</write_file>`;
+
+    const out = protocol.parseGeneratedText({ text, tools, options: {} });
+    const tc = out.find(isToolCallContent);
+    expect(tc?.toolName).toBe("write_file");
+    const args =
+      typeof tc?.input === "string" ? JSON.parse(tc.input) : tc?.input;
+    // Raw inner content preserved exactly
+    expect(args.content).toBe(htmlInner);
+    // Sibling fields parsed as usual
+    expect(args.file_path).toBe("/home/u/file.html");
+    expect(args.encoding).toBe("utf-8");
+    // Ensure we did not include sibling markup in content
+    expect(String(args.content)).not.toContain("<file_path>");
+    expect(String(args.content)).not.toContain("<encoding>");
+  });
+
+  it("handles nested markup inside string-typed tag that looks like sibling tags", () => {
+    const protocol = morphXmlProtocol();
+    const tools: LanguageModelV2FunctionTool[] = [
+      {
+        type: "function",
+        name: "write_file",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+            encoding: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      },
+    ];
+
+    // Include markup that resembles another known tag name (<encoding>) inside content
+    const trickyInner = `Hello <encoding>not-a-sibling</encoding> World!`;
+    const text =
+      `<write_file>` +
+      `<file_path>/tmp/file.txt</file_path>` +
+      `<content>${trickyInner}</content>` +
+      `<encoding>utf-8</encoding>` +
+      `</write_file>`;
+
+    const out = protocol.parseGeneratedText({ text, tools, options: {} });
+    const tc = out.find(isToolCallContent);
+    expect(tc?.toolName).toBe("write_file");
+    const args =
+      typeof tc?.input === "string" ? JSON.parse(tc.input) : tc?.input;
+
+    // The content should be the raw inner string including the nested <encoding>...</encoding>
+    expect(args.content).toBe(trickyInner);
+    // The sibling encoding field should still be parsed from its own tag
+    expect(args.encoding).toBe("utf-8");
+  });
+
+  it("treats self-closing string-typed tag as empty string and parses siblings", () => {
+    const protocol = morphXmlProtocol();
+    const tools: LanguageModelV2FunctionTool[] = [
+      {
+        type: "function",
+        name: "write_file",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+            encoding: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      },
+    ];
+
+    const text =
+      `<write_file>` +
+      `<file_path>/tmp/empty.txt</file_path>` +
+      `<content/>` +
+      `<encoding>utf-8</encoding>` +
+      `</write_file>`;
+
+    const out = protocol.parseGeneratedText({ text, tools, options: {} });
+    const tc = out.find(isToolCallContent);
+    const args =
+      typeof tc?.input === "string" ? JSON.parse(tc.input) : tc?.input;
+    expect(args.file_path).toBe("/tmp/empty.txt");
+    expect(args.content).toBe("");
+    expect(args.encoding).toBe("utf-8");
+  });
+
+  it("handles attribute values containing '>' and quotes on string-typed tag", () => {
+    const protocol = morphXmlProtocol();
+    const tools: LanguageModelV2FunctionTool[] = [
+      {
+        type: "function",
+        name: "write_file",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+            encoding: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      },
+    ];
+
+    const inner = `Some text`;
+    const text =
+      `<write_file>` +
+      `<file_path>/tmp/file.txt</file_path>` +
+      `<content data="a > b" note="it's ok">${inner}</content>` +
+      `<encoding>utf-8</encoding>` +
+      `</write_file>`;
+
+    const out = protocol.parseGeneratedText({ text, tools, options: {} });
+    const tc = out.find(isToolCallContent);
+    const args =
+      typeof tc?.input === "string" ? JSON.parse(tc.input) : tc?.input;
+    expect(args.content).toBe(inner);
+    expect(args.encoding).toBe("utf-8");
+  });
+
+  it("selects the shallowest occurrence when same-named tag exists nested and as sibling", () => {
+    const protocol = morphXmlProtocol();
+    const tools: LanguageModelV2FunctionTool[] = [
+      {
+        type: "function",
+        name: "write_file",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      },
+    ];
+
+    const text =
+      `<write_file>` +
+      `<file_path>/tmp/file.txt</file_path>` +
+      `<outer><content>nested</content></outer>` +
+      `<content>top</content>` +
+      `</write_file>`;
+
+    const out = protocol.parseGeneratedText({ text, tools, options: {} });
+    const isText = (
+      p: LanguageModelV2Content
+    ): p is { type: "text"; text: string } => p.type === "text";
+    const only = out.find(isText);
+    expect(only?.text).toBe(text);
+  });
+
+  it("cancels when duplicate string-typed tags include a self-closing and non-empty", () => {
+    const protocol = morphXmlProtocol();
+    const tools: LanguageModelV2FunctionTool[] = [
+      {
+        type: "function",
+        name: "write_file",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      },
+    ];
+
+    const text =
+      `<write_file>` +
+      `<file_path>/tmp/file.txt</file_path>` +
+      `<content/>` +
+      `<content>non-empty</content>` +
+      `</write_file>`;
+
+    const out = protocol.parseGeneratedText({ text, tools, options: {} });
+    const isText = (
+      p: LanguageModelV2Content
+    ): p is { type: "text"; text: string } => p.type === "text";
+    const only = out.find(isText);
+    expect(only?.text).toBe(text);
+  });
+
+  it("preserves CDATA blocks inside string-typed tag as raw content", () => {
+    const protocol = morphXmlProtocol();
+    const tools: LanguageModelV2FunctionTool[] = [
+      {
+        type: "function",
+        name: "write_file",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      },
+    ];
+
+    const inner = `<![CDATA[<encoding>not-sibling</encoding>]]>`;
+    const text =
+      `<write_file>` +
+      `<file_path>/tmp/file.txt</file_path>` +
+      `<content>${inner}</content>` +
+      `</write_file>`;
+
+    const out = protocol.parseGeneratedText({ text, tools, options: {} });
+    const tc = out.find(isToolCallContent);
+    const args =
+      typeof tc?.input === "string" ? JSON.parse(tc.input) : tc?.input;
+    expect(args.content).toBe(inner);
+  });
 });

--- a/packages/parser/tests/protocols/xml-protocol.raw-string.test.ts
+++ b/packages/parser/tests/protocols/xml-protocol.raw-string.test.ts
@@ -1,0 +1,43 @@
+import type { LanguageModelV2FunctionTool } from "@ai-sdk/provider";
+import { describe, expect, it } from "vitest";
+
+import { morphXmlProtocol } from "@/protocols/morph-xml-protocol";
+
+describe("morphXmlProtocol raw string handling by schema", () => {
+  it("treats string-typed args as raw text, not nested XML", () => {
+    const protocol = morphXmlProtocol();
+    const tools: LanguageModelV2FunctionTool[] = [
+      {
+        type: "function",
+        name: "write_file",
+        description: "Write a file",
+        inputSchema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            content: { type: "string" },
+            encoding: { type: "string" },
+          },
+          required: ["file_path", "content"],
+        },
+      },
+    ];
+
+    const html = `<html><body><h1>Title</h1><p>Para</p></body></html>`;
+    const text =
+      `<write_file>` +
+      `<file_path>/home/username/myfile.html</file_path>` +
+      `<content>${html}</content>` +
+      `<encoding>utf-8</encoding>` +
+      `</write_file>`;
+
+    const out = protocol.parseGeneratedText({ text, tools, options: {} });
+    const tc = out.find(p => (p as any).type === "tool-call") as any;
+    expect(tc?.toolName).toBe("write_file");
+    const args = JSON.parse(tc.input);
+    expect(args.file_path).toBe("/home/username/myfile.html");
+    // Content must be the raw inner string including XML-like tags
+    expect(args.content).toBe(html);
+    expect(args.encoding).toBe("utf-8");
+  });
+});


### PR DESCRIPTION
This PR improves Morph-XML protocol parsing to preserve raw inner text for string-typed arguments based on the tool schema.\n\nKey changes:\n- Preserve raw inner content for string-typed properties during parse and stream parse\n- Add unit tests for raw string handling in parse and streaming\n- Adjust eval examples (model targets, reporter)\n\nAll tests pass and type checks succeed.