### PR TITLE
Find and fix a single bug

### DIFF
--- a/packages/parser/tests/rxml-import.test.ts
+++ b/packages/parser/tests/rxml-import.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+// Import the workspace package by name to validate test-time resolution
+import * as RXML from "@ai-sdk-tool/rxml";
+
+describe("@ai-sdk-tool/rxml package resolution", () => {
+  it("should expose core parser APIs", () => {
+    expect(typeof RXML.parse).toBe("function");
+    expect(typeof RXML.parseWithoutSchema).toBe("function");
+    expect(typeof RXML.parseNode).toBe("function");
+    expect(typeof RXML.stringify).toBe("function");
+  });
+
+  it("should parse a simple xml string via parseWithoutSchema", () => {
+    const xml = "<tool><name>test</name></tool>";
+    const results = RXML.parseWithoutSchema(xml);
+    expect(Array.isArray(results)).toBe(true);
+    // Should contain an object node for <tool>
+    expect(results.some((n: any) => typeof n === "object" && n.tagName === "tool")).toBe(true);
+  });
+});
+

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -27,7 +27,8 @@
     "target": "es2018",
     "stripInternal": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@ai-sdk-tool/rxml": ["../rxml/src/index.ts"]
     }
   },
   "include": ["."],

--- a/packages/parser/vitest.config.ts
+++ b/packages/parser/vitest.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
     conditions: ["node", "import", "module", "require"],
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // Resolve workspace package to source during tests to avoid requiring a build
+      "@ai-sdk-tool/rxml": path.resolve(__dirname, "../rxml/src/index.ts"),
     },
   },
 });


### PR DESCRIPTION
Fix unresolved import of `@ai-sdk-tool/rxml` in parser tests and add a verification test.

Parser tests failed because they attempted to import the `@ai-sdk-tool/rxml` workspace package by name, but the package's `dist` output was not yet built, causing resolution errors. This PR configures Vitest and TypeScript to correctly resolve the package's source during testing and development.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1c57a75-a526-46fb-92b1-b9c050cc3311">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1c57a75-a526-46fb-92b1-b9c050cc3311">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

