### PR TITLE
feat: add v6 branch to changeset release workflow

### DIFF
--- a/.github/workflows/release-changeset.yml
+++ b/.github/workflows/release-changeset.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v6
     paths:
       - ".changeset/**"
       - .github/workflows/release-changeset.yml


### PR DESCRIPTION
- Added v6 branch to the release workflow trigger configuration
- Ensures changesets are processed and released when pushed to v6 branch
- Maintains existing main branch release functionality