### PR TITLE
Revert: add v6 branch to changeset release workflow

### DIFF
--- a/.github/workflows/release-changeset.yml
+++ b/.github/workflows/release-changeset.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v6
     paths:
       - ".changeset/**"
       - .github/workflows/release-changeset.yml


### PR DESCRIPTION
This PR reverts commit 4a8b2eb085a30568440e6b1f820b0a01b307a207 which was accidentally merged to main.

The v6 branch already has this change in its workflow configuration, so this revert only affects the main branch.

Related: #98