### PR TITLE
fix(ci): prevent false benchmark trigger from URLs

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -77,11 +77,12 @@ jobs:
               return;
             }
 
-            // 명령어 파싱
+            // 명령어 파싱 - /benchmark 명령어만 매칭 (URL의 /benchmark-results 등 제외)
             let mode = 'fast';
             let shouldRun = false;
 
-            if (comment.includes('/benchmark')) {
+            const benchmarkMatch = comment.match(/(?:^|\s)\/benchmark(?:\s|$)/);
+            if (benchmarkMatch) {
               shouldRun = true;
 
               if (comment.includes('full') || comment.includes('all')) {


### PR DESCRIPTION
## Summary
- Fixed regex to match only `/benchmark` command, not URLs containing `/benchmark-results`
- Previously, changeset-bot comments with URLs like `/benchmark-results` were triggering full benchmarks

## Changes
- Changed `comment.includes('/benchmark')` to `comment.match(/(?:^|\s)\/benchmark(?:\s|$)/)`
- This ensures only standalone `/benchmark` commands trigger the workflow