### PR TITLE
fix(parser): improve formatToolCall XML output formatting

### DIFF
--- a/.changeset/pretty-xml-output.md
+++ b/.changeset/pretty-xml-output.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+Improve formatToolCall XML output: add proper indentation/newlines and preserve quotes without HTML entity escaping

--- a/packages/parser/src/__tests__/protocols/xml-protocol.formatters.test.ts
+++ b/packages/parser/src/__tests__/protocols/xml-protocol.formatters.test.ts
@@ -25,4 +25,53 @@ describe("xmlProtocol formatters", () => {
     } as any);
     expect(asObject).toMatch(ADD_TAG_REGEX);
   });
+
+  it("formatToolCall outputs formatted XML with newlines and indentation", () => {
+    const p = xmlProtocol();
+    const result = p.formatToolCall({
+      type: "tool-call",
+      toolCallId: "id",
+      toolName: "shell_execute",
+      input: JSON.stringify({ command: "echo hello" }),
+    } as any);
+
+    // Should have newlines (formatted)
+    expect(result).toContain("\n");
+    // Should have indentation
+    expect(result).toContain("  <command>");
+    // Expected structure
+    expect(result).toBe(
+      "<shell_execute>\n  <command>echo hello</command>\n</shell_execute>"
+    );
+  });
+
+  it("formatToolCall preserves quotes without HTML entity escaping", () => {
+    const p = xmlProtocol();
+    const result = p.formatToolCall({
+      type: "tool-call",
+      toolCallId: "id",
+      toolName: "shell_execute",
+      input: JSON.stringify({ command: 'echo "hello world"' }),
+    } as any);
+
+    // Should NOT escape quotes as &quot;
+    expect(result).not.toContain("&quot;");
+    // Should preserve original quotes
+    expect(result).toContain('echo "hello world"');
+  });
+
+  it("formatToolCall still escapes required XML characters", () => {
+    const p = xmlProtocol();
+    const result = p.formatToolCall({
+      type: "tool-call",
+      toolCallId: "id",
+      toolName: "shell_execute",
+      input: JSON.stringify({ command: "echo <script>&test</script>" }),
+    } as any);
+
+    // Should escape < and & (minimalEscaping only escapes < and &, not >)
+    expect(result).toContain("&lt;script>");
+    expect(result).toContain("&amp;test");
+    expect(result).toContain("&lt;/script>");
+  });
 });

--- a/packages/parser/src/core/protocols/xml-protocol.ts
+++ b/packages/parser/src/core/protocols/xml-protocol.ts
@@ -787,7 +787,8 @@ export const xmlProtocol = (
       }
       return stringify(toolCall.toolName, args, {
         suppressEmptyNode: false,
-        format: false,
+        format: true,
+        minimalEscaping: true,
       });
     },
 


### PR DESCRIPTION
## Summary
- Enable proper indentation and newlines in XML output from `formatToolCall`
- Preserve quotes without HTML entity escaping (`"` instead of `&quot;`)
- Add tests for formatting behavior

## Changes
**Before:**
```xml
<shell_execute><command>echo &quot;hello world&quot;</command></shell_execute>
```

**After:**
```xml
<shell_execute>
  <command>echo "hello world"</command>
</shell_execute>
```

## Test plan
- [x] Added 3 new test cases in `xml-protocol.formatters.test.ts`
- [x] All 728 tests pass
- [x] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.ai/code)