### PR TITLE
fix: remove non-existent packages from changeset ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,8 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [
-    "@ai-sdk-tool/examples-parser-core",
-    "@ai-sdk-tool/examples-rxml-core"
-  ]
+  "ignore": []
 }


### PR DESCRIPTION
## Summary
- Remove `@ai-sdk-tool/examples-parser-core` and `@ai-sdk-tool/examples-rxml-core` from changeset ignore list
- These packages no longer exist after the monorepo to single package conversion (#180)

## Test plan
- CI should now pass `changeset version` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)