### PR TITLE
Switch examples to arcee-ai/trinity model

### DIFF
--- a/examples/parser-core/src/00-stream-tool-call.ts
+++ b/examples/parser-core/src/00-stream-tool-call.ts
@@ -16,7 +16,7 @@ const openrouter = createOpenAICompatible({
 async function main() {
   const result = streamText({
     model: wrapLanguageModel({
-      model: openrouter("xiaomi/mimo-v2-flash:free"),
+      model: openrouter("arcee-ai/trinity-large-preview:free"),
       middleware: xmlToolMiddleware,
     }),
     system: "You are a helpful assistant.",

--- a/examples/parser-core/src/00-tool-call.ts
+++ b/examples/parser-core/src/00-tool-call.ts
@@ -17,7 +17,7 @@ const openrouter = createOpenAICompatible({
 async function main() {
   await generateText({
     model: wrapLanguageModel({
-      model: openrouter("xiaomi/mimo-v2-flash:free"),
+      model: openrouter("arcee-ai/trinity-large-preview:free"),
       middleware: xmlToolMiddleware,
     }),
     system: "You are a helpful assistant.",

--- a/examples/parser-core/src/01-reasoning-tool-call.ts
+++ b/examples/parser-core/src/01-reasoning-tool-call.ts
@@ -22,7 +22,7 @@ const openrouter = createOpenAICompatible({
 async function main() {
   await generateText({
     model: wrapLanguageModel({
-      model: openrouter("xiaomi/mimo-v2-flash:free"),
+      model: openrouter("arcee-ai/trinity-large-preview:free"),
 
       middleware: [
         // The order is important, extractReasoningMiddleware is called first and then hermesToolMiddleware,

--- a/examples/parser-core/src/01-stream-reasoning-tool-call.ts
+++ b/examples/parser-core/src/01-stream-reasoning-tool-call.ts
@@ -21,7 +21,7 @@ const openrouter = createOpenAICompatible({
 async function main() {
   const result = streamText({
     model: wrapLanguageModel({
-      model: openrouter("xiaomi/mimo-v2-flash:free"),
+      model: openrouter("arcee-ai/trinity-large-preview:free"),
 
       middleware: [
         // The order is important, extractReasoningMiddleware is called first and then hermesToolMiddleware,

--- a/examples/parser-core/src/02-choice-required.ts
+++ b/examples/parser-core/src/02-choice-required.ts
@@ -19,7 +19,7 @@ const openrouter = createOpenAI({
 async function main() {
   await generateText({
     model: wrapLanguageModel({
-      model: openrouter.chat("xiaomi/mimo-v2-flash:free"),
+      model: openrouter.chat("arcee-ai/trinity-large-preview:free"),
       middleware: hermesToolMiddleware,
     }),
     tools: {

--- a/examples/parser-core/src/02-choice-toolname.ts
+++ b/examples/parser-core/src/02-choice-toolname.ts
@@ -18,7 +18,7 @@ const openrouter = createOpenAI({
 async function main() {
   await generateText({
     model: wrapLanguageModel({
-      model: openrouter.chat("xiaomi/mimo-v2-flash:free"),
+      model: openrouter.chat("arcee-ai/trinity-large-preview:free"),
       middleware: hermesToolMiddleware,
     }),
     tools: {

--- a/examples/parser-core/src/02-stream-choice-required.ts
+++ b/examples/parser-core/src/02-stream-choice-required.ts
@@ -19,7 +19,7 @@ const openrouter = createOpenAI({
 async function main() {
   const result = streamText({
     model: wrapLanguageModel({
-      model: openrouter.chat("xiaomi/mimo-v2-flash:free"),
+      model: openrouter.chat("arcee-ai/trinity-large-preview:free"),
       middleware: hermesToolMiddleware,
     }),
     tools: {

--- a/examples/parser-core/src/02-stream-choice-toolname.ts
+++ b/examples/parser-core/src/02-stream-choice-toolname.ts
@@ -16,7 +16,7 @@ const openrouter = createOpenAI({
 async function main() {
   const result = streamText({
     model: wrapLanguageModel({
-      model: openrouter.chat("xiaomi/mimo-v2-flash:free"),
+      model: openrouter.chat("arcee-ai/trinity-large-preview:free"),
       middleware: hermesToolMiddleware,
     }),
     tools: {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "ci:version": "changeset version"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.25",
     "@ai-sdk/provider": "3.0.7",
     "@ai-sdk/provider-utils": "4.0.13",
     "dedent": "^1.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^3.0.25
+        version: 3.0.25(zod@4.3.6)
       '@ai-sdk/provider':
         specifier: 3.0.7
         version: 3.0.7
@@ -83,6 +86,12 @@ packages:
 
   '@ai-sdk/openai-compatible@2.0.26':
     resolution: {integrity: sha512-l6jdFjI1C2eDAEm7oo+dnRn0oG1EkcyqfbEZ7ozT0TnYrah6amX2JkftYMP1GRzNtAeCB3WNN8XspXdmi6ZNlQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.25':
+    resolution: {integrity: sha512-DsaN46R98+D1W3lU3fKuPU3ofacboLaHlkAwxJPgJ8eup1AJHmPK1N1y10eJJbJcF6iby8Tf/vanoZxc9JPUfw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2087,6 +2096,12 @@ snapshots:
       zod: 4.3.6
 
   '@ai-sdk/openai-compatible@2.0.26(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.7
+      '@ai-sdk/provider-utils': 4.0.13(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/openai@3.0.25(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.7
       '@ai-sdk/provider-utils': 4.0.13(zod@4.3.6)


### PR DESCRIPTION
## Summary
- Update all parser-core examples to use arcee-ai/trinity model
- Add @ai-sdk/openai dependency to package.json