### PR TITLE
⚡ Bolt: optimize getPotentialStartIndex for large buffers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - O(N²) Bottleneck in Streaming Buffer Search
+**Learning:** The `getPotentialStartIndex` utility, used for finding partial tags in streaming buffers, had an O(N²) complexity because it scanned the entire buffer (which grows as streaming progresses) for every possible suffix. By limiting the search loop to only check suffixes shorter than the target string, the complexity is reduced to O(N + M²), where N is the buffer length and M is the tag length.
+**Action:** Always limit suffix-matching loops to the length of the search target when scanning large/growing buffers.

--- a/src/core/utils/get-potential-start-index.ts
+++ b/src/core/utils/get-potential-start-index.ts
@@ -20,7 +20,16 @@ export function getPotentialStartIndex(
 
   // Otherwise, look for the largest suffix of "text" that matches
   // a prefix of "searchedText". We go from the end of text inward.
-  for (let i = text.length - 1; i >= 0; i -= 1) {
+  //
+  // Optimization: We only need to check suffixes of "text" that are shorter
+  // than "searchedText". If a suffix was longer than or equal to "searchedText",
+  // it would have been found by the indexOf check above (if it matched
+  // searchedText) or it can't be a prefix of searchedText (if it's longer).
+  // This reduces complexity from O(N^2) to O(N + M^2) where N is text length
+  // and M is searchedText length.
+  const minIndex = Math.max(0, text.length - searchedText.length + 1);
+
+  for (let i = text.length - 1; i >= minIndex; i -= 1) {
     const suffix = text.substring(i);
     if (searchedText.startsWith(suffix)) {
       return i;


### PR DESCRIPTION
💡 What: Optimized `getPotentialStartIndex` in `src/core/utils/get-potential-start-index.ts`.
🎯 Why: The original implementation had O(N²) complexity when no match was found in a large buffer, because it checked every possible suffix.
📊 Impact: Reduced execution time by ~400x for 1MB buffers.
🔬 Measurement: Verified with a benchmark script showing a drop from 1.37s to 3.3ms for 100 calls.
✅ Tests: All 1095 existing tests passed.
📖 Journal: Updated `.jules/bolt.md` with the learning.

---
*PR created automatically by Jules for task [6821378248419188014](https://jules.google.com/task/6821378248419188014) started by @minpeter*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized streaming buffer performance by reducing computational complexity in tag matching operations, resulting in faster processing of large buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->