### PR TITLE
feat: add BFCL v4 benchmark script for native vs middleware comparison

### DIFF
--- a/.changeset/bfcl-benchmark-script.md
+++ b/.changeset/bfcl-benchmark-script.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+feat: add BFCL v4 benchmark script for native vs middleware comparison

--- a/examples/bfcl-gemini-benchmark.ts
+++ b/examples/bfcl-gemini-benchmark.ts
@@ -14,14 +14,13 @@ import {
 async function loadEval() {
   const evalRepoBase = new URL("../../ai-sdk-eval/", import.meta.url);
   const localDist = new URL("dist/index.js", evalRepoBase).href;
-  const localData = fileURLToPath(new URL("data", evalRepoBase));
-
-  if (!process.env.BFCL_DATA_DIR) {
-    process.env.BFCL_DATA_DIR = localData;
-  }
 
   try {
-    return await import(localDist);
+    const mod = await import(localDist);
+    if (!process.env.BFCL_DATA_DIR) {
+      process.env.BFCL_DATA_DIR = fileURLToPath(new URL("data", evalRepoBase));
+    }
+    return mod;
   } catch (err) {
     console.warn(
       "Local ai-sdk-eval not found, falling back to npm package:",
@@ -47,6 +46,15 @@ type ProtocolName = (typeof PROTOCOL_NAMES)[number];
 const MODE_NAMES = ["native", "middleware", "both"] as const;
 type ModeName = (typeof MODE_NAMES)[number];
 
+const REPORTER_NAMES = [
+  "console",
+  "console.summary",
+  "console.debug",
+  "json",
+  "none",
+] as const;
+type ReporterName = (typeof REPORTER_NAMES)[number];
+
 interface Options {
   benchmark: BenchmarkName;
   cache: boolean;
@@ -55,7 +63,7 @@ interface Options {
   mode: ModeName;
   model: string;
   protocol: ProtocolName;
-  reporter: string;
+  reporter: ReporterName;
   temperature: number;
 }
 
@@ -64,7 +72,7 @@ function readArg(name: string): string | undefined {
   const flag = `--${name}`;
   const prefix = `${flag}=`;
   for (let i = 2; i < argv.length; i++) {
-    if (argv[i] === flag && argv[i + 1]) {
+    if (argv[i] === flag && argv[i + 1] && !argv[i + 1].startsWith("--")) {
       return argv[i + 1];
     }
     if (argv[i]?.startsWith(prefix)) {
@@ -84,7 +92,7 @@ function parseOptions(): Options {
     benchmark: (readArg("benchmark") ?? "simple") as BenchmarkName,
     mode: (readArg("mode") ?? "both") as ModeName,
     protocol: (readArg("protocol") ?? "morphXml") as ProtocolName,
-    reporter: readArg("reporter") ?? "console.summary",
+    reporter: (readArg("reporter") ?? "console.summary") as ReporterName,
     temperature: Number(readArg("temperature") ?? "0"),
     maxTokens: Number(readArg("max-tokens") ?? "4096"),
     cache: hasFlag("cache"),
@@ -115,6 +123,12 @@ function validateOptions(opts: Options) {
   if (!PROTOCOL_NAMES.includes(opts.protocol)) {
     console.error(
       `Invalid protocol: ${opts.protocol}. Valid: ${PROTOCOL_NAMES.join(", ")}`
+    );
+    process.exit(1);
+  }
+  if (!(REPORTER_NAMES as readonly string[]).includes(opts.reporter)) {
+    console.error(
+      `Invalid reporter: ${opts.reporter}. Valid: ${REPORTER_NAMES.join(", ")}`
     );
     process.exit(1);
   }
@@ -264,12 +278,7 @@ async function main() {
   const results = await evalModule.evaluate({
     models,
     benchmarks,
-    reporter: opts.reporter as
-      | "console"
-      | "json"
-      | "console.debug"
-      | "console.summary"
-      | "none",
+    reporter: opts.reporter,
     temperature: opts.temperature,
     maxTokens: opts.maxTokens,
     cache: opts.cache

--- a/examples/bfcl-gemini-benchmark.ts
+++ b/examples/bfcl-gemini-benchmark.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 
+import { fileURLToPath } from "node:url";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { LanguageModelV3Middleware } from "@ai-sdk/provider";
 import type { LanguageModel } from "ai";
@@ -13,7 +14,7 @@ import {
 async function loadEval() {
   const evalRepoBase = new URL("../../ai-sdk-eval/", import.meta.url);
   const localDist = new URL("dist/index.js", evalRepoBase).href;
-  const localData = new URL("data", evalRepoBase).pathname;
+  const localData = fileURLToPath(new URL("data", evalRepoBase));
 
   if (!process.env.BFCL_DATA_DIR) {
     process.env.BFCL_DATA_DIR = localData;
@@ -21,7 +22,11 @@ async function loadEval() {
 
   try {
     return await import(localDist);
-  } catch {
+  } catch (err) {
+    console.warn(
+      "Local ai-sdk-eval not found, falling back to npm package:",
+      (err as Error).message
+    );
     const pkg = "@ai-sdk-tool/eval";
     return await import(pkg);
   }
@@ -110,6 +115,18 @@ function validateOptions(opts: Options) {
   if (!PROTOCOL_NAMES.includes(opts.protocol)) {
     console.error(
       `Invalid protocol: ${opts.protocol}. Valid: ${PROTOCOL_NAMES.join(", ")}`
+    );
+    process.exit(1);
+  }
+  if (!Number.isFinite(opts.temperature)) {
+    console.error(
+      `Invalid temperature: ${readArg("temperature")}. Must be a number.`
+    );
+    process.exit(1);
+  }
+  if (!Number.isFinite(opts.maxTokens) || opts.maxTokens <= 0) {
+    console.error(
+      `Invalid max-tokens: ${readArg("max-tokens")}. Must be a positive number.`
     );
     process.exit(1);
   }

--- a/examples/bfcl-gemini-benchmark.ts
+++ b/examples/bfcl-gemini-benchmark.ts
@@ -1,0 +1,269 @@
+/// <reference types="node" />
+
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type { LanguageModelV3Middleware } from "@ai-sdk/provider";
+import type { LanguageModel } from "ai";
+import {
+  hermesToolMiddleware,
+  morphXmlToolMiddleware,
+  qwen3CoderToolMiddleware,
+  yamlXmlToolMiddleware,
+} from "../src/preconfigured-middleware";
+
+async function loadEval() {
+  const evalRepoBase = new URL("../../ai-sdk-eval/", import.meta.url);
+  const localDist = new URL("dist/index.js", evalRepoBase).href;
+  const localData = new URL("data", evalRepoBase).pathname;
+
+  if (!process.env.BFCL_DATA_DIR) {
+    process.env.BFCL_DATA_DIR = localData;
+  }
+
+  try {
+    return await import(localDist);
+  } catch {
+    const pkg = "@ai-sdk-tool/eval";
+    return await import(pkg);
+  }
+}
+
+const BENCHMARK_NAMES = [
+  "simple",
+  "parallel",
+  "multiple",
+  "parallel-multiple",
+  "all",
+] as const;
+type BenchmarkName = (typeof BENCHMARK_NAMES)[number];
+
+const PROTOCOL_NAMES = ["morphXml", "hermes", "yamlXml", "qwen3Coder"] as const;
+type ProtocolName = (typeof PROTOCOL_NAMES)[number];
+
+const MODE_NAMES = ["native", "middleware", "both"] as const;
+type ModeName = (typeof MODE_NAMES)[number];
+
+interface Options {
+  benchmark: BenchmarkName;
+  cache: boolean;
+  dryRun: boolean;
+  maxTokens: number;
+  mode: ModeName;
+  model: string;
+  protocol: ProtocolName;
+  reporter: string;
+  temperature: number;
+}
+
+function readArg(name: string): string | undefined {
+  const argv = process.argv;
+  const flag = `--${name}`;
+  const prefix = `${flag}=`;
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === flag && argv[i + 1]) {
+      return argv[i + 1];
+    }
+    if (argv[i]?.startsWith(prefix)) {
+      return argv[i]?.slice(prefix.length);
+    }
+  }
+  return undefined;
+}
+
+function hasFlag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+function parseOptions(): Options {
+  return {
+    model: readArg("model") ?? "google/gemini-3.1-pro-preview",
+    benchmark: (readArg("benchmark") ?? "simple") as BenchmarkName,
+    mode: (readArg("mode") ?? "both") as ModeName,
+    protocol: (readArg("protocol") ?? "morphXml") as ProtocolName,
+    reporter: readArg("reporter") ?? "console.summary",
+    temperature: Number(readArg("temperature") ?? "0"),
+    maxTokens: Number(readArg("max-tokens") ?? "4096"),
+    cache: hasFlag("cache"),
+    dryRun: hasFlag("dry-run"),
+  };
+}
+
+const MIDDLEWARE_MAP: Record<ProtocolName, LanguageModelV3Middleware> = {
+  morphXml: morphXmlToolMiddleware,
+  hermes: hermesToolMiddleware,
+  yamlXml: yamlXmlToolMiddleware,
+  qwen3Coder: qwen3CoderToolMiddleware,
+};
+
+function validateOptions(opts: Options) {
+  if (!BENCHMARK_NAMES.includes(opts.benchmark)) {
+    console.error(
+      `Invalid benchmark: ${opts.benchmark}. Valid: ${BENCHMARK_NAMES.join(", ")}`
+    );
+    process.exit(1);
+  }
+  if (!MODE_NAMES.includes(opts.mode)) {
+    console.error(
+      `Invalid mode: ${opts.mode}. Valid: ${MODE_NAMES.join(", ")}`
+    );
+    process.exit(1);
+  }
+  if (!PROTOCOL_NAMES.includes(opts.protocol)) {
+    console.error(
+      `Invalid protocol: ${opts.protocol}. Valid: ${PROTOCOL_NAMES.join(", ")}`
+    );
+    process.exit(1);
+  }
+}
+
+function printConfig(opts: Options) {
+  console.log("=== BFCL Benchmark: Native vs Middleware ===");
+  console.log(`  Base URL:    ${process.env.AI_BASE_URL ?? "(not set)"}`);
+  console.log(`  Model:       ${opts.model}`);
+  console.log(`  Benchmark:   ${opts.benchmark}`);
+  console.log(`  Mode:        ${opts.mode}`);
+  console.log(`  Protocol:    ${opts.protocol}`);
+  console.log(`  Temperature: ${opts.temperature}`);
+  console.log(`  Max Tokens:  ${opts.maxTokens}`);
+  console.log(`  Cache:       ${opts.cache}`);
+  console.log(`  Reporter:    ${opts.reporter}`);
+  console.log();
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`${name} is required.`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function buildModels(
+  baseModel: LanguageModel,
+  opts: Options
+): Record<
+  string,
+  | LanguageModel
+  | { model: LanguageModel; middleware: LanguageModelV3Middleware }
+> {
+  const models: Record<
+    string,
+    | LanguageModel
+    | { model: LanguageModel; middleware: LanguageModelV3Middleware }
+  > = {};
+
+  if (opts.mode === "native" || opts.mode === "both") {
+    models[`${opts.model} (native)`] = baseModel;
+  }
+
+  if (opts.mode === "middleware" || opts.mode === "both") {
+    models[`${opts.model} (${opts.protocol})`] = {
+      model: baseModel,
+      middleware: MIDDLEWARE_MAP[opts.protocol],
+    };
+  }
+
+  return models;
+}
+
+const PAD_WIDTH = 45;
+
+function printSummary(
+  results: {
+    benchmark: string;
+    modelKey?: string;
+    model: string;
+    result: { metrics: Record<string, number | string>; score: number };
+  }[]
+) {
+  console.log("\n=== Summary ===\n");
+
+  const grouped = new Map<string, typeof results>();
+  for (const r of results) {
+    const bucket = grouped.get(r.benchmark) ?? [];
+    bucket.push(r);
+    grouped.set(r.benchmark, bucket);
+  }
+
+  for (const [benchmark, group] of grouped) {
+    console.log(`  ${benchmark}`);
+    for (const r of group) {
+      const label = r.modelKey ?? r.model;
+      const accuracy =
+        typeof r.result.metrics.accuracy === "number"
+          ? (Number(r.result.metrics.accuracy) * 100).toFixed(1)
+          : "n/a";
+      const score = r.result.score.toFixed(4);
+      console.log(
+        `    ${label.padEnd(PAD_WIDTH)} accuracy=${accuracy}%  score=${score}`
+      );
+    }
+    console.log();
+  }
+}
+
+async function main() {
+  const opts = parseOptions();
+  validateOptions(opts);
+  printConfig(opts);
+
+  if (opts.dryRun) {
+    console.log("Dry run — exiting.");
+    return;
+  }
+
+  const apiKey = requireEnv("AI_API_KEY");
+  const baseURL = requireEnv("AI_BASE_URL");
+
+  const evalModule = await loadEval();
+
+  const provider = createOpenAICompatible({
+    name: "ai-provider",
+    apiKey,
+    baseURL,
+  });
+
+  const baseModel = provider(opts.model);
+
+  const benchmarkMap = {
+    simple: [evalModule.bfclSimpleBenchmark],
+    parallel: [evalModule.bfclParallelBenchmark],
+    multiple: [evalModule.bfclMultipleBenchmark],
+    "parallel-multiple": [evalModule.bfclParallelMultipleBenchmark],
+    all: [
+      evalModule.bfclSimpleBenchmark,
+      evalModule.bfclParallelBenchmark,
+      evalModule.bfclMultipleBenchmark,
+      evalModule.bfclParallelMultipleBenchmark,
+    ],
+  };
+  const benchmarks = benchmarkMap[opts.benchmark];
+  const models = buildModels(baseModel, opts);
+
+  console.log(
+    `Running ${benchmarks.length} benchmark(s) x ${Object.keys(models).length} model config(s)...\n`
+  );
+
+  const results = await evalModule.evaluate({
+    models,
+    benchmarks,
+    reporter: opts.reporter as
+      | "console"
+      | "json"
+      | "console.debug"
+      | "console.summary"
+      | "none",
+    temperature: opts.temperature,
+    maxTokens: opts.maxTokens,
+    cache: opts.cache
+      ? { enabled: true, cacheDir: ".ai-cache/bfcl-benchmark" }
+      : undefined,
+  });
+
+  printSummary(results);
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/examples/bfcl-gemini-benchmark.ts
+++ b/examples/bfcl-gemini-benchmark.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { LanguageModelV3Middleware } from "@ai-sdk/provider";
 import type { LanguageModel } from "ai";
@@ -11,15 +11,16 @@ import {
   yamlXmlToolMiddleware,
 } from "../src/preconfigured-middleware";
 
-function isMissingLocalEvalError(
+function isMissingLocalEvalEntry(
   error: unknown,
   localDistPath: string
 ): boolean {
-  const err = error as NodeJS.ErrnoException;
+  const err = error as NodeJS.ErrnoException & { url?: string };
+  const localDistUrl = pathToFileURL(localDistPath).href;
   return (
     err.code === "ERR_MODULE_NOT_FOUND" &&
-    typeof err.message === "string" &&
-    err.message.includes(localDistPath)
+    (err.url === localDistUrl ||
+      (typeof err.message === "string" && err.message.includes(localDistPath)))
   );
 }
 
@@ -35,13 +36,13 @@ async function loadEval() {
     }
     return mod;
   } catch (err) {
-    if (!isMissingLocalEvalError(err, localDistPath)) {
+    if (!isMissingLocalEvalEntry(err, localDistPath)) {
       throw err;
     }
-    throw new Error(
-      `Local ai-sdk-eval build not found at ${localDistPath}. Build ../ai-sdk-eval first before running this benchmark.`,
-      { cause: err }
+    console.warn(
+      `Local ai-sdk-eval build not found at ${localDistPath}; falling back to @ai-sdk-tool/eval.`
     );
+    return await import("@ai-sdk-tool/eval");
   }
 }
 

--- a/examples/bfcl-gemini-benchmark.ts
+++ b/examples/bfcl-gemini-benchmark.ts
@@ -1,6 +1,8 @@
 /// <reference types="node" />
 
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { constants } from "node:fs";
+import { access } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { LanguageModelV3Middleware } from "@ai-sdk/provider";
 import type { LanguageModel } from "ai";
@@ -11,39 +13,25 @@ import {
   yamlXmlToolMiddleware,
 } from "../src/preconfigured-middleware";
 
-function isMissingLocalEvalEntry(
-  error: unknown,
-  localDistPath: string
-): boolean {
-  const err = error as NodeJS.ErrnoException & { url?: string };
-  const localDistUrl = pathToFileURL(localDistPath).href;
-  return (
-    err.code === "ERR_MODULE_NOT_FOUND" &&
-    (err.url === localDistUrl ||
-      (typeof err.message === "string" && err.message.includes(localDistPath)))
-  );
-}
-
 async function loadEval() {
   const evalRepoBase = new URL("../../ai-sdk-eval/", import.meta.url);
   const localDistUrl = new URL("dist/index.js", evalRepoBase);
   const localDistPath = fileURLToPath(localDistUrl);
 
   try {
-    const mod = await import(localDistUrl.href);
-    if (!process.env.BFCL_DATA_DIR) {
-      process.env.BFCL_DATA_DIR = fileURLToPath(new URL("data", evalRepoBase));
-    }
-    return mod;
-  } catch (err) {
-    if (!isMissingLocalEvalEntry(err, localDistPath)) {
-      throw err;
-    }
+    await access(localDistPath, constants.R_OK);
+  } catch {
     console.warn(
       `Local ai-sdk-eval build not found at ${localDistPath}; falling back to @ai-sdk-tool/eval.`
     );
     return await import("@ai-sdk-tool/eval");
   }
+
+  const mod = await import(localDistUrl.href);
+  if (!process.env.BFCL_DATA_DIR) {
+    process.env.BFCL_DATA_DIR = fileURLToPath(new URL("data", evalRepoBase));
+  }
+  return mod;
 }
 
 const BENCHMARK_NAMES = [
@@ -123,6 +111,10 @@ const MIDDLEWARE_MAP: Record<ProtocolName, LanguageModelV3Middleware> = {
 };
 
 function validateOptions(opts: Options) {
+  if (!opts.model.trim()) {
+    console.error("Invalid model: must be a non-empty string.");
+    process.exit(1);
+  }
   if (!BENCHMARK_NAMES.includes(opts.benchmark)) {
     console.error(
       `Invalid benchmark: ${opts.benchmark}. Valid: ${BENCHMARK_NAMES.join(", ")}`
@@ -147,15 +139,15 @@ function validateOptions(opts: Options) {
     );
     process.exit(1);
   }
-  if (!Number.isFinite(opts.temperature)) {
+  if (!Number.isFinite(opts.temperature) || opts.temperature < 0) {
     console.error(
-      `Invalid temperature: ${readArg("temperature")}. Must be a number.`
+      `Invalid temperature: ${readArg("temperature")}. Must be a non-negative number.`
     );
     process.exit(1);
   }
-  if (!Number.isFinite(opts.maxTokens) || opts.maxTokens <= 0) {
+  if (!Number.isInteger(opts.maxTokens) || opts.maxTokens < 256) {
     console.error(
-      `Invalid max-tokens: ${readArg("max-tokens")}. Must be a positive number.`
+      `Invalid max-tokens: ${readArg("max-tokens")}. Must be an integer >= 256.`
     );
     process.exit(1);
   }

--- a/examples/bfcl-gemini-benchmark.ts
+++ b/examples/bfcl-gemini-benchmark.ts
@@ -11,23 +11,37 @@ import {
   yamlXmlToolMiddleware,
 } from "../src/preconfigured-middleware";
 
+function isMissingLocalEvalError(
+  error: unknown,
+  localDistPath: string
+): boolean {
+  const err = error as NodeJS.ErrnoException;
+  return (
+    err.code === "ERR_MODULE_NOT_FOUND" &&
+    typeof err.message === "string" &&
+    err.message.includes(localDistPath)
+  );
+}
+
 async function loadEval() {
   const evalRepoBase = new URL("../../ai-sdk-eval/", import.meta.url);
-  const localDist = new URL("dist/index.js", evalRepoBase).href;
+  const localDistUrl = new URL("dist/index.js", evalRepoBase);
+  const localDistPath = fileURLToPath(localDistUrl);
 
   try {
-    const mod = await import(localDist);
+    const mod = await import(localDistUrl.href);
     if (!process.env.BFCL_DATA_DIR) {
       process.env.BFCL_DATA_DIR = fileURLToPath(new URL("data", evalRepoBase));
     }
     return mod;
   } catch (err) {
-    console.warn(
-      "Local ai-sdk-eval not found, falling back to npm package:",
-      (err as Error).message
+    if (!isMissingLocalEvalError(err, localDistPath)) {
+      throw err;
+    }
+    throw new Error(
+      `Local ai-sdk-eval build not found at ${localDistPath}. Build ../ai-sdk-eval first before running this benchmark.`,
+      { cause: err }
     );
-    const pkg = "@ai-sdk-tool/eval";
-    return await import(pkg);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "typescript": "6.0.3",
     "ultracite": "7.6.0",
     "vitest": "^4.1.4",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@ai-sdk-tool/eval": "^1.1.0"
   },
   "packageManager": "pnpm@10.32.1",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
     devDependencies:
+      '@ai-sdk-tool/eval':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@ai-sdk/openai-compatible':
         specifier: 2.0.41
         version: 2.0.41(zod@4.3.6)
@@ -78,8 +81,20 @@ importers:
 
 packages:
 
+  '@ai-sdk-tool/eval@1.1.0':
+    resolution: {integrity: sha512-UoTCJH0PMHrN/u6nQXZ6Tp0nBh5wwqwNPLreaLJm1f3tfAD/hr7FBHvhcXo2XpMAL9I7KHAqeIWAFLROllrGhg==}
+
+  '@ai-sdk-tool/middleware@0.0.2':
+    resolution: {integrity: sha512-YvawQVvCeaVM4+pvhfFNN2eKcyE0GAxO8F4eoqszKKeDEPM1ksE5RKKHiwBuX7HDYBvL8k1SFaDxOAfH7wmzug==}
+
   '@ai-sdk/gateway@3.0.104':
     resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@3.0.5':
+    resolution: {integrity: sha512-AtxA1wcoKTHr9uFoC5KZEXqJP4SMW4j3VbcliUECUYssbWbePJ9+b3AaCny1lxf1xhDK9EIyAgBOKhXoQSr9nA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -96,11 +111,21 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.2':
+    resolution: {integrity: sha512-KaykkuRBdF/ffpI5bwpL4aSCmO/99p8/ci+VeHwJO8tmvXtiVAb99QeyvvvXmL61e9Zrvv4GBGoajW19xdjkVQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.23':
     resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.1':
+    resolution: {integrity: sha512-2lR4w7mr9XrydzxBSjir4N6YMGdXD+Np1Sh0RXABh7tWdNFFwIeRI1Q+SaYZMbfL8Pg8RRLcrxQm51yxTLhokg==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
@@ -947,6 +972,10 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@vercel/oidc@3.0.5':
+    resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
+    engines: {node: '>= 20'}
+
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
@@ -999,6 +1028,15 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  ai@6.0.6:
+    resolution: {integrity: sha512-LM0eAMWVn3RTj+0X5O1m/8g+7QiTeWG5aN5FsDbdmCkAQHVg93XxLbljFOLzi0NMjuJgf7fKLKmWoPsrdMyqfw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -1174,6 +1212,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
@@ -1273,6 +1314,9 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -1282,6 +1326,9 @@ packages:
 
   fast-string-width@1.1.0:
     resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
@@ -1599,6 +1646,9 @@ packages:
   json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
@@ -1904,6 +1954,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -2341,11 +2395,31 @@ packages:
 
 snapshots:
 
+  '@ai-sdk-tool/eval@1.1.0':
+    dependencies:
+      '@ai-sdk-tool/middleware': 0.0.2
+      '@ai-sdk/provider': 3.0.1
+      ai: 6.0.6(zod@4.3.6)
+      ajv: 8.18.0
+      decimal.js: 10.6.0
+      zod: 4.3.6
+
+  '@ai-sdk-tool/middleware@0.0.2':
+    dependencies:
+      '@ai-sdk/provider': 3.0.1
+
   '@ai-sdk/gateway@3.0.104(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       '@vercel/oidc': 3.2.0
+      zod: 4.3.6
+
+  '@ai-sdk/gateway@3.0.5(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.1
+      '@ai-sdk/provider-utils': 4.0.2(zod@4.3.6)
+      '@vercel/oidc': 3.0.5
       zod: 4.3.6
 
   '@ai-sdk/openai-compatible@2.0.41(zod@4.3.6)':
@@ -2360,12 +2434,23 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@4.0.2(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.1
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
+
+  '@ai-sdk/provider@3.0.1':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
     dependencies:
@@ -2978,6 +3063,8 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@vercel/oidc@3.0.5': {}
+
   '@vercel/oidc@3.2.0': {}
 
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
@@ -3044,6 +3131,21 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
+
+  ai@6.0.6(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.5(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.1
+      '@ai-sdk/provider-utils': 4.0.2(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -3214,6 +3316,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   dedent@1.7.2: {}
 
@@ -3404,6 +3508,8 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
+  fast-deep-equal@3.1.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3417,6 +3523,8 @@ snapshots:
   fast-string-width@1.1.0:
     dependencies:
       fast-string-truncated-width: 1.2.1
+
+  fast-uri@3.1.0: {}
 
   fast-wrap-ansi@0.1.6:
     dependencies:
@@ -3741,6 +3849,8 @@ snapshots:
 
   json-parse-better-errors@1.0.2: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-schema@0.4.0: {}
 
   jsonc-parser@3.3.1: {}
@@ -4026,6 +4136,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-from@5.0.0: {}
 


### PR DESCRIPTION
## Summary

- Add `examples/bfcl-gemini-benchmark.ts` — CLI tool for running BFCL v4 benchmarks comparing native tool calling vs middleware-based tool calling

## How to Reproduce

### Prerequisites

1. Clone and build [ai-sdk-eval](https://github.com/minpeter/ai-sdk-eval) as a sibling directory:
   ```bash
   cd .. && git clone https://github.com/minpeter/ai-sdk-eval.git
   cd ai-sdk-eval && pnpm install && pnpm build && cd ../ai-sdk-tool-call-middleware
   ```
2. An OpenAI-compatible API endpoint with tool calling support

### Quick Start

```bash
AI_API_KEY=<your-key> \
AI_BASE_URL=<your-endpoint>/v1 \
pnpm dlx tsx examples/bfcl-gemini-benchmark.ts \
  --model <model-id> \
  --benchmark all \
  --mode both
```

### CLI Options

| Option | Default | Values |
|---|---|---|
| `--model` | `google/gemini-3.1-pro-preview` | Any model ID on your endpoint |
| `--benchmark` | `simple` | `simple`, `parallel`, `multiple`, `parallel-multiple`, `all` |
| `--mode` | `both` | `native`, `middleware`, `both` |
| `--protocol` | `morphXml` | `morphXml`, `hermes`, `yamlXml`, `qwen3Coder` |
| `--temperature` | `0` | Any number |
| `--max-tokens` | `4096` | Any number |
| `--reporter` | `console.summary` | `console`, `console.summary`, `console.debug`, `json`, `none` |
| `--cache` | off | Enable disk caching to `.ai-cache/bfcl-benchmark` |
| `--dry-run` | off | Print config and exit |

### Benchmark Results (Gemini Pro & Flash via LiteLLM)

**Gemini Pro** (`minpeter/gemini-pro-latest`, max-tokens=4096, temperature=0)

| Benchmark | Native (FC) | morphXml Middleware | Δ |
|---|---|---|---|
| Simple (400) | 96.8% | **97.3%** | +0.5% |
| Parallel (200) | 91.5% | **95.0%** | +3.5% |
| Multiple (200) | 95.5% | 95.5% | 0% |
| Parallel-Multiple (200) | 90.0% | **91.0%** | +1.0% |

**Gemini Flash** (`minpeter/gemini-flash-latest`, max-tokens=4096, temperature=0)

| Benchmark | Native (FC) | morphXml Middleware | Δ |
|---|---|---|---|
| Simple (400) | 89.0% | **94.8%** | +5.8% |
| Parallel (200) | 91.0% | **94.5%** | +3.5% |
| Multiple (200) | 89.0% | **93.0%** | +4.0% |
| Parallel-Multiple (200) | 83.5% | **88.0%** | +4.5% |

### Key Findings

- morphXml middleware matches or exceeds native tool calling across all BFCL v4 categories on both Gemini Pro and Flash
- The gap is larger on Flash (+3.5~5.8%) than Pro (+0~3.5%), primarily because Flash's native FC has more refusal behavior (model responds with text instead of tool calls)
- `max-tokens` must be ≥4096 for middleware mode — at 1024, complex XML gets truncated (`finish_reason: length`), particularly on parallel-multiple
- The middleware advantage is **not** from BFCL overfitting — it comes from (1) explicit prompting rules that reduce refusal, (2) textual enum visibility improving exact-match accuracy, offset by (3) a slight verbosity penalty in text-mode output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a BFCL v4 benchmark CLI to compare native tool calling vs middleware protocols on OpenAI-compatible models. Improves CLI validation and prefers a local `ai-sdk-eval` build with a safe fallback to `@ai-sdk-tool/eval`.

- **New Features**
  - Added `examples/bfcl-gemini-benchmark.ts` CLI for BFCL v4 benchmarking.
  - Benchmarks: simple, parallel, multiple, parallel-multiple; modes: native, middleware, both; protocols: `morphXml`, `hermes`, `yamlXml`, `qwen3Coder`.
  - Configurable model, temperature, max tokens, reporter; requires `AI_API_KEY` and `AI_BASE_URL`; optional disk cache. Declares `@ai-sdk-tool/eval` as a dev dependency and adds a patch changeset for `@ai-sdk-tool/parser`.

- **Bug Fixes**
  - Safer arg parsing: prevent flags as values; validate reporter; ensure non-empty model.
  - Stronger constraints: temperature is finite and ≥ 0; max tokens is an integer ≥ 256.
  - Robust eval loading: cross-platform paths via `fileURLToPath`; check local dist readability; set `BFCL_DATA_DIR` only after a successful local import; fall back to `@ai-sdk-tool/eval` only when the local dist entry is missing (other local import failures surface).

<sup>Written for commit 0b155c1bd3eb040a7f7b1472c2bfd269bfd33d97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BFCL v4 벤치마크 스크립트 추가: 네이티브 및 미들웨어 구현의 성능 비교를 지원합니다. 모델, 벤치마크, 실행 모드를 선택하여 상세한 성능 메트릭을 확인할 수 있습니다.

* **Chores**
  * 개발 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->