### PR TITLE
fix: skip </tool_call> end tags inside JSON string values

### DIFF
--- a/.changeset/json-string-end-tag-boundary.md
+++ b/.changeset/json-string-end-tag-boundary.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+fix: skip `</tool_call>` end tags inside JSON string values

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ yarn-error.log*
 AGENTS.md
 .ralph-tui
 tasks
+package-lock.json

--- a/src/__tests__/protocols/hermes-protocol/options.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/options.test.ts
@@ -28,4 +28,22 @@ describe("hermesProtocol options", () => {
     expect(toolCall.toolName).toBe("ok");
     expect(JSON.parse(toolCall.input)).toEqual({});
   });
+
+  it("does not treat an unquoted RJSON key matching a custom start delimiter as nested", () => {
+    const protocol = hermesProtocol({
+      toolCallStart: "name",
+      toolCallEnd: "END",
+    });
+
+    const text = 'name{name:"ok",arguments:{}}END';
+    const out = protocol.parseGeneratedText({ text, tools: [] });
+    const toolCall = out.find((part) => part.type === "tool-call") as any;
+
+    expect(toolCall).toBeTruthy();
+    expect(toolCall.toolName).toBe("ok");
+    expect(JSON.parse(toolCall.input)).toEqual({});
+    expect(protocol.extractToolCallSegments?.({ text, tools: [] })).toEqual([
+      text,
+    ]);
+  });
 });

--- a/src/__tests__/protocols/hermes-protocol/options.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/options.test.ts
@@ -64,4 +64,19 @@ describe("hermesProtocol options", () => {
       text,
     ]);
   });
+
+  it("does not treat comma-delimited RJSON properties matching a custom delimiter as nested", () => {
+    const protocol = hermesProtocol({
+      toolCallStart: "name:",
+      toolCallEnd: "END",
+    });
+
+    const text = 'name:{name:"ok",arguments:{x:1,name:{a:1}}}END';
+    const out = protocol.parseGeneratedText({ text, tools: [] });
+    const toolCall = out.find((part) => part.type === "tool-call") as any;
+
+    expect(toolCall).toBeTruthy();
+    expect(toolCall.toolName).toBe("ok");
+    expect(JSON.parse(toolCall.input)).toEqual({ x: 1, name: { a: 1 } });
+  });
 });

--- a/src/__tests__/protocols/hermes-protocol/options.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/options.test.ts
@@ -79,4 +79,19 @@ describe("hermesProtocol options", () => {
     expect(toolCall.toolName).toBe("ok");
     expect(JSON.parse(toolCall.input)).toEqual({ x: 1, name: { a: 1 } });
   });
+
+  it("does not treat spaced RJSON properties matching a custom delimiter as nested", () => {
+    const protocol = hermesProtocol({
+      toolCallStart: "name:",
+      toolCallEnd: "END",
+    });
+
+    const text = 'name:{name:"ok",arguments:{x:1, name:{a:1}}}END';
+    const out = protocol.parseGeneratedText({ text, tools: [] });
+    const toolCall = out.find((part) => part.type === "tool-call") as any;
+
+    expect(toolCall).toBeTruthy();
+    expect(toolCall.toolName).toBe("ok");
+    expect(JSON.parse(toolCall.input)).toEqual({ x: 1, name: { a: 1 } });
+  });
 });

--- a/src/__tests__/protocols/hermes-protocol/options.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/options.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { hermesProtocol } from "../../../core/protocols/hermes-protocol";
+
+describe("hermesProtocol options", () => {
+  it.each([
+    "toolCallStart",
+    "toolCallEnd",
+  ] as const)("rejects an empty %s delimiter", (optionName) => {
+    expect(() => hermesProtocol({ [optionName]: "" })).toThrow(
+      `hermesProtocol ${optionName} must not be empty`
+    );
+  });
+
+  it("still accepts non-empty custom delimiters", () => {
+    const protocol = hermesProtocol({
+      toolCallStart: "[[tool]]",
+      toolCallEnd: "[[/tool]]",
+    });
+
+    const out = protocol.parseGeneratedText({
+      text: 'before [[tool]]{"name":"ok","arguments":{}}[[/tool]] after',
+      tools: [],
+    });
+
+    const toolCall = out.find((part) => part.type === "tool-call") as any;
+    expect(toolCall).toBeTruthy();
+    expect(toolCall.toolName).toBe("ok");
+    expect(JSON.parse(toolCall.input)).toEqual({});
+  });
+});

--- a/src/__tests__/protocols/hermes-protocol/options.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/options.test.ts
@@ -46,4 +46,22 @@ describe("hermesProtocol options", () => {
       text,
     ]);
   });
+
+  it("does not treat a nested RJSON property matching a custom start delimiter as nested", () => {
+    const protocol = hermesProtocol({
+      toolCallStart: "name:",
+      toolCallEnd: "END",
+    });
+
+    const text = 'name:{name:"ok",arguments:{name:{a:1}}}END';
+    const out = protocol.parseGeneratedText({ text, tools: [] });
+    const toolCall = out.find((part) => part.type === "tool-call") as any;
+
+    expect(toolCall).toBeTruthy();
+    expect(toolCall.toolName).toBe("ok");
+    expect(JSON.parse(toolCall.input)).toEqual({ name: { a: 1 } });
+    expect(protocol.extractToolCallSegments?.({ text, tools: [] })).toEqual([
+      text,
+    ]);
+  });
 });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
@@ -129,6 +129,18 @@ it("does not treat // inside a relaxed unquoted identifier as a comment", () => 
   expect(JSON.parse(tool.input)).toEqual({ path: "a//b" });
 });
 
+it("still treats // after a relaxed number literal as a comment", () => {
+  const p = hermesProtocol();
+  const text =
+    '<tool_call>{name:"x",arguments:{n:1// " </tool_call> inside comment\n}}</tool_call>';
+  const out = p.parseGeneratedText({ text, tools: [] });
+
+  const tool = out.find((x) => x.type === "tool-call") as any;
+  expect(tool).toBeTruthy();
+  expect(tool.toolName).toBe("x");
+  expect(JSON.parse(tool.input)).toEqual({ n: 1 });
+});
+
 describe("parseGeneratedText – malformed tool call recovery", () => {
   it("recovers from malformed tool call with embedded end tag but no real closing tag", () => {
     const p = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
@@ -171,6 +171,16 @@ describe("parseGeneratedText – malformed tool call recovery", () => {
   });
 });
 
+it("recovers a valid adjacent tool call after a malformed one without whitespace", () => {
+  const p = hermesProtocol();
+  const text =
+    '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}}' +
+    '<tool_call>{"name":"ok","arguments":{}}</tool_call>';
+  const out = p.parseGeneratedText({ text, tools: [] });
+  const tools = out.filter((x) => x.type === "tool-call") as any[];
+  expect(tools.map((tool) => tool.toolName)).toEqual(["ok"]);
+});
+
 describe("extractToolCallSegments – end tag inside JSON string values", () => {
   it("skips end tag embedded in a JSON string value", () => {
     const p = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
@@ -76,4 +76,92 @@ describe("parseGeneratedText – end tag inside JSON string values", () => {
     const parsed = JSON.parse(tc.input);
     expect(parsed.cmd).toBe('say "</tool_call>" ok');
   });
+
+  it("handles multiple false end tags in one string value", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"bash","arguments":{"cmd":"first </tool_call> and second </tool_call> end"}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("tool-call");
+    const tc = out[0] as any;
+    expect(tc.toolName).toBe("bash");
+    const parsed = JSON.parse(tc.input);
+    expect(parsed.cmd).toBe(
+      "first </tool_call> and second </tool_call> end"
+    );
+  });
+});
+
+describe("parseGeneratedText – malformed tool call recovery", () => {
+  it("recovers from malformed tool call with embedded end tag but no real closing tag", () => {
+    const p = hermesProtocol();
+    // First tool call has </tool_call> inside the string but no real closing tag
+    // Second tool call is valid
+    const text =
+      '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}} ' +
+      '<tool_call>{"name":"ok","arguments":{}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+    const tools = out.filter((x) => x.type === "tool-call") as any[];
+    // The valid second tool call should be parsed
+    expect(tools.length).toBeGreaterThanOrEqual(1);
+    expect(tools.some((t: any) => t.toolName === "ok")).toBe(true);
+  });
+
+  it("does not emit text twice for malformed tool call with no real closing tag", () => {
+    const p = hermesProtocol();
+    const text =
+      'prefix <tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}} suffix';
+    const out = p.parseGeneratedText({ text, tools: [] });
+    const allText = out
+      .filter((x) => x.type === "text")
+      .map((x) => (x as any).text)
+      .join("");
+    // "prefix" should appear exactly once
+    const prefixCount = (allText.match(/prefix/g) || []).length;
+    expect(prefixCount).toBe(1);
+  });
+});
+
+describe("extractToolCallSegments – end tag inside JSON string values", () => {
+  it("skips end tag embedded in a JSON string value", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"bash","arguments":{"command":"echo \'</tool_call>\' test"}}</tool_call>';
+    const segments = p.extractToolCallSegments({ text });
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toBe(text);
+  });
+
+  it("extracts multiple segments with embedded end tags correctly", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"a","arguments":{}}</tool_call>' +
+      " middle " +
+      '<tool_call>{"name":"bash","arguments":{"cmd":"</tool_call>"}}</tool_call>';
+    const segments = p.extractToolCallSegments({ text });
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toBe(
+      '<tool_call>{"name":"a","arguments":{}}</tool_call>'
+    );
+    expect(segments[1]).toBe(
+      '<tool_call>{"name":"bash","arguments":{"cmd":"</tool_call>"}}</tool_call>'
+    );
+  });
+
+  it("does not treat <tool_call> inside a JSON string as a nested start tag", () => {
+    const p = hermesProtocol();
+    // The argument value contains a literal <tool_call> tag inside a string.
+    // This should NOT cause the parser to think a nested tool call exists.
+    const text =
+      '<tool_call>{"name":"bash","arguments":{"cmd":"echo <tool_call> test"}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("bash");
+    expect(JSON.parse(tool.input).cmd).toBe("echo <tool_call> test");
+  });
 });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
+
+vi.mock("@ai-sdk/provider-utils", () => ({
+  generateId: vi.fn(() => "mock-id"),
+}));
+
+describe("parseGeneratedText – end tag inside JSON string values", () => {
+  it("does not split on </tool_call> inside a JSON string value", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"bash","arguments":{"command":"echo \'</tool_call>\' test"}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("tool-call");
+    const tc = out[0] as any;
+    expect(tc.toolName).toBe("bash");
+    expect(JSON.parse(tc.input)).toEqual({
+      command: "echo '</tool_call>' test",
+    });
+  });
+
+  it("handles multiple tool calls where one contains end tag in string value", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"a","arguments":{}}</tool_call>' +
+      " middle " +
+      '<tool_call>{"name":"bash","arguments":{"cmd":"</tool_call>"}}</tool_call>' +
+      " end";
+    const out = p.parseGeneratedText({ text, tools: [] });
+
+    const toolCalls = out.filter((e) => e.type === "tool-call") as any[];
+    const textParts = out
+      .filter((e) => e.type === "text")
+      .map((e) => (e as any).text);
+
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0].toolName).toBe("a");
+    expect(toolCalls[1].toolName).toBe("bash");
+    expect(JSON.parse(toolCalls[1].input)).toEqual({ cmd: "</tool_call>" });
+    expect(textParts.join("")).toContain("middle");
+    expect(textParts.join("")).toContain("end");
+  });
+
+  it("still parses normal tool calls correctly (regression check)", () => {
+    const p = hermesProtocol();
+    const text =
+      'before <tool_call>{"name":"get_weather","arguments":{"city":"NYC"}}</tool_call> after';
+    const out = p.parseGeneratedText({ text, tools: [] });
+
+    const toolCalls = out.filter((e) => e.type === "tool-call") as any[];
+    const textParts = out
+      .filter((e) => e.type === "text")
+      .map((e) => (e as any).text);
+
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].toolName).toBe("get_weather");
+    expect(JSON.parse(toolCalls[0].input)).toEqual({ city: "NYC" });
+    expect(textParts.join("")).toContain("before");
+    expect(textParts.join("")).toContain("after");
+  });
+
+  it("handles escaped quotes adjacent to end tag in string value", () => {
+    const p = hermesProtocol();
+    // The argument value is: say \"</tool_call>\" ok
+    const text =
+      '<tool_call>{"name":"bash","arguments":{"cmd":"say \\"</tool_call>\\" ok"}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("tool-call");
+    const tc = out[0] as any;
+    expect(tc.toolName).toBe("bash");
+    const parsed = JSON.parse(tc.input);
+    expect(parsed.cmd).toBe('say "</tool_call>" ok');
+  });
+});

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
@@ -118,6 +118,17 @@ describe("parseGeneratedText – relaxed JSON comments around tool-call tags", (
   });
 });
 
+it("does not treat // inside a relaxed unquoted identifier as a comment", () => {
+  const p = hermesProtocol();
+  const text = '<tool_call>{name:"x",arguments:{path:a//b}}</tool_call>';
+  const out = p.parseGeneratedText({ text, tools: [] });
+
+  const tool = out.find((x) => x.type === "tool-call") as any;
+  expect(tool).toBeTruthy();
+  expect(tool.toolName).toBe("x");
+  expect(JSON.parse(tool.input)).toEqual({ path: "a//b" });
+});
+
 describe("parseGeneratedText – malformed tool call recovery", () => {
   it("recovers from malformed tool call with embedded end tag but no real closing tag", () => {
     const p = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
@@ -88,9 +88,7 @@ describe("parseGeneratedText – end tag inside JSON string values", () => {
     const tc = out[0] as any;
     expect(tc.toolName).toBe("bash");
     const parsed = JSON.parse(tc.input);
-    expect(parsed.cmd).toBe(
-      "first </tool_call> and second </tool_call> end"
-    );
+    expect(parsed.cmd).toBe("first </tool_call> and second </tool_call> end");
   });
 });
 
@@ -129,7 +127,10 @@ describe("extractToolCallSegments – end tag inside JSON string values", () => 
     const p = hermesProtocol();
     const text =
       '<tool_call>{"name":"bash","arguments":{"command":"echo \'</tool_call>\' test"}}</tool_call>';
-    const segments = p.extractToolCallSegments({ text });
+    if (!p.extractToolCallSegments) {
+      throw new Error("extractToolCallSegments is not defined");
+    }
+    const segments = p.extractToolCallSegments({ text, tools: [] });
 
     expect(segments).toHaveLength(1);
     expect(segments[0]).toBe(text);
@@ -141,7 +142,10 @@ describe("extractToolCallSegments – end tag inside JSON string values", () => 
       '<tool_call>{"name":"a","arguments":{}}</tool_call>' +
       " middle " +
       '<tool_call>{"name":"bash","arguments":{"cmd":"</tool_call>"}}</tool_call>';
-    const segments = p.extractToolCallSegments({ text });
+    if (!p.extractToolCallSegments) {
+      throw new Error("extractToolCallSegments is not defined");
+    }
+    const segments = p.extractToolCallSegments({ text, tools: [] });
 
     expect(segments).toHaveLength(2);
     expect(segments[0]).toBe(

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-string-boundary.test.ts
@@ -92,6 +92,32 @@ describe("parseGeneratedText – end tag inside JSON string values", () => {
   });
 });
 
+describe("parseGeneratedText – relaxed JSON comments around tool-call tags", () => {
+  it("ignores </tool_call> and quotes inside relaxed line comments", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{name:"line_comment",arguments:{}, // " </tool_call> inside comment\n}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("line_comment");
+    expect(JSON.parse(tool.input)).toEqual({});
+  });
+
+  it("ignores <tool_call> nested-start text inside relaxed block comments", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{name:"block_comment",arguments:{}, /* ignored <tool_call> text */}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("block_comment");
+    expect(JSON.parse(tool.input)).toEqual({});
+  });
+});
+
 describe("parseGeneratedText – malformed tool call recovery", () => {
   it("recovers from malformed tool call with embedded end tag but no real closing tag", () => {
     const p = hermesProtocol();
@@ -167,5 +193,24 @@ describe("extractToolCallSegments – end tag inside JSON string values", () => 
     expect(tool).toBeTruthy();
     expect(tool.toolName).toBe("bash");
     expect(JSON.parse(tool.input).cmd).toBe("echo <tool_call> test");
+  });
+
+  it("ignores relaxed comments while extracting tool-call segments", () => {
+    const p = hermesProtocol();
+    if (!p.extractToolCallSegments) {
+      throw new Error("extractToolCallSegments is not defined");
+    }
+
+    const lineComment =
+      '<tool_call>{name:"line_comment",arguments:{}, // " </tool_call> inside comment\n}</tool_call>';
+    const blockComment =
+      '<tool_call>{name:"block_comment",arguments:{}, /* ignored <tool_call> text */}</tool_call>';
+
+    const segments = p.extractToolCallSegments({
+      text: `${lineComment} between ${blockComment}`,
+      tools: [],
+    });
+
+    expect(segments).toEqual([lineComment, blockComment]);
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -410,6 +410,66 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(JSON.parse(toolCall.input)).toEqual({});
   });
 
+  it("still treats // after a relaxed number literal as a comment", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{name:"x",arguments:{n:1// " </tool_call> inside comment\n}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("x");
+    expect(JSON.parse(tool.input)).toEqual({ n: 1 });
+  });
+
+  it("does not treat a nested RJSON property matching a custom start delimiter as nested in streams", async () => {
+    const protocol = hermesProtocol({
+      toolCallStart: "name:",
+      toolCallEnd: "END",
+    });
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: 'name:{name:"ok",arguments:{name:{a:1}}}END',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const toolCall = out.find((c) => c.type === "tool-call") as any;
+    expect(toolCall).toBeTruthy();
+    expect(toolCall.toolName).toBe("ok");
+    expect(JSON.parse(toolCall.input)).toEqual({ name: { a: 1 } });
+  });
+
   it("reports and optionally emits raw text when recovering after a malformed nested start", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -70,7 +70,7 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
         ctrl.enqueue({
           type: "text-delta",
           id: "1",
-          delta: '\' test"}}</tool_call>',
+          delta: "' test\"}}</tool_call>",
         });
         ctrl.enqueue({
           type: "finish",
@@ -183,7 +183,8 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
         ctrl.enqueue({
           type: "text-delta",
           id: "1",
-          delta: '<tool_call>{"name":"get_weather","arguments":{"city":"NYC"}}</tool_call>',
+          delta:
+            '<tool_call>{"name":"get_weather","arguments":{"city":"NYC"}}</tool_call>',
         });
         ctrl.enqueue({
           type: "text-delta",
@@ -216,7 +217,6 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(text).not.toContain("<tool_call>");
     expect(text).not.toContain("</tool_call>");
   });
-
 
   it("parses the first tool call cleanly when </tool_call> appears inside its JSON string value", async () => {
     const protocol = hermesProtocol();
@@ -292,9 +292,7 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     const out = await convertReadableStreamToArray(
       pipeWithTransformer(rs, transformer)
     );
-    const toolCalls = out.filter(
-      (c) => c.type === "tool-input-start"
-    ) as any[];
+    const toolCalls = out.filter((c) => c.type === "tool-input-start") as any[];
     expect(toolCalls.find((c) => c.toolName === "bash")).toBeDefined();
     expect(toolCalls.find((c) => c.toolName === "ok")).toBeDefined();
   });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -470,6 +470,37 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(JSON.parse(toolCall.input)).toEqual({ name: { a: 1 } });
   });
 
+  it("does not treat comma-delimited RJSON properties matching a custom delimiter as nested in streams", async () => {
+    const protocol = hermesProtocol({
+      toolCallStart: "name:",
+      toolCallEnd: "END",
+    });
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: 'name:{name:"ok",arguments:{x:1,name:{a:1}}}END',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const toolCall = out.find((c) => c.type === "tool-call") as any;
+    expect(toolCall).toBeTruthy();
+    expect(toolCall.toolName).toBe("ok");
+    expect(JSON.parse(toolCall.input)).toEqual({ x: 1, name: { a: 1 } });
+  });
+
   it("reports and optionally emits raw text when recovering after a malformed nested start", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -218,11 +218,11 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
   });
 
 
-  it("handles malformed tool call followed by valid one in same chunk", async () => {
+  it("parses the first tool call cleanly when </tool_call> appears inside its JSON string value", async () => {
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({ tools: [] });
-    // Malformed: has </tool_call> inside string but no real closing tag
-    // Valid: proper tool call immediately after
+    // First tool call has a literal </tool_call> inside a JSON string value;
+    // the parser must skip that end tag and close on the real one.
     const rs = new ReadableStream<LanguageModelV3StreamPart>({
       start(ctrl) {
         ctrl.enqueue({
@@ -244,10 +244,94 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     const out = await convertReadableStreamToArray(
       pipeWithTransformer(rs, transformer)
     );
-    // The valid tool call should eventually be parsed (possibly after
-    // the malformed one is emitted as text at finish time)
-    const toolCalls = out.filter((c) => c.type === "tool-call") as any[];
-    // At minimum, the stream should not crash or hang
     expect(out.some((c) => c.type === "finish")).toBe(true);
+    expect(out.filter((c) => c.type === "finish").length).toBe(1);
+
+    // The first tool call must be parsed with the inner </tool_call>
+    // preserved inside its arguments (not truncated by the false end tag).
+    const toolInputStart = out.find(
+      (c) => c.type === "tool-input-start"
+    ) as any;
+    expect(toolInputStart).toBeDefined();
+    expect(toolInputStart.toolName).toBe("bash");
+
+    const deltas = out
+      .filter((c) => c.type === "tool-input-delta")
+      .map((c) => (c as any).delta)
+      .join("");
+    expect(deltas).toContain('"x </tool_call> y"');
+  });
+
+  // Known limitation (tracked as follow-up): once the first <tool_call> in
+  // a stream has been closed, a second <tool_call> that appears later in
+  // the same chunk is not currently parsed. Recovery requires the streaming
+  // parser to re-enter scanning mode for new start tags after closing a
+  // tool call mid-chunk. The non-streaming parseGeneratedText already
+  // handles this correctly via findNextToolCallSpan.
+  it.skip("parses a second <tool_call> that follows a fully closed first one in the same chunk", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}} ' +
+            '<tool_call>{"name":"ok","arguments":{}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const toolCalls = out.filter(
+      (c) => c.type === "tool-input-start"
+    ) as any[];
+    expect(toolCalls.find((c) => c.toolName === "bash")).toBeDefined();
+    expect(toolCalls.find((c) => c.toolName === "ok")).toBeDefined();
+  });
+
+  // Known limitation (tracked as follow-up): when the first <tool_call> in a
+  // stream is unclosed before a second <tool_call> start tag appears, the
+  // second tool call is currently not recovered. A fix requires incremental
+  // JSON boundary detection inside the streaming parser (the non-streaming
+  // parseGeneratedText already does this via findNextToolCallSpan).
+  it.skip("recovers a valid tool call that follows an unclosed/malformed one", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"bash","arguments":{"cmd":"oops ' +
+            '<tool_call>{"name":"ok","arguments":{}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.some((c) => c.type === "finish")).toBe(true);
+
+    const toolCalls = out.filter((c) => c.type === "tool-call") as any[];
+    const okCall = toolCalls.find((c) => c.toolName === "ok");
+    expect(okCall).toBeDefined();
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -170,6 +170,35 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     });
   });
 
+  it("ignores </tool_call> and quotes inside relaxed line comments", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{name:"line_comment",arguments:{}, // " </tool_call> inside comment\n}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("line_comment");
+    expect(JSON.parse(tool.input)).toEqual({});
+  });
+
   it("still parses normal streaming tool calls correctly (regression check)", async () => {
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({ tools: [] });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -560,6 +560,34 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(toolCalls.map((c) => c.toolName)).toEqual(["ok"]);
   });
 
+  it("recovers a valid tool call after an unterminated relaxed block comment consumes an end tag", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{name:"bad",arguments:{n:1/*x}}</tool_call>' +
+            '<tool_call>{"name":"ok","arguments":{}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const toolCalls = out.filter((c) => c.type === "tool-call") as any[];
+    expect(toolCalls.map((c) => c.toolName)).toEqual(["ok"]);
+  });
+
   it("reports and optionally emits raw text when recovering after a malformed nested start", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -199,6 +199,39 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(JSON.parse(tool.input)).toEqual({});
   });
 
+  it("ignores </tool_call> inside a relaxed block comment split across chunks", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{name:"block_comment",arguments:{}, /* " </tool_',
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: "call> inside comment */}</tool_call>",
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("block_comment");
+    expect(JSON.parse(tool.input)).toEqual({});
+  });
+
   it("still parses normal streaming tool calls correctly (regression check)", async () => {
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({ tools: [] });
@@ -247,7 +280,7 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(text).not.toContain("</tool_call>");
   });
 
-  it("parses the first tool call cleanly when </tool_call> appears inside its JSON string value", async () => {
+  it("parses adjacent tool calls when the first contains </tool_call> inside its JSON string value", async () => {
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({ tools: [] });
     // First tool call has a literal </tool_call> inside a JSON string value;
@@ -258,7 +291,7 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
           type: "text-delta",
           id: "1",
           delta:
-            '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}} ' +
+            '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}}</tool_call>' +
             '<tool_call>{"name":"ok","arguments":{}}</tool_call>',
         });
         ctrl.enqueue({
@@ -284,20 +317,13 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(toolInputStart).toBeDefined();
     expect(toolInputStart.toolName).toBe("bash");
 
-    const deltas = out
-      .filter((c) => c.type === "tool-input-delta")
-      .map((c) => (c as any).delta)
-      .join("");
-    expect(deltas).toContain('"x </tool_call> y"');
+    const toolCalls = out.filter((c) => c.type === "tool-call") as any[];
+    expect(toolCalls.map((c) => c.toolName)).toEqual(["bash", "ok"]);
+    expect(JSON.parse(toolCalls[0].input)).toEqual({ cmd: "x </tool_call> y" });
+    expect(JSON.parse(toolCalls[1].input)).toEqual({});
   });
 
-  // Known limitation (tracked as follow-up): once the first <tool_call> in
-  // a stream has been closed, a second <tool_call> that appears later in
-  // the same chunk is not currently parsed. Recovery requires the streaming
-  // parser to re-enter scanning mode for new start tags after closing a
-  // tool call mid-chunk. The non-streaming parseGeneratedText already
-  // handles this correctly via findNextToolCallSpan.
-  it.skip("parses a second <tool_call> that follows a fully closed first one in the same chunk", async () => {
+  it("parses a second <tool_call> that follows a fully closed first one in the same chunk", async () => {
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({ tools: [] });
     const rs = new ReadableStream<LanguageModelV3StreamPart>({
@@ -306,7 +332,7 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
           type: "text-delta",
           id: "1",
           delta:
-            '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}} ' +
+            '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}}</tool_call>' +
             '<tool_call>{"name":"ok","arguments":{}}</tool_call>',
         });
         ctrl.enqueue({
@@ -321,17 +347,11 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     const out = await convertReadableStreamToArray(
       pipeWithTransformer(rs, transformer)
     );
-    const toolCalls = out.filter((c) => c.type === "tool-input-start") as any[];
-    expect(toolCalls.find((c) => c.toolName === "bash")).toBeDefined();
-    expect(toolCalls.find((c) => c.toolName === "ok")).toBeDefined();
+    const toolCalls = out.filter((c) => c.type === "tool-call") as any[];
+    expect(toolCalls.map((c) => c.toolName)).toEqual(["bash", "ok"]);
   });
 
-  // Known limitation (tracked as follow-up): when the first <tool_call> in a
-  // stream is unclosed before a second <tool_call> start tag appears, the
-  // second tool call is currently not recovered. A fix requires incremental
-  // JSON boundary detection inside the streaming parser (the non-streaming
-  // parseGeneratedText already does this via findNextToolCallSpan).
-  it.skip("recovers a valid tool call that follows an unclosed/malformed one", async () => {
+  it("recovers a valid tool call that follows an unclosed/malformed one", async () => {
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({ tools: [] });
     const rs = new ReadableStream<LanguageModelV3StreamPart>({
@@ -340,7 +360,7 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
           type: "text-delta",
           id: "1",
           delta:
-            '<tool_call>{"name":"bash","arguments":{"cmd":"oops ' +
+            '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}} ' +
             '<tool_call>{"name":"ok","arguments":{}}</tool_call>',
         });
         ctrl.enqueue({

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -92,6 +92,84 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     });
   });
 
+  it("handles chunk split in the middle of an escape sequence", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    // The value is: say \"</tool_call>\" ok
+    // We split the chunk right between the backslash and the quote
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"bash","arguments":{"cmd":"say \\',
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '"</tool_call>\\',
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '" ok"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("bash");
+    expect(JSON.parse(tool.input)).toEqual({
+      cmd: 'say "</tool_call>" ok',
+    });
+  });
+
+  it("handles multiple false end tags in one string value (streaming)", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"bash","arguments":{"cmd":"first </tool_call>',
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: ' and second </tool_call> end"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("bash");
+    expect(JSON.parse(tool.input)).toEqual({
+      cmd: "first </tool_call> and second </tool_call> end",
+    });
+  });
+
   it("still parses normal streaming tool calls correctly (regression check)", async () => {
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({ tools: [] });
@@ -137,5 +215,39 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(text).toContain("after");
     expect(text).not.toContain("<tool_call>");
     expect(text).not.toContain("</tool_call>");
+  });
+
+
+  it("handles malformed tool call followed by valid one in same chunk", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    // Malformed: has </tool_call> inside string but no real closing tag
+    // Valid: proper tool call immediately after
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}} ' +
+            '<tool_call>{"name":"ok","arguments":{}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    // The valid tool call should eventually be parsed (possibly after
+    // the malformed one is emitted as text at finish time)
+    const toolCalls = out.filter((c) => c.type === "tool-call") as any[];
+    // At minimum, the stream should not crash or hang
+    expect(out.some((c) => c.type === "finish")).toBe(true);
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -532,6 +532,34 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(JSON.parse(toolCall.input)).toEqual({ x: 1, name: { a: 1 } });
   });
 
+  it("recovers a valid tool call after an unterminated relaxed line comment consumes an end tag", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{name:"bad",arguments:{n:1//x}}</tool_call>' +
+            '<tool_call>{"name":"ok","arguments":{}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const toolCalls = out.filter((c) => c.type === "tool-call") as any[];
+    expect(toolCalls.map((c) => c.toolName)).toEqual(["ok"]);
+  });
+
   it("reports and optionally emits raw text when recovering after a malformed nested start", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -1,0 +1,141 @@
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
+import { describe, expect, it, vi } from "vitest";
+import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
+import {
+  pipeWithTransformer,
+  stopFinishReason,
+  zeroUsage,
+} from "../../../test-helpers";
+
+vi.mock("@ai-sdk/provider-utils", () => ({
+  generateId: vi.fn(() => "mock-id"),
+}));
+
+describe("hermesProtocol streaming – end tag inside JSON string values", () => {
+  it("does not split on </tool_call> inside a JSON string value (single chunk)", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"bash","arguments":{"command":"echo \'</tool_call>\' test"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("bash");
+    expect(JSON.parse(tool.input)).toEqual({
+      command: "echo '</tool_call>' test",
+    });
+
+    // No tool-call content should leak into text output
+    const text = out
+      .filter((c) => c.type === "text-delta")
+      .map((c) => (c as any).delta)
+      .join("");
+    expect(text).not.toContain("<tool_call>");
+    expect(text).not.toContain("</tool_call>");
+  });
+
+  it("does not split on </tool_call> inside a JSON string value split across chunks", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"bash","arguments":{"command":"echo \'',
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: "</tool_call>",
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '\' test"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("bash");
+    expect(JSON.parse(tool.input)).toEqual({
+      command: "echo '</tool_call>' test",
+    });
+  });
+
+  it("still parses normal streaming tool calls correctly (regression check)", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: "before ",
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"get_weather","arguments":{"city":"NYC"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: " after",
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("get_weather");
+    expect(JSON.parse(tool.input)).toEqual({ city: "NYC" });
+
+    const text = out
+      .filter((c) => c.type === "text-delta")
+      .map((c) => (c as any).delta)
+      .join("");
+    expect(text).toContain("before");
+    expect(text).toContain("after");
+    expect(text).not.toContain("<tool_call>");
+    expect(text).not.toContain("</tool_call>");
+  });
+});

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -351,6 +351,37 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(toolCalls.map((c) => c.toolName)).toEqual(["bash", "ok"]);
   });
 
+  it("does not treat an unquoted RJSON key matching a custom start delimiter as nested in streams", async () => {
+    const protocol = hermesProtocol({
+      toolCallStart: "name",
+      toolCallEnd: "END",
+    });
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: 'name{name:"ok",arguments:{}}END',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const toolCall = out.find((c) => c.type === "tool-call") as any;
+    expect(toolCall).toBeTruthy();
+    expect(toolCall.toolName).toBe("ok");
+    expect(JSON.parse(toolCall.input)).toEqual({});
+  });
+
   it("reports and optionally emits raw text when recovering after a malformed nested start", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -588,6 +588,34 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(toolCalls.map((c) => c.toolName)).toEqual(["ok"]);
   });
 
+  it("recovers a valid adjacent tool call after a malformed one without whitespace", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}}' +
+            '<tool_call>{"name":"ok","arguments":{}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const toolCalls = out.filter((c) => c.type === "tool-call") as any[];
+    expect(toolCalls.map((c) => c.toolName)).toEqual(["ok"]);
+  });
+
   it("reports and optionally emits raw text when recovering after a malformed nested start", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -547,7 +547,10 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
       toolName: "bash",
       dropReason: "malformed-nested-tool-call",
     });
-    expect(metadata.toolCallId).toEqual(expect.any(String));
+    expect(
+      metadata.toolCallId === undefined ||
+        typeof metadata.toolCallId === "string"
+    ).toBe(true);
   });
 
   it("recovers a valid tool call that follows an unclosed/malformed one", async () => {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -501,6 +501,37 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(JSON.parse(toolCall.input)).toEqual({ x: 1, name: { a: 1 } });
   });
 
+  it("does not treat spaced RJSON properties matching a custom delimiter as nested in streams", async () => {
+    const protocol = hermesProtocol({
+      toolCallStart: "name:",
+      toolCallEnd: "END",
+    });
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: 'name:{name:"ok",arguments:{x:1, name:{a:1}}}END',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const toolCall = out.find((c) => c.type === "tool-call") as any;
+    expect(toolCall).toBeTruthy();
+    expect(toolCall.toolName).toBe("ok");
+    expect(JSON.parse(toolCall.input)).toEqual({ x: 1, name: { a: 1 } });
+  });
+
   it("reports and optionally emits raw text when recovering after a malformed nested start", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -351,6 +351,55 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     expect(toolCalls.map((c) => c.toolName)).toEqual(["bash", "ok"]);
   });
 
+  it("reports and optionally emits raw text when recovering after a malformed nested start", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [],
+      options: { onError, emitRawToolCallTextOnError: true },
+    });
+    const malformedPrefix =
+      '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}} ';
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: `${malformedPrefix}<tool_call>{"name":"ok","arguments":{}}</tool_call>`,
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+
+    const text = out
+      .filter((c) => c.type === "text-delta")
+      .map((c) => (c as any).delta)
+      .join("");
+    expect(text).toContain(malformedPrefix);
+
+    const toolCalls = out.filter((c) => c.type === "tool-call") as any[];
+    expect(toolCalls.map((c) => c.toolName)).toEqual(["ok"]);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [message, metadata] = onError.mock.calls[0];
+    expect(message).toContain("emitting original text");
+    expect(metadata).toMatchObject({
+      toolCall: malformedPrefix,
+      toolName: "bash",
+      dropReason: "malformed-nested-tool-call",
+    });
+    expect(metadata.toolCallId).toEqual(expect.any(String));
+  });
+
   it("recovers a valid tool call that follows an unclosed/malformed one", async () => {
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({ tools: [] });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-string-boundary.test.ts
@@ -170,6 +170,34 @@ describe("hermesProtocol streaming – end tag inside JSON string values", () =>
     });
   });
 
+  it("does not treat // inside a relaxed unquoted identifier as a comment", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{name:"x",arguments:{path:a//b}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("x");
+    expect(JSON.parse(tool.input)).toEqual({ path: "a//b" });
+  });
+
   it("ignores </tool_call> and quotes inside relaxed line comments", async () => {
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({ tools: [] });

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -101,7 +101,9 @@ function startsRjsonComment(
  */
 function hasNestedStartBoundary(segment: string, startIndex: number): boolean {
   const previous = segment[startIndex - 1];
-  return previous == null || WHITESPACE_JSON_REGEX.test(previous);
+  return (
+    previous == null || WHITESPACE_JSON_REGEX.test(previous) || previous === "}"
+  );
 }
 
 function isLikelyNestedToolCallStart(

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -1055,6 +1055,74 @@ function processTagMatch(context: TagProcessingContext) {
   }
 }
 
+function recoverNestedStreamingToolCall(options: {
+  context: TagProcessingContext;
+  jsonSoFar: string;
+  nestedStartIndex: number;
+  startIndex: number;
+  tag: string;
+}): number | null {
+  const { context, jsonSoFar, nestedStartIndex, startIndex, tag } = options;
+  const {
+    state,
+    controller,
+    toolCallStart,
+    toolCallEnd,
+    options: parserOptions,
+  } = context;
+  const droppedToolCall = `${toolCallStart}${jsonSoFar.slice(
+    0,
+    nestedStartIndex
+  )}`;
+  const shouldEmitRawFallback = shouldEmitRawToolCallTextOnError(parserOptions);
+  const streamingToolCallId = state.activeToolInput?.id;
+  const streamingToolName =
+    state.activeToolInput?.toolName ??
+    extractStreamingToolCallProgress(jsonSoFar.slice(0, nestedStartIndex))
+      .toolName;
+
+  logParseFailure({
+    phase: "stream",
+    reason: "Abandoning malformed streaming tool call before nested start tag",
+    snippet: droppedToolCall,
+  });
+  if (shouldEmitRawFallback) {
+    const errorId = generateId();
+    controller.enqueue({
+      type: "text-start",
+      id: errorId,
+    } as LanguageModelV3StreamPart);
+    controller.enqueue({
+      type: "text-delta",
+      id: errorId,
+      delta: droppedToolCall,
+    } as LanguageModelV3StreamPart);
+    controller.enqueue({
+      type: "text-end",
+      id: errorId,
+    } as LanguageModelV3StreamPart);
+  }
+  closeToolInput(state, controller);
+  parserOptions?.onError?.(
+    shouldEmitRawFallback
+      ? "Could not process malformed streaming JSON tool call before nested start; emitting original text."
+      : "Could not process malformed streaming JSON tool call before nested start.",
+    {
+      toolCall: droppedToolCall,
+      toolCallId: streamingToolCallId,
+      toolName: streamingToolName,
+      dropReason: "malformed-nested-tool-call",
+    }
+  );
+  state.currentToolCallJson = "";
+  state.isInsideToolCall = false;
+  state.buffer =
+    jsonSoFar.slice(nestedStartIndex) +
+    toolCallEnd +
+    state.buffer.slice(startIndex + tag.length);
+  return getPotentialStartIndex(state.buffer, toolCallStart);
+}
+
 function processBufferTags(context: TagProcessingContext) {
   const { state, controller, toolCallStart, toolCallEnd, tools } = context;
   let startIndex = getPotentialStartIndex(
@@ -1096,20 +1164,13 @@ function processBufferTags(context: TagProcessingContext) {
         toolCallStart
       );
       if (nestedStartIndex !== null) {
-        logParseFailure({
-          phase: "stream",
-          reason:
-            "Abandoning malformed streaming tool call before nested start tag",
-          snippet: `${toolCallStart}${jsonSoFar.slice(0, nestedStartIndex)}`,
+        startIndex = recoverNestedStreamingToolCall({
+          context,
+          jsonSoFar,
+          nestedStartIndex,
+          startIndex,
+          tag,
         });
-        closeToolInput(state, controller);
-        state.currentToolCallJson = "";
-        state.isInsideToolCall = false;
-        state.buffer =
-          jsonSoFar.slice(nestedStartIndex) +
-          toolCallEnd +
-          state.buffer.slice(startIndex + tag.length);
-        startIndex = getPotentialStartIndex(state.buffer, toolCallStart);
         continue;
       }
     }

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -89,67 +89,6 @@ function startsRjsonComment(
 }
 
 /**
- * Returns true if the current position in `json` is inside syntax that can
- * legally contain literal tool-call tag text: a relaxed-JSON string or
- * comment. `parseRJSON` supports `// ...` and block comments, so tag-boundary
- * detection must ignore quotes and tag-looking text inside those comments.
- */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Relaxed JSON boundary scanning must track strings, escapes, and comments.
-function isInsideRjsonStringOrComment(json: string): boolean {
-  let quote: '"' | "'" | null = null;
-  let esc = false;
-
-  for (let i = 0; i < json.length; i += 1) {
-    const ch = json[i];
-
-    if (esc) {
-      esc = false;
-      continue;
-    }
-
-    if (quote !== null) {
-      if (ch === "\\") {
-        esc = true;
-        continue;
-      }
-      if (ch === quote) {
-        quote = null;
-      }
-      continue;
-    }
-
-    if (startsRjsonComment(json, i) && json[i + 1] === "/") {
-      i += 2;
-      while (i < json.length && json[i] !== "\n" && json[i] !== "\r") {
-        i += 1;
-      }
-      if (i >= json.length) {
-        return true;
-      }
-      continue;
-    }
-
-    if (startsRjsonComment(json, i) && json[i + 1] === "*") {
-      i += 2;
-      while (i + 1 < json.length && !(json[i] === "*" && json[i + 1] === "/")) {
-        i += 1;
-      }
-      if (i + 1 >= json.length) {
-        return true;
-      }
-      i += 1;
-      continue;
-    }
-
-    if (ch === '"' || ch === "'") {
-      quote = ch;
-    }
-  }
-
-  return quote !== null;
-}
-
-/**
  * Detect whether `segment` contains an occurrence of `startTag` outside any
  * relaxed-JSON string or comment. Used to identify nested `<tool_call>` start
  * tags that indicate the current tool call's `</tool_call>` actually belongs
@@ -171,62 +110,24 @@ function isLikelyNestedToolCallStart(
   );
 }
 
-function findOuterToolCallStartIndex(
-  segment: string,
-  startTag: string
-): number | null {
-  let pos = 0;
-  while (pos < segment.length) {
-    const next = segment.indexOf(startTag, pos);
-    if (next === -1) {
-      return null;
-    }
-    if (
-      !isInsideRjsonStringOrComment(segment.slice(0, next)) &&
-      isLikelyNestedToolCallStart(segment, next, startTag)
-    ) {
-      return next;
-    }
-    pos = next + 1;
-  }
-  return null;
-}
+type ToolCallBoundary =
+  | { kind: "end"; endIdx: number }
+  | { kind: "nested"; endIdx: number; nestedStartIndex: number };
 
-/**
- * Locate the next valid `<tool_call>...</tool_call>` span in `text` starting
- * at `searchFrom`. Skips `</tool_call>` sequences that occur inside
- * relaxed-JSON strings or comments, and bails out when a nested `<tool_call>`
- * start tag appears outside a string/comment (treating the current start tag
- * as orphaned — its presumed close belongs to a later call).
- *
- * Returns:
- *   - `null`: no more start tags in the remaining text
- *   - `{ startIdx, found: true, jsonStart, endIdx }`: a valid span
- *   - `{ startIdx, found: false }`: an orphan start tag (caller should skip
- *     past it and resume scanning)
- */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Tool-call span scanning tracks relaxed JSON string/comment state and tag boundaries in one pass.
-function findNextToolCallSpan(
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Boundary scanning tracks relaxed JSON string/comment state and two delimiter types in one pass.
+function findToolCallBoundaryOutsideRjsonSyntax(
   text: string,
-  searchFrom: number,
+  scanFrom: number,
   startTag: string,
   endTag: string
-):
-  | { startIdx: number; found: true; jsonStart: number; endIdx: number }
-  | { startIdx: number; found: false }
-  | null {
-  const startIdx = text.indexOf(startTag, searchFrom);
-  if (startIdx === -1) {
-    return null;
-  }
-  const jsonStart = startIdx + startTag.length;
-
+): ToolCallBoundary | null {
   let quote: '"' | "'" | null = null;
   let esc = false;
   let inLineComment = false;
   let inBlockComment = false;
+  let nestedStartIndex: number | null = null;
 
-  for (let index = jsonStart; index < text.length; index += 1) {
+  for (let index = scanFrom; index < text.length; index += 1) {
     const ch = text[index];
 
     if (esc) {
@@ -260,7 +161,7 @@ function findNextToolCallSpan(
       continue;
     }
 
-    if (startsRjsonComment(text, index, jsonStart)) {
+    if (startsRjsonComment(text, index, scanFrom)) {
       if (text[index + 1] === "/") {
         inLineComment = true;
         index += 1;
@@ -274,16 +175,19 @@ function findNextToolCallSpan(
     }
 
     if (text.startsWith(endTag, index)) {
-      return { startIdx, found: true, jsonStart, endIdx: index };
+      return nestedStartIndex == null
+        ? { kind: "end", endIdx: index }
+        : { kind: "nested", endIdx: index, nestedStartIndex };
     }
 
     if (
+      nestedStartIndex == null &&
       text.startsWith(startTag, index) &&
       isLikelyNestedToolCallStart(text, index, startTag)
     ) {
-      // Nested <tool_call> outside a string/comment — abandon this
-      // start; its presumed </tool_call> belongs to a later call.
-      return { startIdx, found: false };
+      nestedStartIndex = index;
+      index += startTag.length - 1;
+      continue;
     }
 
     if (ch === '"' || ch === "'") {
@@ -291,7 +195,52 @@ function findNextToolCallSpan(
     }
   }
 
-  return { startIdx, found: false };
+  return null;
+}
+
+/**
+ * Locate the next valid `<tool_call>...</tool_call>` span in `text` starting
+ * at `searchFrom`. Skips `</tool_call>` sequences that occur inside
+ * relaxed-JSON strings or comments, and bails out when a nested `<tool_call>`
+ * start tag appears outside a string/comment (treating the current start tag
+ * as orphaned — its presumed close belongs to a later call).
+ *
+ * Returns:
+ *   - `null`: no more start tags in the remaining text
+ *   - `{ startIdx, found: true, jsonStart, endIdx }`: a valid span
+ *   - `{ startIdx, found: false }`: an orphan start tag (caller should skip
+ *     past it and resume scanning)
+ */
+function findNextToolCallSpan(
+  text: string,
+  searchFrom: number,
+  startTag: string,
+  endTag: string
+):
+  | { startIdx: number; found: true; jsonStart: number; endIdx: number }
+  | { startIdx: number; found: false }
+  | null {
+  const startIdx = text.indexOf(startTag, searchFrom);
+  if (startIdx === -1) {
+    return null;
+  }
+  const jsonStart = startIdx + startTag.length;
+
+  const boundary = findToolCallBoundaryOutsideRjsonSyntax(
+    text,
+    jsonStart,
+    startTag,
+    endTag
+  );
+  if (boundary == null) {
+    return { startIdx, found: false };
+  }
+  if (boundary.kind === "nested") {
+    // Nested <tool_call> outside a string/comment — abandon this
+    // start; its presumed </tool_call> belongs to a later call.
+    return { startIdx, found: false };
+  }
+  return { startIdx, found: true, jsonStart, endIdx: boundary.endIdx };
 }
 
 function canonicalizeToolInput(argumentsValue: unknown): string {
@@ -1243,66 +1192,74 @@ function recoverNestedStreamingToolCall(options: {
   return getPotentialStartIndex(state.buffer, toolCallStart);
 }
 
-function processBufferTags(context: TagProcessingContext) {
+function processInsideToolCallBoundary(context: TagProcessingContext): boolean {
   const { state, controller, toolCallStart, toolCallEnd, tools } = context;
-  let startIndex = getPotentialStartIndex(
-    state.buffer,
-    state.isInsideToolCall ? toolCallEnd : toolCallStart
+  const currentLength = state.currentToolCallJson.length;
+  const combined = state.currentToolCallJson + state.buffer;
+  const boundary = findToolCallBoundaryOutsideRjsonSyntax(
+    combined,
+    0,
+    toolCallStart,
+    toolCallEnd
   );
+  if (boundary == null) {
+    return false;
+  }
+
+  const relativeEndIndex = boundary.endIdx - currentLength;
+  if (relativeEndIndex < 0) {
+    return false;
+  }
+
+  if (boundary.kind === "nested") {
+    recoverNestedStreamingToolCall({
+      context,
+      jsonSoFar: combined.slice(0, boundary.endIdx),
+      nestedStartIndex: boundary.nestedStartIndex,
+      startIndex: relativeEndIndex,
+      tag: toolCallEnd,
+    });
+    return true;
+  }
+
+  publishText(
+    state.buffer.slice(0, relativeEndIndex),
+    state,
+    controller,
+    tools
+  );
+  state.buffer = state.buffer.slice(relativeEndIndex + toolCallEnd.length);
+  processTagMatch(context);
+  return true;
+}
+
+function processBufferTags(context: TagProcessingContext) {
+  const { state, controller, toolCallStart, tools } = context;
+
+  while (state.isInsideToolCall) {
+    if (!processInsideToolCallBoundary(context)) {
+      return;
+    }
+  }
+
+  let startIndex = getPotentialStartIndex(state.buffer, toolCallStart);
 
   while (startIndex != null) {
-    const tag = state.isInsideToolCall ? toolCallEnd : toolCallStart;
-    if (startIndex + tag.length > state.buffer.length) {
+    if (startIndex + toolCallStart.length > state.buffer.length) {
       break;
     }
 
-    // When inside a tool call and we found an end tag, check whether
-    // it falls inside a relaxed-JSON string/comment. If so, consume it
-    // as content rather than treating it as a real closing tag.
-    if (state.isInsideToolCall) {
-      const jsonSoFar =
-        state.currentToolCallJson + state.buffer.slice(0, startIndex);
-      if (isInsideRjsonStringOrComment(jsonSoFar)) {
-        // Consume through the false end tag as tool-call JSON content
-        const consumeEnd = startIndex + tag.length;
-        publishText(
-          state.buffer.slice(0, consumeEnd),
-          state,
-          controller,
-          tools
-        );
-        state.buffer = state.buffer.slice(consumeEnd);
-        startIndex = getPotentialStartIndex(
-          state.buffer,
-          state.isInsideToolCall ? toolCallEnd : toolCallStart
-        );
-        continue;
-      }
+    publishText(state.buffer.slice(0, startIndex), state, controller, tools);
+    state.buffer = state.buffer.slice(startIndex + toolCallStart.length);
+    processTagMatch(context);
 
-      const nestedStartIndex = findOuterToolCallStartIndex(
-        jsonSoFar,
-        toolCallStart
-      );
-      if (nestedStartIndex !== null) {
-        startIndex = recoverNestedStreamingToolCall({
-          context,
-          jsonSoFar,
-          nestedStartIndex,
-          startIndex,
-          tag,
-        });
-        continue;
+    while (state.isInsideToolCall) {
+      if (!processInsideToolCallBoundary(context)) {
+        return;
       }
     }
 
-    publishText(state.buffer.slice(0, startIndex), state, controller, tools);
-    state.buffer = state.buffer.slice(startIndex + tag.length);
-    processTagMatch(context);
-
-    startIndex = getPotentialStartIndex(
-      state.buffer,
-      state.isInsideToolCall ? toolCallEnd : toolCallStart
-    );
+    startIndex = getPotentialStartIndex(state.buffer, toolCallStart);
   }
 }
 

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -50,6 +50,67 @@ function isInsideJsonString(json: string): boolean {
   return inStr;
 }
 
+/**
+ * Detect whether `segment` contains an occurrence of `startTag` outside any
+ * JSON string literal. Used to identify nested `<tool_call>` start tags that
+ * indicate the current tool call's `</tool_call>` actually belongs to a later
+ * tool call (i.e. the current call is orphaned / malformed).
+ */
+function hasOuterToolCallStart(segment: string, startTag: string): boolean {
+  let pos = 0;
+  while (pos < segment.length) {
+    const next = segment.indexOf(startTag, pos);
+    if (next === -1) return false;
+    if (!isInsideJsonString(segment.slice(0, next))) return true;
+    pos = next + 1;
+  }
+  return false;
+}
+
+/**
+ * Locate the next valid `<tool_call>...</tool_call>` span in `text` starting
+ * at `searchFrom`. Skips `</tool_call>` sequences that occur inside JSON
+ * string literals, and bails out when a nested `<tool_call>` start tag
+ * appears outside a JSON string (treating the current start tag as orphaned
+ * — its presumed close belongs to a later call).
+ *
+ * Returns:
+ *   - `null`: no more start tags in the remaining text
+ *   - `{ startIdx, found: true, jsonStart, endIdx }`: a valid span
+ *   - `{ startIdx, found: false }`: an orphan start tag (caller should skip
+ *     past it and resume scanning)
+ */
+function findNextToolCallSpan(
+  text: string,
+  searchFrom: number,
+  startTag: string,
+  endTag: string,
+):
+  | { startIdx: number; found: true; jsonStart: number; endIdx: number }
+  | { startIdx: number; found: false }
+  | null {
+  const startIdx = text.indexOf(startTag, searchFrom);
+  if (startIdx === -1) return null;
+  const jsonStart = startIdx + startTag.length;
+
+  let endIdx = jsonStart;
+  while (endIdx < text.length) {
+    endIdx = text.indexOf(endTag, endIdx);
+    if (endIdx === -1) break;
+    const jsonSegment = text.slice(jsonStart, endIdx);
+    if (!isInsideJsonString(jsonSegment)) {
+      if (hasOuterToolCallStart(jsonSegment, startTag)) {
+        // Nested <tool_call> outside JSON string — abandon this start,
+        // its presumed </tool_call> belongs to a later call.
+        return { startIdx, found: false };
+      }
+      return { startIdx, found: true, jsonStart, endIdx };
+    }
+    endIdx += 1;
+  }
+  return { startIdx, found: false };
+}
+
 function canonicalizeToolInput(argumentsValue: unknown): string {
   return JSON.stringify(argumentsValue ?? {});
 }
@@ -833,7 +894,6 @@ export const hermesProtocol = ({
     })}${toolCallEnd}`;
   },
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Manual scanning needed to skip end tags inside JSON string literals.
   parseGeneratedText({
     text,
     options,
@@ -847,55 +907,18 @@ export const hermesProtocol = ({
     let searchFrom = 0;
 
     while (searchFrom < text.length) {
-      const startIdx = text.indexOf(toolCallStart, searchFrom);
-      if (startIdx === -1) {
-        break;
-      }
+      const span = findNextToolCallSpan(
+        text,
+        searchFrom,
+        toolCallStart,
+        toolCallEnd,
+      );
+      if (span === null) break;
 
-      const jsonStart = startIdx + toolCallStart.length;
-      let endIdx = jsonStart;
-      let found = false;
-
-      while (endIdx < text.length) {
-        endIdx = text.indexOf(toolCallEnd, endIdx);
-        if (endIdx === -1) {
-          break;
-        }
-        const jsonSegment = text.slice(jsonStart, endIdx);
-        if (!isInsideJsonString(jsonSegment)) {
-          // Also check that we haven't crossed into another tool call's
-          // territory — if there's a <tool_call> start tag inside the
-          // JSON segment (outside a string), this end tag belongs to
-          // a later tool call, not ours.
-          // Check for any <tool_call> NOT inside a JSON string — if
-          // found, this </tool_call> belongs to a later tool call.
-          let hasOuterInner = false;
-          let isp = 0;
-          while (isp < jsonSegment.length) {
-            const pos = jsonSegment.indexOf(toolCallStart, isp);
-            if (pos === -1) break;
-            if (!isInsideJsonString(jsonSegment.slice(0, pos))) {
-              hasOuterInner = true;
-              break;
-            }
-            isp = pos + 1;
-          }
-          if (!hasOuterInner) {
-            found = true;
-            break;
-          }
-          // Inner <tool_call> outside a string — this </tool_call>
-          // belongs to a later call.
-          break;
-        }
-        endIdx += 1;
-      }
-
-      if (!found) {
-        // No valid closing tag found for this <tool_call> — emit everything
-        // up to and including the start tag as text, then continue searching
-        // for subsequent tool calls.
-        const skipTo = startIdx + toolCallStart.length;
+      if (!span.found) {
+        // Orphan start tag — emit everything up to and including it as text,
+        // then continue searching for subsequent tool calls.
+        const skipTo = span.startIdx + toolCallStart.length;
         if (skipTo > currentIndex) {
           addTextSegment(text.slice(currentIndex, skipTo), processedElements);
           currentIndex = skipTo;
@@ -904,15 +927,21 @@ export const hermesProtocol = ({
         continue;
       }
 
-      const toolCallJson = text.slice(jsonStart, endIdx);
-      const fullMatch = text.slice(startIdx, endIdx + toolCallEnd.length);
+      const toolCallJson = text.slice(span.jsonStart, span.endIdx);
+      const fullMatch = text.slice(
+        span.startIdx,
+        span.endIdx + toolCallEnd.length,
+      );
 
-      if (startIdx > currentIndex) {
-        addTextSegment(text.slice(currentIndex, startIdx), processedElements);
+      if (span.startIdx > currentIndex) {
+        addTextSegment(
+          text.slice(currentIndex, span.startIdx),
+          processedElements,
+        );
       }
 
       processToolCallJson(toolCallJson, fullMatch, processedElements, options);
-      currentIndex = endIdx + toolCallEnd.length;
+      currentIndex = span.endIdx + toolCallEnd.length;
       searchFrom = currentIndex;
     }
 
@@ -982,54 +1011,22 @@ export const hermesProtocol = ({
     let searchFrom = 0;
 
     while (searchFrom < text.length) {
-      const startIdx = text.indexOf(toolCallStart, searchFrom);
-      if (startIdx === -1) {
-        break;
-      }
+      const span = findNextToolCallSpan(
+        text,
+        searchFrom,
+        toolCallStart,
+        toolCallEnd,
+      );
+      if (span === null) break;
 
-      const jsonStart = startIdx + toolCallStart.length;
-      let endIdx = jsonStart;
-      let found = false;
-
-      while (endIdx < text.length) {
-        endIdx = text.indexOf(toolCallEnd, endIdx);
-        if (endIdx === -1) {
-          break;
-        }
-        const jsonSegment = text.slice(jsonStart, endIdx);
-        if (!isInsideJsonString(jsonSegment)) {
-          // Check for any <tool_call> NOT inside a JSON string — if
-          // found, this </tool_call> belongs to a later tool call.
-          let hasOuterInner2 = false;
-          let isp2 = 0;
-          while (isp2 < jsonSegment.length) {
-            const pos = jsonSegment.indexOf(toolCallStart, isp2);
-            if (pos === -1) break;
-            if (!isInsideJsonString(jsonSegment.slice(0, pos))) {
-              hasOuterInner2 = true;
-              break;
-            }
-            isp2 = pos + 1;
-          }
-          if (!hasOuterInner2) {
-            found = true;
-            break;
-          }
-          // Inner <tool_call> outside a string — this </tool_call>
-          // belongs to a later call.
-          break;
-        }
-        endIdx += 1;
-      }
-
-      if (!found) {
-        // No valid closing tag — skip past the start tag and keep searching
-        searchFrom = startIdx + toolCallStart.length;
+      if (!span.found) {
+        // Orphan start tag — skip past it and keep searching
+        searchFrom = span.startIdx + toolCallStart.length;
         continue;
       }
 
-      segments.push(text.slice(startIdx, endIdx + toolCallEnd.length));
-      searchFrom = endIdx + toolCallEnd.length;
+      segments.push(text.slice(span.startIdx, span.endIdx + toolCallEnd.length));
+      searchFrom = span.endIdx + toolCallEnd.length;
     }
 
     return segments;

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -34,16 +34,16 @@ interface HermesProtocolOptions {
 function isInsideJsonString(json: string): boolean {
   let inStr = false;
   let esc = false;
-  for (let i = 0; i < json.length; i++) {
+  for (const ch of json) {
     if (esc) {
       esc = false;
       continue;
     }
-    if (json[i] === "\\") {
+    if (ch === "\\") {
       esc = true;
       continue;
     }
-    if (json[i] === '"') {
+    if (ch === '"') {
       inStr = !inStr;
     }
   }
@@ -60,8 +60,12 @@ function hasOuterToolCallStart(segment: string, startTag: string): boolean {
   let pos = 0;
   while (pos < segment.length) {
     const next = segment.indexOf(startTag, pos);
-    if (next === -1) return false;
-    if (!isInsideJsonString(segment.slice(0, next))) return true;
+    if (next === -1) {
+      return false;
+    }
+    if (!isInsideJsonString(segment.slice(0, next))) {
+      return true;
+    }
     pos = next + 1;
   }
   return false;
@@ -84,19 +88,23 @@ function findNextToolCallSpan(
   text: string,
   searchFrom: number,
   startTag: string,
-  endTag: string,
+  endTag: string
 ):
   | { startIdx: number; found: true; jsonStart: number; endIdx: number }
   | { startIdx: number; found: false }
   | null {
   const startIdx = text.indexOf(startTag, searchFrom);
-  if (startIdx === -1) return null;
+  if (startIdx === -1) {
+    return null;
+  }
   const jsonStart = startIdx + startTag.length;
 
   let endIdx = jsonStart;
   while (endIdx < text.length) {
     endIdx = text.indexOf(endTag, endIdx);
-    if (endIdx === -1) break;
+    if (endIdx === -1) {
+      break;
+    }
     const jsonSegment = text.slice(jsonStart, endIdx);
     if (!isInsideJsonString(jsonSegment)) {
       if (hasOuterToolCallStart(jsonSegment, startTag)) {
@@ -771,7 +779,6 @@ function processTagMatch(context: TagProcessingContext) {
   }
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Must check JSON string context before accepting end tags.
 function processBufferTags(context: TagProcessingContext) {
   const { state, controller, toolCallStart, toolCallEnd, tools } = context;
   let startIndex = getPotentialStartIndex(
@@ -911,9 +918,11 @@ export const hermesProtocol = ({
         text,
         searchFrom,
         toolCallStart,
-        toolCallEnd,
+        toolCallEnd
       );
-      if (span === null) break;
+      if (span === null) {
+        break;
+      }
 
       if (!span.found) {
         // Orphan start tag — emit everything up to and including it as text,
@@ -930,13 +939,13 @@ export const hermesProtocol = ({
       const toolCallJson = text.slice(span.jsonStart, span.endIdx);
       const fullMatch = text.slice(
         span.startIdx,
-        span.endIdx + toolCallEnd.length,
+        span.endIdx + toolCallEnd.length
       );
 
       if (span.startIdx > currentIndex) {
         addTextSegment(
           text.slice(currentIndex, span.startIdx),
-          processedElements,
+          processedElements
         );
       }
 
@@ -1006,7 +1015,7 @@ export const hermesProtocol = ({
     });
   },
 
-  extractToolCallSegments({ text }: { text: string }) {
+  extractToolCallSegments({ text }) {
     const segments: string[] = [];
     let searchFrom = 0;
 
@@ -1015,9 +1024,11 @@ export const hermesProtocol = ({
         text,
         searchFrom,
         toolCallStart,
-        toolCallEnd,
+        toolCallEnd
       );
-      if (span === null) break;
+      if (span === null) {
+        break;
+      }
 
       if (!span.found) {
         // Orphan start tag — skip past it and keep searching
@@ -1025,7 +1036,9 @@ export const hermesProtocol = ({
         continue;
       }
 
-      segments.push(text.slice(span.startIdx, span.endIdx + toolCallEnd.length));
+      segments.push(
+        text.slice(span.startIdx, span.endIdx + toolCallEnd.length)
+      );
       searchFrom = span.endIdx + toolCallEnd.length;
     }
 

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -44,6 +44,11 @@ function isRjsonIdentifierChar(ch: string | undefined): boolean {
   return ch != null && RJSON_IDENTIFIER_CHAR_REGEX.test(ch);
 }
 
+function isRjsonPropertyLikeDelimiter(startTag: string): boolean {
+  const key = startTag.endsWith(":") ? startTag.slice(0, -1) : "";
+  return key.length > 0 && [...key].every((ch) => isRjsonIdentifierChar(ch));
+}
+
 function previousRjsonToken(json: string, index: number, minIndex = 0): string {
   let start = index - 1;
   while (start >= minIndex && isRjsonIdentifierChar(json[start])) {
@@ -104,6 +109,9 @@ function isLikelyNestedToolCallStart(
   startIndex: number,
   startTag: string
 ): boolean {
+  if (isRjsonPropertyLikeDelimiter(startTag)) {
+    return false;
+  }
   const jsonStart = skipJsonWhitespace(segment, startIndex + startTag.length);
   return (
     segment[jsonStart] === "{" && hasNestedStartBoundary(segment, startIndex)

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -25,6 +25,7 @@ interface HermesProtocolOptions {
 }
 
 const RJSON_IDENTIFIER_CHAR_REGEX = /[$a-zA-Z0-9_\-+.*?!|&%^/#\\]/;
+const RJSON_NUMBER_TOKEN_REGEX = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
 
 function validateNonEmptyDelimiters(
   toolCallStart: string,
@@ -43,14 +44,40 @@ function isRjsonIdentifierChar(ch: string | undefined): boolean {
   return ch != null && RJSON_IDENTIFIER_CHAR_REGEX.test(ch);
 }
 
-function startsRjsonComment(json: string, index: number): boolean {
-  if (isRjsonIdentifierChar(json[index - 1])) {
-    return false;
+function previousRjsonToken(json: string, index: number): string {
+  let start = index - 1;
+  while (start >= 0 && isRjsonIdentifierChar(json[start])) {
+    start -= 1;
+  }
+  return json.slice(start + 1, index);
+}
+
+function previousTokenAllowsComment(json: string, index: number): boolean {
+  const previous = previousRjsonToken(json, index);
+  if (previous.length === 0) {
+    return true;
   }
   return (
-    (json[index] === "/" && json[index + 1] === "/") ||
-    (json[index] === "/" && json[index + 1] === "*")
+    RJSON_NUMBER_TOKEN_REGEX.test(previous) ||
+    previous === "true" ||
+    previous === "false" ||
+    previous === "null"
   );
+}
+
+function startsRjsonComment(json: string, index: number): boolean {
+  if (
+    !(
+      (json[index] === "/" && json[index + 1] === "/") ||
+      (json[index] === "/" && json[index + 1] === "*")
+    )
+  ) {
+    return false;
+  }
+  if (isRjsonIdentifierChar(json[index - 1])) {
+    return previousTokenAllowsComment(json, index);
+  }
+  return true;
 }
 
 /**
@@ -120,13 +147,24 @@ function isInsideRjsonStringOrComment(json: string): boolean {
  * tags that indicate the current tool call's `</tool_call>` actually belongs
  * to a later tool call (i.e. the current call is orphaned / malformed).
  */
+function hasNestedStartBoundary(segment: string, startIndex: number): boolean {
+  const previous = segment[startIndex - 1];
+  return (
+    previous == null ||
+    WHITESPACE_JSON_REGEX.test(previous) ||
+    !(isRjsonIdentifierChar(previous) || previous === "{" || previous === "[")
+  );
+}
+
 function isLikelyNestedToolCallStart(
   segment: string,
   startIndex: number,
   startTag: string
 ): boolean {
   const jsonStart = skipJsonWhitespace(segment, startIndex + startTag.length);
-  return segment[jsonStart] === "{";
+  return (
+    segment[jsonStart] === "{" && hasNestedStartBoundary(segment, startIndex)
+  );
 }
 
 function findOuterToolCallStartIndex(

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -25,36 +25,71 @@ interface HermesProtocolOptions {
 }
 
 /**
- * Returns true if the current position in `json` is inside an unfinished
- * double-quoted string literal.  Only double quotes are tracked because
- * single-quote tracking would be confused by apostrophes in comments
- * (`parseRJSON` also supports `// ...` and block comments), and
- * models virtually never emit single-quoted JSON in tool calls.
+ * Returns true if the current position in `json` is inside syntax that can
+ * legally contain literal tool-call tag text: a relaxed-JSON string or
+ * comment. `parseRJSON` supports `// ...` and block comments, so tag-boundary
+ * detection must ignore quotes and tag-looking text inside those comments.
  */
-function isInsideJsonString(json: string): boolean {
-  let inStr = false;
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Relaxed JSON boundary scanning must track strings, escapes, and comments.
+function isInsideRjsonStringOrComment(json: string): boolean {
+  let quote: '"' | "'" | null = null;
   let esc = false;
-  for (const ch of json) {
+
+  for (let i = 0; i < json.length; i += 1) {
+    const ch = json[i];
+
     if (esc) {
       esc = false;
       continue;
     }
-    if (ch === "\\") {
-      esc = true;
+
+    if (quote !== null) {
+      if (ch === "\\") {
+        esc = true;
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+      }
       continue;
     }
-    if (ch === '"') {
-      inStr = !inStr;
+
+    if (ch === "/" && json[i + 1] === "/") {
+      i += 2;
+      while (i < json.length && json[i] !== "\n" && json[i] !== "\r") {
+        i += 1;
+      }
+      if (i >= json.length) {
+        return true;
+      }
+      continue;
+    }
+
+    if (ch === "/" && json[i + 1] === "*") {
+      i += 2;
+      while (i + 1 < json.length && !(json[i] === "*" && json[i + 1] === "/")) {
+        i += 1;
+      }
+      if (i + 1 >= json.length) {
+        return true;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
     }
   }
-  return inStr;
+
+  return quote !== null;
 }
 
 /**
  * Detect whether `segment` contains an occurrence of `startTag` outside any
- * JSON string literal. Used to identify nested `<tool_call>` start tags that
- * indicate the current tool call's `</tool_call>` actually belongs to a later
- * tool call (i.e. the current call is orphaned / malformed).
+ * relaxed-JSON string or comment. Used to identify nested `<tool_call>` start
+ * tags that indicate the current tool call's `</tool_call>` actually belongs
+ * to a later tool call (i.e. the current call is orphaned / malformed).
  */
 function hasOuterToolCallStart(segment: string, startTag: string): boolean {
   let pos = 0;
@@ -63,7 +98,7 @@ function hasOuterToolCallStart(segment: string, startTag: string): boolean {
     if (next === -1) {
       return false;
     }
-    if (!isInsideJsonString(segment.slice(0, next))) {
+    if (!isInsideRjsonStringOrComment(segment.slice(0, next))) {
       return true;
     }
     pos = next + 1;
@@ -73,10 +108,10 @@ function hasOuterToolCallStart(segment: string, startTag: string): boolean {
 
 /**
  * Locate the next valid `<tool_call>...</tool_call>` span in `text` starting
- * at `searchFrom`. Skips `</tool_call>` sequences that occur inside JSON
- * string literals, and bails out when a nested `<tool_call>` start tag
- * appears outside a JSON string (treating the current start tag as orphaned
- * — its presumed close belongs to a later call).
+ * at `searchFrom`. Skips `</tool_call>` sequences that occur inside
+ * relaxed-JSON strings or comments, and bails out when a nested `<tool_call>`
+ * start tag appears outside a string/comment (treating the current start tag
+ * as orphaned — its presumed close belongs to a later call).
  *
  * Returns:
  *   - `null`: no more start tags in the remaining text
@@ -106,10 +141,10 @@ function findNextToolCallSpan(
       break;
     }
     const jsonSegment = text.slice(jsonStart, endIdx);
-    if (!isInsideJsonString(jsonSegment)) {
+    if (!isInsideRjsonStringOrComment(jsonSegment)) {
       if (hasOuterToolCallStart(jsonSegment, startTag)) {
-        // Nested <tool_call> outside JSON string — abandon this start,
-        // its presumed </tool_call> belongs to a later call.
+        // Nested <tool_call> outside a string/comment — abandon this
+        // start; its presumed </tool_call> belongs to a later call.
         return { startIdx, found: false };
       }
       return { startIdx, found: true, jsonStart, endIdx };
@@ -1014,12 +1049,12 @@ function processBufferTags(context: TagProcessingContext) {
     }
 
     // When inside a tool call and we found an end tag, check whether
-    // it falls inside a JSON string literal. If so, consume it as
-    // content rather than treating it as a real closing tag.
+    // it falls inside a relaxed-JSON string/comment. If so, consume it
+    // as content rather than treating it as a real closing tag.
     if (state.isInsideToolCall) {
       const jsonSoFar =
         state.currentToolCallJson + state.buffer.slice(0, startIndex);
-      if (isInsideJsonString(jsonSoFar)) {
+      if (isInsideRjsonStringOrComment(jsonSoFar)) {
         // Consume through the false end tag as tool-call JSON content
         const consumeEnd = startIndex + tag.length;
         publishText(

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -12,7 +12,6 @@ import {
   addTextSegment,
   formatToolsWithPromptTemplate,
 } from "../utils/protocol-utils";
-import { escapeRegExp } from "../utils/regex";
 import {
   emitToolInputProgressDelta,
   shouldEmitRawToolCallTextOnError,
@@ -23,6 +22,29 @@ import type { ParserOptions, TCMProtocol } from "./protocol-interface";
 interface HermesProtocolOptions {
   toolCallEnd?: string;
   toolCallStart?: string;
+}
+
+/**
+ * Returns true if the current position in `json` is inside an unfinished
+ * string literal \u2014 i.e., there is an odd number of unescaped double-quotes.
+ */
+function isInsideJsonString(json: string): boolean {
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < json.length; i++) {
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (json[i] === "\\") {
+      esc = true;
+      continue;
+    }
+    if (json[i] === '"') {
+      inStr = !inStr;
+    }
+  }
+  return inStr;
 }
 
 function canonicalizeToolInput(argumentsValue: unknown): string {
@@ -710,6 +732,7 @@ function processTagMatch(context: TagProcessingContext) {
   }
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Must check JSON string context before accepting end tags.
 function processBufferTags(context: TagProcessingContext) {
   const { state, controller, toolCallStart, toolCallEnd, tools } = context;
   let startIndex = getPotentialStartIndex(
@@ -721,6 +744,30 @@ function processBufferTags(context: TagProcessingContext) {
     const tag = state.isInsideToolCall ? toolCallEnd : toolCallStart;
     if (startIndex + tag.length > state.buffer.length) {
       break;
+    }
+
+    // When inside a tool call and we found an end tag, check whether
+    // it falls inside a JSON string literal. If so, consume it as
+    // content rather than treating it as a real closing tag.
+    if (state.isInsideToolCall) {
+      const jsonSoFar =
+        state.currentToolCallJson + state.buffer.slice(0, startIndex);
+      if (isInsideJsonString(jsonSoFar)) {
+        // Consume through the false end tag as tool-call JSON content
+        const consumeEnd = startIndex + tag.length;
+        publishText(
+          state.buffer.slice(0, consumeEnd),
+          state,
+          controller,
+          tools
+        );
+        state.buffer = state.buffer.slice(consumeEnd);
+        startIndex = getPotentialStartIndex(
+          state.buffer,
+          state.isInsideToolCall ? toolCallEnd : toolCallStart
+        );
+        continue;
+      }
     }
 
     publishText(state.buffer.slice(0, startIndex), state, controller, tools);
@@ -808,6 +855,7 @@ export const hermesProtocol = ({
     })}${toolCallEnd}`;
   },
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Manual scanning needed to skip end tags inside JSON string literals.
   parseGeneratedText({
     text,
     options,
@@ -816,26 +864,47 @@ export const hermesProtocol = ({
     tools: LanguageModelV3FunctionTool[];
     options?: ParserOptions;
   }) {
-    const startEsc = escapeRegExp(toolCallStart);
-    const endEsc = escapeRegExp(toolCallEnd);
-    const toolCallRegex = new RegExp(
-      `${startEsc}([\u0000-\uFFFF]*?)${endEsc}`,
-      "gs"
-    );
-
     const processedElements: LanguageModelV3Content[] = [];
     let currentIndex = 0;
-    let match = toolCallRegex.exec(text);
+    let searchFrom = 0;
 
-    while (match !== null) {
-      currentIndex = processMatchedToolCall({
-        match,
-        text,
-        currentIndex,
-        processedElements,
-        options,
-      });
-      match = toolCallRegex.exec(text);
+    while (searchFrom < text.length) {
+      const startIdx = text.indexOf(toolCallStart, searchFrom);
+      if (startIdx === -1) {
+        break;
+      }
+
+      const jsonStart = startIdx + toolCallStart.length;
+      let endIdx = jsonStart;
+      let found = false;
+
+      while (endIdx < text.length) {
+        endIdx = text.indexOf(toolCallEnd, endIdx);
+        if (endIdx === -1) {
+          break;
+        }
+        const jsonSegment = text.slice(jsonStart, endIdx);
+        if (!isInsideJsonString(jsonSegment)) {
+          found = true;
+          break;
+        }
+        endIdx += 1;
+      }
+
+      if (!found) {
+        break;
+      }
+
+      const toolCallJson = text.slice(jsonStart, endIdx);
+      const fullMatch = text.slice(startIdx, endIdx + toolCallEnd.length);
+
+      if (startIdx > currentIndex) {
+        addTextSegment(text.slice(currentIndex, startIdx), processedElements);
+      }
+
+      processToolCallJson(toolCallJson, fullMatch, processedElements, options);
+      currentIndex = endIdx + toolCallEnd.length;
+      searchFrom = currentIndex;
     }
 
     if (currentIndex < text.length) {
@@ -900,15 +969,40 @@ export const hermesProtocol = ({
   },
 
   extractToolCallSegments({ text }: { text: string }) {
-    const startEsc = escapeRegExp(toolCallStart);
-    const endEsc = escapeRegExp(toolCallEnd);
-    const regex = new RegExp(`${startEsc}([\u0000-\uFFFF]*?)${endEsc}`, "gs");
     const segments: string[] = [];
-    let m = regex.exec(text);
-    while (m != null) {
-      segments.push(m[0]);
-      m = regex.exec(text);
+    let searchFrom = 0;
+
+    while (searchFrom < text.length) {
+      const startIdx = text.indexOf(toolCallStart, searchFrom);
+      if (startIdx === -1) {
+        break;
+      }
+
+      const jsonStart = startIdx + toolCallStart.length;
+      let endIdx = jsonStart;
+      let found = false;
+
+      while (endIdx < text.length) {
+        endIdx = text.indexOf(toolCallEnd, endIdx);
+        if (endIdx === -1) {
+          break;
+        }
+        const jsonSegment = text.slice(jsonStart, endIdx);
+        if (!isInsideJsonString(jsonSegment)) {
+          found = true;
+          break;
+        }
+        endIdx += 1;
+      }
+
+      if (!found) {
+        break;
+      }
+
+      segments.push(text.slice(startIdx, endIdx + toolCallEnd.length));
+      searchFrom = endIdx + toolCallEnd.length;
     }
+
     return segments;
   },
 });

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -24,6 +24,19 @@ interface HermesProtocolOptions {
   toolCallStart?: string;
 }
 
+function validateNonEmptyDelimiters(
+  toolCallStart: string,
+  toolCallEnd: string
+): Record<never, never> {
+  if (toolCallStart.length === 0) {
+    throw new TypeError("hermesProtocol toolCallStart must not be empty");
+  }
+  if (toolCallEnd.length === 0) {
+    throw new TypeError("hermesProtocol toolCallEnd must not be empty");
+  }
+  return {};
+}
+
 /**
  * Returns true if the current position in `json` is inside syntax that can
  * legally contain literal tool-call tag text: a relaxed-JSON string or
@@ -1132,6 +1145,8 @@ export const hermesProtocol = ({
   toolCallStart = "<tool_call>",
   toolCallEnd = "</tool_call>",
 }: HermesProtocolOptions = {}): TCMProtocol => ({
+  ...validateNonEmptyDelimiters(toolCallStart, toolCallEnd),
+
   formatTools({
     tools,
     toolSystemPromptTemplate,

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -104,19 +104,26 @@ function isInsideRjsonStringOrComment(json: string): boolean {
  * tags that indicate the current tool call's `</tool_call>` actually belongs
  * to a later tool call (i.e. the current call is orphaned / malformed).
  */
-function hasOuterToolCallStart(segment: string, startTag: string): boolean {
+function findOuterToolCallStartIndex(
+  segment: string,
+  startTag: string
+): number | null {
   let pos = 0;
   while (pos < segment.length) {
     const next = segment.indexOf(startTag, pos);
     if (next === -1) {
-      return false;
+      return null;
     }
     if (!isInsideRjsonStringOrComment(segment.slice(0, next))) {
-      return true;
+      return next;
     }
     pos = next + 1;
   }
-  return false;
+  return null;
+}
+
+function hasOuterToolCallStart(segment: string, startTag: string): boolean {
+  return findOuterToolCallStartIndex(segment, startTag) !== null;
 }
 
 /**
@@ -1081,6 +1088,28 @@ function processBufferTags(context: TagProcessingContext) {
           state.buffer,
           state.isInsideToolCall ? toolCallEnd : toolCallStart
         );
+        continue;
+      }
+
+      const nestedStartIndex = findOuterToolCallStartIndex(
+        jsonSoFar,
+        toolCallStart
+      );
+      if (nestedStartIndex !== null) {
+        logParseFailure({
+          phase: "stream",
+          reason:
+            "Abandoning malformed streaming tool call before nested start tag",
+          snippet: `${toolCallStart}${jsonSoFar.slice(0, nestedStartIndex)}`,
+        });
+        closeToolInput(state, controller);
+        state.currentToolCallJson = "";
+        state.isInsideToolCall = false;
+        state.buffer =
+          jsonSoFar.slice(nestedStartIndex) +
+          toolCallEnd +
+          state.buffer.slice(startIndex + tag.length);
+        startIndex = getPotentialStartIndex(state.buffer, toolCallStart);
         continue;
       }
     }

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -24,6 +24,8 @@ interface HermesProtocolOptions {
   toolCallStart?: string;
 }
 
+const RJSON_IDENTIFIER_CHAR_REGEX = /[$a-zA-Z0-9_\-+.*?!|&%^/#\\]/;
+
 function validateNonEmptyDelimiters(
   toolCallStart: string,
   toolCallEnd: string
@@ -35,6 +37,20 @@ function validateNonEmptyDelimiters(
     throw new TypeError("hermesProtocol toolCallEnd must not be empty");
   }
   return {};
+}
+
+function isRjsonIdentifierChar(ch: string | undefined): boolean {
+  return ch != null && RJSON_IDENTIFIER_CHAR_REGEX.test(ch);
+}
+
+function startsRjsonComment(json: string, index: number): boolean {
+  if (isRjsonIdentifierChar(json[index - 1])) {
+    return false;
+  }
+  return (
+    (json[index] === "/" && json[index + 1] === "/") ||
+    (json[index] === "/" && json[index + 1] === "*")
+  );
 }
 
 /**
@@ -67,7 +83,7 @@ function isInsideRjsonStringOrComment(json: string): boolean {
       continue;
     }
 
-    if (ch === "/" && json[i + 1] === "/") {
+    if (startsRjsonComment(json, i) && json[i + 1] === "/") {
       i += 2;
       while (i < json.length && json[i] !== "\n" && json[i] !== "\r") {
         i += 1;
@@ -78,7 +94,7 @@ function isInsideRjsonStringOrComment(json: string): boolean {
       continue;
     }
 
-    if (ch === "/" && json[i + 1] === "*") {
+    if (startsRjsonComment(json, i) && json[i + 1] === "*") {
       i += 2;
       while (i + 1 < json.length && !(json[i] === "*" && json[i + 1] === "/")) {
         i += 1;

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -133,6 +133,7 @@ function findToolCallBoundaryOutsideRjsonSyntax(
   let esc = false;
   let inLineComment = false;
   let inBlockComment = false;
+  let lineCommentSawEndTag = false;
   let nestedStartIndex: number | null = null;
 
   for (let index = scanFrom; index < text.length; index += 1) {
@@ -157,6 +158,24 @@ function findToolCallBoundaryOutsideRjsonSyntax(
     if (inLineComment) {
       if (ch === "\n" || ch === "\r") {
         inLineComment = false;
+        lineCommentSawEndTag = false;
+        continue;
+      }
+      if (text.startsWith(endTag, index)) {
+        lineCommentSawEndTag = true;
+        index += endTag.length - 1;
+        continue;
+      }
+      if (
+        lineCommentSawEndTag &&
+        text.startsWith(startTag, index) &&
+        text[skipJsonWhitespace(text, index + startTag.length)] === "{"
+      ) {
+        nestedStartIndex = index;
+        inLineComment = false;
+        lineCommentSawEndTag = false;
+        index += startTag.length - 1;
+        continue;
       }
       continue;
     }
@@ -172,6 +191,7 @@ function findToolCallBoundaryOutsideRjsonSyntax(
     if (startsRjsonComment(text, index, scanFrom)) {
       if (text[index + 1] === "/") {
         inLineComment = true;
+        lineCommentSawEndTag = false;
         index += 1;
         continue;
       }

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -134,6 +134,7 @@ function findToolCallBoundaryOutsideRjsonSyntax(
   let inLineComment = false;
   let inBlockComment = false;
   let lineCommentSawEndTag = false;
+  let blockCommentSawEndTag = false;
   let nestedStartIndex: number | null = null;
 
   for (let index = scanFrom; index < text.length; index += 1) {
@@ -183,7 +184,25 @@ function findToolCallBoundaryOutsideRjsonSyntax(
     if (inBlockComment) {
       if (ch === "*" && text[index + 1] === "/") {
         inBlockComment = false;
+        blockCommentSawEndTag = false;
         index += 1;
+        continue;
+      }
+      if (text.startsWith(endTag, index)) {
+        blockCommentSawEndTag = true;
+        index += endTag.length - 1;
+        continue;
+      }
+      if (
+        blockCommentSawEndTag &&
+        text.startsWith(startTag, index) &&
+        text[skipJsonWhitespace(text, index + startTag.length)] === "{"
+      ) {
+        nestedStartIndex = index;
+        inBlockComment = false;
+        blockCommentSawEndTag = false;
+        index += startTag.length - 1;
+        continue;
       }
       continue;
     }
@@ -197,6 +216,7 @@ function findToolCallBoundaryOutsideRjsonSyntax(
       }
       if (text[index + 1] === "*") {
         inBlockComment = true;
+        blockCommentSawEndTag = false;
         index += 1;
         continue;
       }

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -44,16 +44,20 @@ function isRjsonIdentifierChar(ch: string | undefined): boolean {
   return ch != null && RJSON_IDENTIFIER_CHAR_REGEX.test(ch);
 }
 
-function previousRjsonToken(json: string, index: number): string {
+function previousRjsonToken(json: string, index: number, minIndex = 0): string {
   let start = index - 1;
-  while (start >= 0 && isRjsonIdentifierChar(json[start])) {
+  while (start >= minIndex && isRjsonIdentifierChar(json[start])) {
     start -= 1;
   }
   return json.slice(start + 1, index);
 }
 
-function previousTokenAllowsComment(json: string, index: number): boolean {
-  const previous = previousRjsonToken(json, index);
+function previousTokenAllowsComment(
+  json: string,
+  index: number,
+  minIndex = 0
+): boolean {
+  const previous = previousRjsonToken(json, index, minIndex);
   if (previous.length === 0) {
     return true;
   }
@@ -65,7 +69,11 @@ function previousTokenAllowsComment(json: string, index: number): boolean {
   );
 }
 
-function startsRjsonComment(json: string, index: number): boolean {
+function startsRjsonComment(
+  json: string,
+  index: number,
+  minIndex = 0
+): boolean {
   if (
     !(
       (json[index] === "/" && json[index + 1] === "/") ||
@@ -74,8 +82,8 @@ function startsRjsonComment(json: string, index: number): boolean {
   ) {
     return false;
   }
-  if (isRjsonIdentifierChar(json[index - 1])) {
-    return previousTokenAllowsComment(json, index);
+  if (index > minIndex && isRjsonIdentifierChar(json[index - 1])) {
+    return previousTokenAllowsComment(json, index, minIndex);
   }
   return true;
 }
@@ -184,10 +192,6 @@ function findOuterToolCallStartIndex(
   return null;
 }
 
-function hasOuterToolCallStart(segment: string, startTag: string): boolean {
-  return findOuterToolCallStartIndex(segment, startTag) !== null;
-}
-
 /**
  * Locate the next valid `<tool_call>...</tool_call>` span in `text` starting
  * at `searchFrom`. Skips `</tool_call>` sequences that occur inside
@@ -201,6 +205,7 @@ function hasOuterToolCallStart(segment: string, startTag: string): boolean {
  *   - `{ startIdx, found: false }`: an orphan start tag (caller should skip
  *     past it and resume scanning)
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Tool-call span scanning tracks relaxed JSON string/comment state and tag boundaries in one pass.
 function findNextToolCallSpan(
   text: string,
   searchFrom: number,
@@ -216,23 +221,76 @@ function findNextToolCallSpan(
   }
   const jsonStart = startIdx + startTag.length;
 
-  let endIdx = jsonStart;
-  while (endIdx < text.length) {
-    endIdx = text.indexOf(endTag, endIdx);
-    if (endIdx === -1) {
-      break;
+  let quote: '"' | "'" | null = null;
+  let esc = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let index = jsonStart; index < text.length; index += 1) {
+    const ch = text[index];
+
+    if (esc) {
+      esc = false;
+      continue;
     }
-    const jsonSegment = text.slice(jsonStart, endIdx);
-    if (!isInsideRjsonStringOrComment(jsonSegment)) {
-      if (hasOuterToolCallStart(jsonSegment, startTag)) {
-        // Nested <tool_call> outside a string/comment — abandon this
-        // start; its presumed </tool_call> belongs to a later call.
-        return { startIdx, found: false };
+
+    if (quote !== null) {
+      if (ch === "\\") {
+        esc = true;
+        continue;
       }
-      return { startIdx, found: true, jsonStart, endIdx };
+      if (ch === quote) {
+        quote = null;
+      }
+      continue;
     }
-    endIdx += 1;
+
+    if (inLineComment) {
+      if (ch === "\n" || ch === "\r") {
+        inLineComment = false;
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (ch === "*" && text[index + 1] === "/") {
+        inBlockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (startsRjsonComment(text, index, jsonStart)) {
+      if (text[index + 1] === "/") {
+        inLineComment = true;
+        index += 1;
+        continue;
+      }
+      if (text[index + 1] === "*") {
+        inBlockComment = true;
+        index += 1;
+        continue;
+      }
+    }
+
+    if (text.startsWith(endTag, index)) {
+      return { startIdx, found: true, jsonStart, endIdx: index };
+    }
+
+    if (
+      text.startsWith(startTag, index) &&
+      isLikelyNestedToolCallStart(text, index, startTag)
+    ) {
+      // Nested <tool_call> outside a string/comment — abandon this
+      // start; its presumed </tool_call> belongs to a later call.
+      return { startIdx, found: false };
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+    }
   }
+
   return { startIdx, found: false };
 }
 

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -149,11 +149,7 @@ function isInsideRjsonStringOrComment(json: string): boolean {
  */
 function hasNestedStartBoundary(segment: string, startIndex: number): boolean {
   const previous = segment[startIndex - 1];
-  return (
-    previous == null ||
-    WHITESPACE_JSON_REGEX.test(previous) ||
-    !(isRjsonIdentifierChar(previous) || previous === "{" || previous === "[")
-  );
+  return previous == null || WHITESPACE_JSON_REGEX.test(previous);
 }
 
 function isLikelyNestedToolCallStart(

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -104,6 +104,15 @@ function isInsideRjsonStringOrComment(json: string): boolean {
  * tags that indicate the current tool call's `</tool_call>` actually belongs
  * to a later tool call (i.e. the current call is orphaned / malformed).
  */
+function isLikelyNestedToolCallStart(
+  segment: string,
+  startIndex: number,
+  startTag: string
+): boolean {
+  const jsonStart = skipJsonWhitespace(segment, startIndex + startTag.length);
+  return segment[jsonStart] === "{";
+}
+
 function findOuterToolCallStartIndex(
   segment: string,
   startTag: string
@@ -114,7 +123,10 @@ function findOuterToolCallStartIndex(
     if (next === -1) {
       return null;
     }
-    if (!isInsideRjsonStringOrComment(segment.slice(0, next))) {
+    if (
+      !isInsideRjsonStringOrComment(segment.slice(0, next)) &&
+      isLikelyNestedToolCallStart(segment, next, startTag)
+    ) {
       return next;
     }
     pos = next + 1;

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -26,7 +26,10 @@ interface HermesProtocolOptions {
 
 /**
  * Returns true if the current position in `json` is inside an unfinished
- * string literal \u2014 i.e., there is an odd number of unescaped double-quotes.
+ * double-quoted string literal.  Only double quotes are tracked because
+ * single-quote tracking would be confused by apostrophes in comments
+ * (`parseRJSON` also supports `// ...` and block comments), and
+ * models virtually never emit single-quoted JSON in tool calls.
  */
 function isInsideJsonString(json: string): boolean {
   let inStr = false;
@@ -81,31 +84,6 @@ function processToolCallJson(
     );
     processedElements.push({ type: "text", text: fullMatch });
   }
-}
-
-interface ParseContext {
-  currentIndex: number;
-  match: RegExpExecArray;
-  options?: ParserOptions;
-  processedElements: LanguageModelV3Content[];
-  text: string;
-}
-
-function processMatchedToolCall(context: ParseContext): number {
-  const { match, text, currentIndex, processedElements, options } = context;
-  const startIndex = match.index;
-  const toolCallJson = match[1];
-
-  if (startIndex > currentIndex) {
-    const textSegment = text.slice(currentIndex, startIndex);
-    addTextSegment(textSegment, processedElements);
-  }
-
-  if (toolCallJson) {
-    processToolCallJson(toolCallJson, match[0], processedElements, options);
-  }
-
-  return startIndex + match[0].length;
 }
 
 interface StreamState {
@@ -885,14 +863,45 @@ export const hermesProtocol = ({
         }
         const jsonSegment = text.slice(jsonStart, endIdx);
         if (!isInsideJsonString(jsonSegment)) {
-          found = true;
+          // Also check that we haven't crossed into another tool call's
+          // territory — if there's a <tool_call> start tag inside the
+          // JSON segment (outside a string), this end tag belongs to
+          // a later tool call, not ours.
+          // Check for any <tool_call> NOT inside a JSON string — if
+          // found, this </tool_call> belongs to a later tool call.
+          let hasOuterInner = false;
+          let isp = 0;
+          while (isp < jsonSegment.length) {
+            const pos = jsonSegment.indexOf(toolCallStart, isp);
+            if (pos === -1) break;
+            if (!isInsideJsonString(jsonSegment.slice(0, pos))) {
+              hasOuterInner = true;
+              break;
+            }
+            isp = pos + 1;
+          }
+          if (!hasOuterInner) {
+            found = true;
+            break;
+          }
+          // Inner <tool_call> outside a string — this </tool_call>
+          // belongs to a later call.
           break;
         }
         endIdx += 1;
       }
 
       if (!found) {
-        break;
+        // No valid closing tag found for this <tool_call> — emit everything
+        // up to and including the start tag as text, then continue searching
+        // for subsequent tool calls.
+        const skipTo = startIdx + toolCallStart.length;
+        if (skipTo > currentIndex) {
+          addTextSegment(text.slice(currentIndex, skipTo), processedElements);
+          currentIndex = skipTo;
+        }
+        searchFrom = skipTo;
+        continue;
       }
 
       const toolCallJson = text.slice(jsonStart, endIdx);
@@ -989,14 +998,34 @@ export const hermesProtocol = ({
         }
         const jsonSegment = text.slice(jsonStart, endIdx);
         if (!isInsideJsonString(jsonSegment)) {
-          found = true;
+          // Check for any <tool_call> NOT inside a JSON string — if
+          // found, this </tool_call> belongs to a later tool call.
+          let hasOuterInner2 = false;
+          let isp2 = 0;
+          while (isp2 < jsonSegment.length) {
+            const pos = jsonSegment.indexOf(toolCallStart, isp2);
+            if (pos === -1) break;
+            if (!isInsideJsonString(jsonSegment.slice(0, pos))) {
+              hasOuterInner2 = true;
+              break;
+            }
+            isp2 = pos + 1;
+          }
+          if (!hasOuterInner2) {
+            found = true;
+            break;
+          }
+          // Inner <tool_call> outside a string — this </tool_call>
+          // belongs to a later call.
           break;
         }
         endIdx += 1;
       }
 
       if (!found) {
-        break;
+        // No valid closing tag — skip past the start tag and keep searching
+        searchFrom = startIdx + toolCallStart.length;
+        continue;
       }
 
       segments.push(text.slice(startIdx, endIdx + toolCallEnd.length));


### PR DESCRIPTION
## Summary

Fixes the hermes protocol parser incorrectly matching `</tool_call>` end tags that appear inside JSON string values.

- Replace regex-based matching in `parseGeneratedText` and `extractToolCallSegments` with manual `indexOf` scanning that checks `isInsideJsonString` before accepting a candidate end tag
- Add the same check to streaming `processBufferTags`
- Handle malformed tool calls gracefully: when no valid end tag is found, skip past the start tag and continue parsing subsequent tool calls
- Detect nested `<tool_call>` start tags (outside JSON strings) to avoid swallowing a later valid tool call's closing tag

Closes #297

## Test plan

- 10 new test cases covering non-streaming, streaming, and `extractToolCallSegments`
- End tag inside double-quoted string values
- Multiple false end tags in one string value
- Escaped quotes adjacent to end tags
- Malformed tool call recovery (no double text emission, subsequent valid tool calls still parsed)
- `<tool_call>` inside a JSON string not treated as a nested start tag
- Chunk-split edge cases in streaming mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Hermes parser to skip `</tool_call>` inside JSON strings and relaxed comments, switches scans to single‑pass, and fixes recovery so adjacent tool calls after malformed JSON (including immediately after `}`) are parsed correctly.

- **Bug Fixes**
  - Replace regex with `indexOf` scanning that respects relaxed JSON strings and `//`/`/* */` comments across parse, extract, and streaming.
  - Start comments only at token boundaries; preserve identifiers with slashes (e.g., `a//b`); skip end tags inside strings/comments; detect nested `<tool_call>`; recover when no close tag exists without double-emitting text.
  - Streaming recovery mirrors non‑streaming: abandon malformed starts, reprocess later calls (including adjacent in one chunk and right after `}`), handle unterminated `//` and `/* */` comments that consumed a close tag, report errors, and optionally emit raw text.
  - Validate non-empty custom delimiters; only treat a nested start when a JSON object follows and the marker is at a start/whitespace/`}` boundary; disable nested recovery for RJSON key–like delimiters (e.g., `name:`) to avoid false positives.

- **Refactors**
  - Extract `findNextToolCallSpan` and nested-start helpers; update `extractToolCallSegments` interface and call sites; changeset for `@ai-sdk-tool/parser`; `.gitignore` update.
  - Make non‑streaming and streaming boundary detection single‑pass to avoid quadratic rescans on many false end tags.

<sup>Written for commit 448e3b02215c4574c19fe2d1eb533fdcada1c0c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

