### PR TITLE
fix: repair malformed JSON with unescaped quotes in tool call arguments

### DIFF
--- a/.changeset/repair-all-unknown-keys-bailout.md
+++ b/.changeset/repair-all-unknown-keys-bailout.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+fix: repair malformed JSON with unescaped quotes in tool call arguments

--- a/src/__tests__/core/protocols/hermes-argument-schema.test.ts
+++ b/src/__tests__/core/protocols/hermes-argument-schema.test.ts
@@ -64,4 +64,34 @@ describe("argumentValueMatchesSchemaKeyShape", () => {
       argumentValueMatchesSchemaKeyShape({ aaaa: 123 }, schema, new Set(), true)
     ).toBe(false);
   });
+
+  it("fails closed without overflowing on a recursive schema and a deeply nested value", () => {
+    // Live-cyclic schema: additionalProperties references the schema object
+    // itself. The value-graph `seen` guard never fires (every value node is a
+    // distinct object), so recursion depth follows the value, not the schema.
+    const cyclicSchema: Record<string, unknown> = {
+      type: "object",
+      additionalProperties: {},
+    };
+    cyclicSchema.additionalProperties = cyclicSchema;
+
+    // Nest far beyond MAX_ARGUMENT_SHAPE_DEPTH (256). Without the depth guard
+    // this overflows the stack (RangeError); with it, validation stops at the
+    // cap and fails closed.
+    let deepValue: Record<string, unknown> = {};
+    for (let index = 0; index < 5000; index += 1) {
+      deepValue = { nested: deepValue };
+    }
+
+    let result: boolean | undefined;
+    expect(() => {
+      result = argumentValueMatchesSchemaKeyShape(
+        deepValue,
+        cyclicSchema,
+        new Set(),
+        true
+      );
+    }).not.toThrow();
+    expect(result).toBe(false);
+  });
 });

--- a/src/__tests__/core/protocols/hermes-argument-schema.test.ts
+++ b/src/__tests__/core/protocols/hermes-argument-schema.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { argumentValueMatchesSchemaKeyShape } from "../../../core/protocols/hermes-argument-schema";
+
+describe("argumentValueMatchesSchemaKeyShape", () => {
+  it("validates reused array item references against each item schema", () => {
+    const shared = { value: "text" };
+    const schema = {
+      type: "array",
+      prefixItems: [
+        {
+          type: "object",
+          properties: { value: { type: "string" } },
+          required: ["value"],
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          properties: { value: { type: "number" } },
+          required: ["value"],
+          additionalProperties: false,
+        },
+      ],
+    };
+
+    expect(
+      argumentValueMatchesSchemaKeyShape(
+        [shared, shared],
+        schema,
+        new Set(),
+        true
+      )
+    ).toBe(false);
+  });
+
+  it("accepts unconstrained unsafe pattern schemas when unknown keys are allowed", () => {
+    const schema = {
+      type: "object",
+      patternProperties: {
+        "^(a+)+$": {},
+      },
+      additionalProperties: true,
+    };
+
+    expect(
+      argumentValueMatchesSchemaKeyShape(
+        { aaaa: "ok" },
+        schema,
+        new Set(),
+        true
+      )
+    ).toBe(true);
+  });
+
+  it("rejects constrained unsafe pattern schemas that may match a key", () => {
+    const schema = {
+      type: "object",
+      patternProperties: {
+        "^(a+)+$": { type: "string", enum: ["allowed"] },
+      },
+      additionalProperties: true,
+    };
+
+    expect(
+      argumentValueMatchesSchemaKeyShape({ aaaa: 123 }, schema, new Set(), true)
+    ).toBe(false);
+  });
+});

--- a/src/__tests__/core/utils/tool-call-coercion.unit.test.ts
+++ b/src/__tests__/core/utils/tool-call-coercion.unit.test.ts
@@ -29,6 +29,36 @@ describe("tool-call coercion utils", () => {
     expect(input).toBeUndefined();
   });
 
+  it("leaves null input unchanged for non-nullable schemas", () => {
+    const input = coerceToolCallInput("calc", null, [
+      {
+        type: "function",
+        name: "calc",
+        inputSchema: {
+          type: "object",
+          properties: { a: { type: "number" } },
+        },
+      },
+    ]);
+
+    expect(input).toBeUndefined();
+  });
+
+  it("preserves null input when the schema allows null", () => {
+    const input = coerceToolCallInput("calc", null, [
+      {
+        type: "function",
+        name: "calc",
+        inputSchema: {
+          type: ["object", "null"],
+          properties: { a: { type: "number" } },
+        },
+      },
+    ]);
+
+    expect(input).toBe("null");
+  });
+
   it("coerceToolCallPart updates tool-call input when coercion succeeds", () => {
     const part = coerceToolCallPart(
       {

--- a/src/__tests__/generate-handler/coercion.test.ts
+++ b/src/__tests__/generate-handler/coercion.test.ts
@@ -1,0 +1,102 @@
+import type { LanguageModelV3FunctionTool } from "@ai-sdk/provider";
+import { describe, expect, it, vi } from "vitest";
+
+import type { TCMCoreProtocol } from "../../core/protocols/protocol-interface";
+import { originalToolsSchema } from "../../core/utils/provider-options";
+import { wrapGenerate } from "../../generate-handler";
+import { stopFinishReason, zeroUsage } from "../test-helpers";
+
+const passthroughProtocol: TCMCoreProtocol = {
+  formatTools: ({ toolSystemPromptTemplate }) => toolSystemPromptTemplate([]),
+  formatToolCall: () => "",
+  parseGeneratedText: () => [],
+  createStreamParser: () => new TransformStream(),
+};
+
+function generateContent(content: unknown[]) {
+  return {
+    content,
+    finishReason: stopFinishReason,
+    usage: zeroUsage,
+    warnings: [],
+  };
+}
+
+describe("wrapGenerate tool-call coercion", () => {
+  it("leaves generated null tool-call input unchanged for non-nullable schemas", async () => {
+    const tools: LanguageModelV3FunctionTool[] = [
+      {
+        type: "function",
+        name: "calc",
+        inputSchema: {
+          type: "object",
+          properties: { a: { type: "number" } },
+        },
+      },
+    ];
+    const malformedToolCall = {
+      type: "tool-call",
+      toolCallId: "id",
+      toolName: "calc",
+      input: null,
+    };
+    const doGenerate = vi
+      .fn()
+      .mockResolvedValue(generateContent([malformedToolCall]));
+
+    const result = await wrapGenerate({
+      protocol: passthroughProtocol,
+      doGenerate,
+      params: {
+        providerOptions: {
+          toolCallMiddleware: {
+            originalTools: originalToolsSchema.encode(tools),
+          },
+        },
+      },
+    });
+
+    expect(result.content[0]).toBe(malformedToolCall);
+  });
+
+  it("preserves generated null tool-call input for nullable schemas", async () => {
+    const tools: LanguageModelV3FunctionTool[] = [
+      {
+        type: "function",
+        name: "calc",
+        inputSchema: {
+          type: ["object", "null"],
+          properties: { a: { type: "number" } },
+        },
+      },
+    ];
+    const doGenerate = vi.fn().mockResolvedValue(
+      generateContent([
+        {
+          type: "tool-call",
+          toolCallId: "id",
+          toolName: "calc",
+          input: null,
+        },
+      ])
+    );
+
+    const result = await wrapGenerate({
+      protocol: passthroughProtocol,
+      doGenerate,
+      params: {
+        providerOptions: {
+          toolCallMiddleware: {
+            originalTools: originalToolsSchema.encode(tools),
+          },
+        },
+      },
+    });
+
+    expect(result.content[0]).toMatchObject({
+      type: "tool-call",
+      toolName: "calc",
+      input: "null",
+    });
+  });
+});

--- a/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
+++ b/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { describe, expect, it, vi } from "vitest";
 import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
 import { toolInputStreamFixtures } from "../../../fixtures/tool-input-stream-fixtures";
+import { stopFinishReason, zeroUsage } from "../../../test-helpers";
 import {
   assertCanonicalAiSdkEventOrder,
   assertCoreAiSdkEventCoverage,
@@ -47,6 +49,64 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
 
     assertCanonicalAiSdkEventOrder(out);
     assertCoreAiSdkEventCoverage(out);
+  });
+
+  it("json protocol emits progress before a delayed closing tag", async () => {
+    const input = new TransformStream<
+      LanguageModelV3StreamPart,
+      LanguageModelV3StreamPart
+    >();
+    const out: LanguageModelV3StreamPart[] = [];
+    const done = input.readable
+      .pipeThrough(protocol.createStreamParser({ tools: fixture.tools }))
+      .pipeTo(
+        new WritableStream<LanguageModelV3StreamPart>({
+          write(part) {
+            out.push(part);
+          },
+        })
+      );
+    const writer = input.writable.getWriter();
+
+    await writer.write({
+      type: "text-delta",
+      id: "1",
+      delta:
+        '<tool_call>{"name":"get_weather","arguments":{"location":"Seoul","unit":"celsius"}}',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const beforeClose = extractToolInputTimeline(out);
+    expect(beforeClose.starts).toHaveLength(1);
+    expect(beforeClose.deltas.map((delta) => delta.delta).join("")).toBe(
+      '{"location":"Seoul","unit":"celsius"}'
+    );
+    expect(beforeClose.ends).toHaveLength(0);
+    expect(out.some((part) => part.type === "tool-call")).toBe(false);
+
+    await writer.write({
+      type: "text-delta",
+      id: "1",
+      delta: "</tool_call>",
+    });
+    await writer.write({
+      type: "finish",
+      finishReason: stopFinishReason,
+      usage: zeroUsage,
+    });
+    await writer.close();
+    await done;
+
+    const { starts, ends } = extractToolInputTimeline(out);
+    const toolCall = out.find((part) => part.type === "tool-call") as {
+      type: "tool-call";
+      toolCallId: string;
+      input: string;
+    };
+    expect(starts).toHaveLength(1);
+    expect(ends).toHaveLength(1);
+    expect(toolCall.toolCallId).toBe(starts[0].id);
+    expect(toolCall.input).toBe('{"location":"Seoul","unit":"celsius"}');
   });
 
   it("json protocol force-completes tool input at finish when closing tag is missing", async () => {
@@ -97,46 +157,38 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
     expect(leakedText).not.toContain("</tool_");
   });
 
-  it("json protocol normalizes streamed arguments:null progress to match final tool-call input", async () => {
-    const out = await runHermesJsonStream([
-      '<tool_call>{"name":"get_weather","arguments":null',
-      "}</tool_call>",
-    ]);
+  it("json protocol rejects streamed arguments:null for object schemas", async () => {
+    const onError = vi.fn();
+    const out = await runProtocolTextDeltaStream({
+      protocol,
+      tools: fixture.tools,
+      chunks: ['<tool_call>{"name":"get_weather","arguments":null', "}</tool_call>"],
+      options: { onError },
+    });
 
     const { starts, deltas, ends } = extractToolInputTimeline(out);
-    const toolCall = out.find((part) => part.type === "tool-call") as {
-      type: "tool-call";
-      toolCallId: string;
-      toolName: string;
-      input: string;
-    };
-
-    expect(starts).toHaveLength(1);
-    expect(ends).toHaveLength(1);
-    expect(toolCall.toolCallId).toBe(starts[0].id);
-    expect(toolCall.input).toBe("{}");
-    expect(deltas.map((delta) => delta.delta)).toEqual(["{}"]);
-    expect(deltas.map((delta) => delta.delta).join("")).toBe(toolCall.input);
+    expect(starts).toHaveLength(0);
+    expect(deltas).toHaveLength(0);
+    expect(ends).toHaveLength(0);
+    expect(out.find((part) => part.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 
-  it("json protocol does not emit non-canonical partial literal prefixes for split null arguments", async () => {
-    const out = await runHermesJsonStream([
-      '<tool_call>{"name":"get_weather","arguments":n',
-      "ull}</tool_call>",
-    ]);
+  it("json protocol rejects split null arguments for object schemas", async () => {
+    const onError = vi.fn();
+    const out = await runProtocolTextDeltaStream({
+      protocol,
+      tools: fixture.tools,
+      chunks: ['<tool_call>{"name":"get_weather","arguments":n', "ull}</tool_call>"],
+      options: { onError },
+    });
 
     const { starts, deltas, ends } = extractToolInputTimeline(out);
-    const toolCall = out.find((part) => part.type === "tool-call") as {
-      type: "tool-call";
-      toolCallId: string;
-      input: string;
-    };
-
-    expect(starts).toHaveLength(1);
-    expect(ends).toHaveLength(1);
-    expect(toolCall.input).toBe("{}");
-    expect(deltas.map((delta) => delta.delta)).toEqual(["{}"]);
-    expect(deltas.map((delta) => delta.delta).join("")).toBe(toolCall.input);
+    expect(starts).toHaveLength(0);
+    expect(deltas).toHaveLength(0);
+    expect(ends).toHaveLength(0);
+    expect(out.find((part) => part.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 
   it("json protocol canonicalizes pretty-printed arguments progress before emitting deltas", async () => {
@@ -161,7 +213,7 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
     expect(deltas.map((delta) => delta.delta).join("")).toBe(toolCall.input);
   });
 
-  it("json protocol emits tool-input deltas for parseable arguments even when outer JSON is incomplete", async () => {
+  it("json protocol does not emit tool-input deltas for incomplete outer JSON", async () => {
     const out = await runHermesJsonStream([
       '<tool_call>{"meta":{"msg":"{"},"name":"get_weather","arguments":{"location":"Seoul","unit":"celsius"}',
     ]);
@@ -172,11 +224,9 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
       .map((part) => (part as { delta: string }).delta)
       .join("");
 
-    expect(starts).toHaveLength(1);
-    expect(ends).toHaveLength(1);
-    expect(deltas.map((delta) => delta.delta).join("")).toBe(
-      '{"location":"Seoul","unit":"celsius"}'
-    );
+    expect(starts).toHaveLength(0);
+    expect(ends).toHaveLength(0);
+    expect(deltas).toHaveLength(0);
     expect(out.some((part) => part.type === "tool-call")).toBe(false);
     expect(leakedText).not.toContain("<tool_call>");
   });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/error-handling.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/error-handling.test.ts
@@ -53,20 +53,4 @@ describe("protocol error paths", () => {
     expect((metadata.toolCallId as string).length).toBeGreaterThan(0);
   });
 
-  it("hermesProtocol parseGeneratedText does NOT recover JSON with unescaped double quotes (#298 proposal-2 not implemented)", () => {
-    const onError = vi.fn();
-    const p = hermesProtocol();
-    const text =
-      '<tool_call>{"name":"edit","arguments":{"content":"He said "hello" to me"}}</tool_call>';
-    const out = p.parseGeneratedText({ text, tools: [], options: { onError } });
-    const toolCalls = out.filter((e) => e.type === "tool-call");
-    expect(toolCalls).toHaveLength(0);
-    expect(onError).toHaveBeenCalledTimes(1);
-    const [, metadata] = onError.mock.calls[0];
-    expect(metadata.dropReason).toBe("malformed-tool-call-body");
-    const rejoined = out
-      .map((x) => (x.type === "text" ? (x as any).text : ""))
-      .join("");
-    expect(rejoined).toBe(text);
-  });
 });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -1,0 +1,106 @@
+import type { LanguageModelV3FunctionTool } from "@ai-sdk/provider";
+import { describe, expect, it, vi } from "vitest";
+import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
+
+vi.mock("@ai-sdk/provider-utils", () => ({
+  generateId: vi.fn(() => "mock-id"),
+}));
+
+function makeTool(
+  name: string,
+  properties: Record<string, { type: string }>
+): LanguageModelV3FunctionTool {
+  return {
+    type: "function",
+    name,
+    inputSchema: {
+      type: "object",
+      properties,
+    },
+  };
+}
+
+describe("parseGeneratedText JSON repair", () => {
+  it("repairs unescaped quotes in a string value", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"content":"He said "hello" to me"}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("edit");
+    const args = JSON.parse(tool.input);
+    expect(args.content).toBe('He said "hello" to me');
+  });
+
+  it("repairs multiple arguments with one having unescaped quotes", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"path":"/tmp/a.txt","content":"use "strict"; var x = 1;"}}</tool_call>';
+    const tools = [makeTool("write", { path: { type: "string" }, content: { type: "string" } })];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("write");
+    const args = JSON.parse(tool.input);
+    expect(args.path).toBe("/tmp/a.txt");
+    expect(args.content).toContain('"strict"');
+  });
+
+  it("uses known arg keys to filter false-positive key matches", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"content":"value with ,"fake": inside"}}</tool_call>';
+    const tools = [makeTool("edit", { content: { type: "string" } })];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("edit");
+    const args = JSON.parse(tool.input);
+    expect(args.content).toContain("fake");
+  });
+
+  it("does not alter already valid JSON", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"read","arguments":{"path":"/tmp/file.txt"}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("read");
+    expect(JSON.parse(tool.input)).toEqual({ path: "/tmp/file.txt" });
+  });
+
+  it("falls through to error for completely broken JSON (no name field)", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text = "<tool_call>{totally broken}</tool_call>";
+    const out = p.parseGeneratedText({ text, tools: [], options: { onError } });
+    expect(onError).toHaveBeenCalled();
+    const rejoined = out
+      .map((x) => (x.type === "text" ? (x as any).text : ""))
+      .join("");
+    expect(rejoined).toContain("{totally broken}");
+  });
+
+  it("repairs alongside numeric and boolean arguments", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"update","arguments":{"content":"He said "hi" there","count":42,"enabled":true}}</tool_call>';
+    const tools = [
+      makeTool("update", {
+        content: { type: "string" },
+        count: { type: "number" },
+        enabled: { type: "boolean" },
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("update");
+    const args = JSON.parse(tool.input);
+    expect(args.content).toBe('He said "hi" there');
+    expect(args.count).toBe(42);
+    expect(args.enabled).toBe(true);
+  });
+});

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -37,7 +37,12 @@ describe("parseGeneratedText JSON repair", () => {
     const p = hermesProtocol();
     const text =
       '<tool_call>{"name":"write","arguments":{"path":"/tmp/a.txt","content":"use "strict"; var x = 1;"}}</tool_call>';
-    const tools = [makeTool("write", { path: { type: "string" }, content: { type: "string" } })];
+    const tools = [
+      makeTool("write", {
+        path: { type: "string" },
+        content: { type: "string" },
+      }),
+    ];
     const out = p.parseGeneratedText({ text, tools });
     const tool = out.find((x) => x.type === "tool-call") as any;
     expect(tool).toBeTruthy();
@@ -47,7 +52,7 @@ describe("parseGeneratedText JSON repair", () => {
     expect(args.content).toContain('"strict"');
   });
 
-  it("does not silently corrupt content when a ,\"unknown\": pattern appears inside broken quotes", () => {
+  it('does not silently corrupt content when a ,"unknown": pattern appears inside broken quotes', () => {
     const onError = vi.fn();
     const p = hermesProtocol();
     // Ambiguous input: ,"fake": could be (a) a real schema-unknown key
@@ -148,8 +153,7 @@ describe("parseGeneratedText JSON repair", () => {
   it("falls through to error when repair is impossible (no arguments field)", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
-    const text =
-      '<tool_call>{"name":"x","params":{"a":1}}</tool_call>';
+    const text = '<tool_call>{"name":"x","params":{"a":1}}</tool_call>';
     const out = p.parseGeneratedText({ text, tools: [], options: { onError } });
     // rjson may handle this, but the tool call should either parse or
     // fall through to onError; it should not crash.
@@ -277,10 +281,8 @@ describe("parseGeneratedText JSON repair", () => {
     // is the last (or second-to-last) top-level property.
     const text =
       '<tool_call>{"name":"edit","arguments":{"content":"He said "hello" to me"},"id":"123"}</tool_call>';
-    const tools = [
-      makeTool("edit", { content: { type: "string" } }),
-    ];
-    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tools = [makeTool("edit", { content: { type: "string" } })];
+    p.parseGeneratedText({ text, tools, options: { onError } });
     expect(onError).toHaveBeenCalled();
   });
 

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -30,6 +30,14 @@ function makeSchemaTool(
 
 type ToolCallContent = Extract<LanguageModelV3Content, { type: "tool-call" }>;
 
+function makeDeepArrayJson(depth: number): string {
+  let value = "0";
+  for (let index = 0; index < depth; index += 1) {
+    value = `[${value}]`;
+  }
+  return value;
+}
+
 function expectToolCall(output: LanguageModelV3Content[]): ToolCallContent {
   const tool = output.find(
     (part): part is ToolCallContent => part.type === "tool-call"
@@ -677,9 +685,7 @@ describe("parseGeneratedText JSON repair", () => {
         additionalProperties: false,
       }),
     ];
-    const started = performance.now();
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
-    expect(performance.now() - started).toBeLessThan(150);
     expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
   });
@@ -701,9 +707,7 @@ describe("parseGeneratedText JSON repair", () => {
         additionalProperties: false,
       }),
     ];
-    const started = performance.now();
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
-    expect(performance.now() - started).toBeLessThan(150);
     expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
   });
@@ -725,9 +729,7 @@ describe("parseGeneratedText JSON repair", () => {
         additionalProperties: true,
       }),
     ];
-    const started = performance.now();
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
-    expect(performance.now() - started).toBeLessThan(150);
     expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
   });
@@ -749,9 +751,7 @@ describe("parseGeneratedText JSON repair", () => {
         additionalProperties: true,
       }),
     ];
-    const started = performance.now();
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
-    expect(performance.now() - started).toBeLessThan(150);
     expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
   });
@@ -933,6 +933,24 @@ describe("parseGeneratedText JSON repair", () => {
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
     const tool = out.find((x) => x.type === "tool-call");
     expect(tool).toBeUndefined();
+    expect(out).toContainEqual({ type: "text", text });
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("does not repair relaxed top-level keys even when argument keys are strict JSON", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{name:"write",arguments:{"content":"He said "hi" there","path":"/tmp/a"}}</tool_call>';
+    const tools = [
+      makeTool("write", {
+        content: { type: "string" },
+        path: { type: "string" },
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(out).toContainEqual({ type: "text", text });
     expect(onError).toHaveBeenCalled();
   });
 
@@ -948,6 +966,19 @@ describe("parseGeneratedText JSON repair", () => {
     const hasToolOrError =
       out.some((x) => x.type === "tool-call") || onError.mock.calls.length > 0;
     expect(hasToolOrError).toBe(true);
+  });
+
+  it("fails closed instead of throwing for deeply nested arguments", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const nestedArray = makeDeepArrayJson(20_000);
+    const text = `<tool_call>{"name":"deep","arguments":{"data":${nestedArray}}}</tool_call>`;
+    let out: LanguageModelV3Content[] = [];
+    expect(() => {
+      out = p.parseGeneratedText({ text, tools: [], options: { onError } });
+    }).not.toThrow();
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 
   it("rejects prototype-sensitive argument keys without a schema policy", () => {
@@ -1159,6 +1190,48 @@ describe("parseGeneratedText JSON repair", () => {
         expect(onError).toHaveBeenCalled();
       }
     }
+  });
+
+  it("accepts omitted arguments for no-input tool calls", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text = '<tool_call>{"name":"ping"}</tool_call>';
+    const out = p.parseGeneratedText({
+      text,
+      tools: [
+        makeSchemaTool("ping", {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    const tool = expectToolCall(out);
+    expect(tool.input).toBe("{}");
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("accepts null arguments when the top-level schema allows null", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text = '<tool_call>{"name":"write","arguments":null}</tool_call>';
+    const out = p.parseGeneratedText({
+      text,
+      tools: [
+        makeSchemaTool("write", {
+          type: ["object", "null"],
+          properties: {
+            content: { type: "string" },
+          },
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    const tool = expectToolCall(out);
+    expect(tool.input).toBe("null");
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("rejects null for non-nullable typed object properties", () => {
@@ -1805,6 +1878,26 @@ describe("parseGeneratedText JSON repair", () => {
       content: "ok",
       note: "safe",
     });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("accepts unconstrained unsafe patternProperties when unknown keys are allowed", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"aaaa":"ok"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        patternProperties: {
+          "^(a+)+$": {},
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = expectToolCall(out);
+    expect(JSON.parse(tool.input)).toEqual({ aaaa: "ok" });
     expect(onError).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -982,6 +982,36 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("fails closed instead of throwing for a recursive schema with a deeply nested value", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    // Live-cyclic tool schema: additionalProperties references the schema
+    // object itself. Combined with a deeply nested value this would overflow
+    // the schema-shape validator (uncaught RangeError) without the depth guard.
+    const tool: LanguageModelV3FunctionTool = {
+      type: "function",
+      name: "deep",
+      inputSchema: { type: "object" },
+    };
+    (tool.inputSchema as Record<string, unknown>).additionalProperties =
+      tool.inputSchema;
+    let deepArgs = "{}";
+    for (let index = 0; index < 5000; index += 1) {
+      deepArgs = `{"nested":${deepArgs}}`;
+    }
+    const text = `<tool_call>{"name":"deep","arguments":${deepArgs}}</tool_call>`;
+    let out: LanguageModelV3Content[] = [];
+    expect(() => {
+      out = p.parseGeneratedText({
+        text,
+        tools: [tool],
+        options: { onError },
+      });
+    }).not.toThrow();
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("rejects prototype-sensitive argument keys without a schema policy", () => {
     const onError = vi.fn();
     const p = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -49,6 +49,10 @@ describe("parseGeneratedText JSON repair", () => {
 
   it("uses known arg keys to filter false-positive key matches", () => {
     const p = hermesProtocol();
+    // The unescaped quotes around "fake" create a ,"fake": pattern that
+    // looks like a key boundary.  With knownArgKeys = ["content"], the
+    // repair should recognize "fake" is not a real key and include it
+    // in the content value.
     const text =
       '<tool_call>{"name":"edit","arguments":{"content":"value with ,"fake": inside"}}</tool_call>';
     const tools = [makeTool("edit", { content: { type: "string" } })];
@@ -102,5 +106,195 @@ describe("parseGeneratedText JSON repair", () => {
     expect(args.content).toBe('He said "hi" there');
     expect(args.count).toBe(42);
     expect(args.enabled).toBe(true);
+  });
+
+  it("handles nested object in arguments without false key splits", () => {
+    const p = hermesProtocol();
+    // Valid JSON with a nested object — the ,"b":2 inside opts must NOT
+    // be treated as a top-level key split.
+    const text =
+      '<tool_call>{"name":"x","arguments":{"opts":{"a":1,"b":2},"content":"say \\"hi\\""}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("x");
+    const args = JSON.parse(tool.input);
+    expect(args.opts).toEqual({ a: 1, b: 2 });
+    expect(args.content).toBe('say "hi"');
+  });
+
+  it("handles array value in arguments without false key splits", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"x","arguments":{"items":[1,2,3],"text":"a \\"b\\" c"}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("x");
+    const args = JSON.parse(tool.input);
+    expect(args.items).toEqual([1, 2, 3]);
+    expect(args.text).toBe('a "b" c');
+  });
+
+  it("falls through to error when repair is impossible (no arguments field)", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"x","params":{"a":1}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [], options: { onError } });
+    // rjson may handle this, but the tool call should either parse or
+    // fall through to onError; it should not crash.
+    const hasToolOrError =
+      out.some((x) => x.type === "tool-call") || onError.mock.calls.length > 0;
+    expect(hasToolOrError).toBe(true);
+  });
+
+  it("repairs nested object arguments when JSON is malformed", () => {
+    const p = hermesProtocol();
+    // Malformed: unescaped quotes in content, plus a nested opts object
+    const text =
+      '<tool_call>{"name":"x","arguments":{"opts":{"a":1,"b":2},"content":"say "hi" there"}}</tool_call>';
+    const tools = [
+      makeTool("x", {
+        opts: { type: "object" },
+        content: { type: "string" },
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("x");
+    const args = JSON.parse(tool.input);
+    expect(args.opts).toEqual({ a: 1, b: 2 });
+    expect(args.content).toBe('say "hi" there');
+  });
+
+  it("does not confuse nested 'name' inside arguments with tool name", () => {
+    const p = hermesProtocol();
+    // The arguments object contains a "name" key — the top-level "name"
+    // (which is the tool name) should be extracted, not the nested one.
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"name":"inner_value","content":"He said "hello" to me"}}</tool_call>';
+    const tools = [
+      makeTool("edit", {
+        name: { type: "string" },
+        content: { type: "string" },
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("edit");
+    const args = JSON.parse(tool.input);
+    expect(args.name).toBe("inner_value");
+    expect(args.content).toBe('He said "hello" to me');
+  });
+
+  it("accepts valid non-string values alongside broken string values", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"update","arguments":{"count":42,"flag":true,"label":null,"content":"He said "hi" there"}}</tool_call>';
+    const tools = [
+      makeTool("update", {
+        count: { type: "number" },
+        flag: { type: "boolean" },
+        label: { type: "string" },
+        content: { type: "string" },
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("update");
+    const args = JSON.parse(tool.input);
+    expect(args.count).toBe(42);
+    expect(args.flag).toBe(true);
+    expect(args.label).toBeNull();
+    expect(args.content).toBe('He said "hi" there');
+  });
+
+  it("returns error when non-string value is broken (type coercion prevention)", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    // A broken number value (not a string) — repair should fail gracefully
+    const text =
+      '<tool_call>{"name":"calc","arguments":{"value":4.2.3,"label":"ok"}}</tool_call>';
+    const tools = [
+      makeTool("calc", {
+        value: { type: "number" },
+        label: { type: "string" },
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    // rjson may still recover this, but if it reaches repair, repair
+    // should not silently coerce "4.2.3" to a string.
+    // Either rjson handles it or onError is called.
+    const hasToolOrError =
+      out.some((x) => x.type === "tool-call") || onError.mock.calls.length > 0;
+    expect(hasToolOrError).toBe(true);
+  });
+
+  it("repairs with knownArgKeys and drops unknown extra keys", () => {
+    const p = hermesProtocol();
+    // Schema knows "content" and "path", but model emits "extra" too.
+    // During repair, unknown keys are dropped as boundaries to prevent
+    // false splits from corrupting known values.
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"He said "hi" there","path":"/tmp/a"}}</tool_call>';
+    const tools = [
+      makeTool("write", {
+        content: { type: "string" },
+        path: { type: "string" },
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    const args = JSON.parse(tool.input);
+    expect(args.content).toBe('He said "hi" there');
+    expect(args.path).toBe("/tmp/a");
+  });
+
+  it("calls onError when arguments is not the last top-level property (backwards scan limitation)", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    // "id" comes after "arguments" — the backwards scan includes
+    // ,"id":"123" in argsBody, which corrupts the arguments object.
+    // This is a known limitation: repair only works when "arguments"
+    // is the last (or second-to-last) top-level property.
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"content":"He said "hello" to me"},"id":"123"}</tool_call>';
+    const tools = [
+      makeTool("edit", { content: { type: "string" } }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("handles nested object as last argument value", () => {
+    const p = hermesProtocol();
+    // The last argument is a nested object — argsClose must find the right }
+    const text =
+      '<tool_call>{"name":"x","arguments":{"a":1,"b":{"c":2}}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools: [] });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    const args = JSON.parse(tool.input);
+    expect(args.a).toBe(1);
+    expect(args.b).toEqual({ c: 2 });
+  });
+
+  it("bails out on arguments body larger than 100KB", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    // Create a payload > 100KB with a malformed string value
+    const bigValue = "x".repeat(110_000);
+    const text = `<tool_call>{"name":"big","arguments":{"data":"${bigValue} with "unescaped" quotes"}}</tool_call>`;
+    const out = p.parseGeneratedText({ text, tools: [], options: { onError } });
+    // rjson may handle it, but repair should bail out on the size.
+    // Either rjson handles it or onError is called.
+    const hasToolOrError =
+      out.some((x) => x.type === "tool-call") || onError.mock.calls.length > 0;
+    expect(hasToolOrError).toBe(true);
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -47,21 +47,30 @@ describe("parseGeneratedText JSON repair", () => {
     expect(args.content).toContain('"strict"');
   });
 
-  it("uses known arg keys to filter false-positive key matches", () => {
+  it("does not silently corrupt content when a ,\"unknown\": pattern appears inside broken quotes", () => {
+    const onError = vi.fn();
     const p = hermesProtocol();
-    // The unescaped quotes around "fake" create a ,"fake": pattern that
-    // looks like a key boundary.  With knownArgKeys = ["content"], the
-    // repair should recognize "fake" is not a real key and include it
-    // in the content value.
+    // Ambiguous input: ,"fake": could be (a) a real schema-unknown key
+    // boundary or (b) part of the preceding content value wrapped in
+    // broken quotes. We prefer correct boundary detection (so adjacent
+    // unknown keys like ",\"extra\":..." repair cleanly — see the
+    // "drops unknown extra keys" test below) over preserving ambiguous
+    // unknown tokens inside a string value.
+    //
+    // Trade-off: when "fake" really was meant as part of the content
+    // string, repair bails and the tool call is emitted as text rather
+    // than producing a corrupted tool call with a truncated value.
     const text =
       '<tool_call>{"name":"edit","arguments":{"content":"value with ,"fake": inside"}}</tool_call>';
     const tools = [makeTool("edit", { content: { type: "string" } })];
-    const out = p.parseGeneratedText({ text, tools });
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
     const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
-    expect(tool.toolName).toBe("edit");
-    const args = JSON.parse(tool.input);
-    expect(args.content).toContain("fake");
+    if (tool) {
+      const args = JSON.parse(tool.input);
+      expect(typeof args.content).toBe("string");
+    } else {
+      expect(onError).toHaveBeenCalled();
+    }
   });
 
   it("does not alter already valid JSON", () => {
@@ -236,11 +245,13 @@ describe("parseGeneratedText JSON repair", () => {
 
   it("repairs with knownArgKeys and drops unknown extra keys", () => {
     const p = hermesProtocol();
-    // Schema knows "content" and "path", but model emits "extra" too.
-    // During repair, unknown keys are dropped as boundaries to prevent
-    // false splits from corrupting known values.
+    // Schema knows "content" and "path"; the model also emits a
+    // schema-unknown "extra" key between them. The unknown boundary is
+    // still used to slice correctly (so "content" does not absorb the
+    // ,"extra":"debug", prefix into a corrupted value), and the unknown
+    // key is dropped from the final args object.
     const text =
-      '<tool_call>{"name":"write","arguments":{"content":"He said "hi" there","path":"/tmp/a"}}</tool_call>';
+      '<tool_call>{"name":"write","arguments":{"content":"He said "hi" there","extra":"debug","path":"/tmp/a"}}</tool_call>';
     const tools = [
       makeTool("write", {
         content: { type: "string" },
@@ -253,6 +264,8 @@ describe("parseGeneratedText JSON repair", () => {
     const args = JSON.parse(tool.input);
     expect(args.content).toBe('He said "hi" there');
     expect(args.path).toBe("/tmp/a");
+    // Schema-unknown key dropped from output
+    expect(args).not.toHaveProperty("extra");
   });
 
   it("calls onError when arguments is not the last top-level property (backwards scan limitation)", () => {

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -1235,6 +1235,20 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("rejects null arguments without a matching nullable schema", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text = '<tool_call>{"name":"write","arguments":null}</tool_call>';
+    const out = p.parseGeneratedText({
+      text,
+      tools: [],
+      options: { onError },
+    });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(out).toContainEqual({ type: "text", text });
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("rejects null for non-nullable typed object properties", () => {
     const onError = vi.fn();
     const p = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -1241,7 +1241,7 @@ describe("parseGeneratedText JSON repair", () => {
     const text = '<tool_call>{"name":"write","arguments":null}</tool_call>';
     const out = p.parseGeneratedText({
       text,
-      tools: [],
+      tools: [makeSchemaTool("write", { type: "object" })],
       options: { onError },
     });
     expect(out.find((x) => x.type === "tool-call")).toBeUndefined();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -1,14 +1,14 @@
-import type { LanguageModelV3FunctionTool } from "@ai-sdk/provider";
+import type {
+  LanguageModelV3Content,
+  LanguageModelV3FunctionTool,
+} from "@ai-sdk/provider";
 import { describe, expect, it, vi } from "vitest";
 import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
 
-vi.mock("@ai-sdk/provider-utils", () => ({
-  generateId: vi.fn(() => "mock-id"),
-}));
-
 function makeTool(
   name: string,
-  properties: Record<string, { type: string }>
+  properties: Record<string, { type: string }>,
+  additionalProperties?: boolean
 ): LanguageModelV3FunctionTool {
   return {
     type: "function",
@@ -16,8 +16,31 @@ function makeTool(
     inputSchema: {
       type: "object",
       properties,
+      ...(additionalProperties === undefined ? {} : { additionalProperties }),
     },
   };
+}
+
+function makeSchemaTool(
+  name: string,
+  inputSchema: LanguageModelV3FunctionTool["inputSchema"]
+): LanguageModelV3FunctionTool {
+  return { type: "function", name, inputSchema };
+}
+
+type ToolCallContent = Extract<LanguageModelV3Content, { type: "tool-call" }>;
+
+function expectToolCall(
+  output: LanguageModelV3Content[]
+): ToolCallContent {
+  const tool = output.find(
+    (part): part is ToolCallContent => part.type === "tool-call"
+  );
+  expect(tool?.type).toBe("tool-call");
+  if (!tool) {
+    throw new Error("Expected tool call");
+  }
+  return tool;
 }
 
 describe("parseGeneratedText JSON repair", () => {
@@ -26,11 +49,28 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"edit","arguments":{"content":"He said "hello" to me"}}</tool_call>';
     const out = p.parseGeneratedText({ text, tools: [] });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    if (tool?.type !== "tool-call") {
+      throw new Error("Expected tool call");
+    }
     expect(tool.toolName).toBe("edit");
     const args = JSON.parse(tool.input);
     expect(args.content).toBe('He said "hello" to me');
+  });
+
+  it("repairs unescaped quotes before a right brace character in a string", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"content":"He said "}" there"}}</tool_call>';
+    const tools = [makeTool("edit", { content: { type: "string" } }, false)];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    if (tool?.type !== "tool-call") {
+      throw new Error("Expected repaired tool call");
+    }
+    expect(JSON.parse(tool.input)).toEqual({ content: 'He said "}" there' });
   });
 
   it("repairs multiple arguments with one having unescaped quotes", () => {
@@ -44,8 +84,11 @@ describe("parseGeneratedText JSON repair", () => {
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    if (tool?.type !== "tool-call") {
+      throw new Error("Expected tool call");
+    }
     expect(tool.toolName).toBe("write");
     const args = JSON.parse(tool.input);
     expect(args.path).toBe("/tmp/a.txt");
@@ -69,7 +112,9 @@ describe("parseGeneratedText JSON repair", () => {
       '<tool_call>{"name":"edit","arguments":{"content":"value with ,"fake": inside"}}</tool_call>';
     const tools = [makeTool("edit", { content: { type: "string" } })];
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
-    const tool = out.find((x) => x.type === "tool-call") as any;
+    const tool = out.find(
+      (x): x is ToolCallContent => x.type === "tool-call"
+    );
     if (tool) {
       const args = JSON.parse(tool.input);
       expect(typeof args.content).toBe("string");
@@ -83,10 +128,20 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"read","arguments":{"path":"/tmp/file.txt"}}</tool_call>';
     const out = p.parseGeneratedText({ text, tools: [] });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("read");
     expect(JSON.parse(tool.input)).toEqual({ path: "/tmp/file.txt" });
+  });
+
+  it("rejects inherited tool call fields from __proto__ wrappers", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"__proto__":{"name":"write","arguments":{"content":"ok"}}}</tool_call>';
+    const tools = [makeTool("write", { content: { type: "string" } })];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 
   it("falls through to error for completely broken JSON (no name field)", () => {
@@ -96,7 +151,7 @@ describe("parseGeneratedText JSON repair", () => {
     const out = p.parseGeneratedText({ text, tools: [], options: { onError } });
     expect(onError).toHaveBeenCalled();
     const rejoined = out
-      .map((x) => (x.type === "text" ? (x as any).text : ""))
+      .map((x) => (x.type === "text" ? x.text : ""))
       .join("");
     expect(rejoined).toContain("{totally broken}");
   });
@@ -113,8 +168,7 @@ describe("parseGeneratedText JSON repair", () => {
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("update");
     const args = JSON.parse(tool.input);
     expect(args.content).toBe('He said "hi" there');
@@ -129,8 +183,7 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"x","arguments":{"opts":{"a":1,"b":2},"content":"say \\"hi\\""}}</tool_call>';
     const out = p.parseGeneratedText({ text, tools: [] });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("x");
     const args = JSON.parse(tool.input);
     expect(args.opts).toEqual({ a: 1, b: 2 });
@@ -142,8 +195,7 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"x","arguments":{"items":[1,2,3],"text":"a \\"b\\" c"}}</tool_call>';
     const out = p.parseGeneratedText({ text, tools: [] });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("x");
     const args = JSON.parse(tool.input);
     expect(args.items).toEqual([1, 2, 3]);
@@ -174,8 +226,7 @@ describe("parseGeneratedText JSON repair", () => {
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("x");
     const args = JSON.parse(tool.input);
     expect(args.opts).toEqual({ a: 1, b: 2 });
@@ -195,8 +246,7 @@ describe("parseGeneratedText JSON repair", () => {
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("edit");
     const args = JSON.parse(tool.input);
     expect(args.name).toBe("inner_value");
@@ -208,16 +258,18 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"update","arguments":{"count":42,"flag":true,"label":null,"content":"He said "hi" there"}}</tool_call>';
     const tools = [
-      makeTool("update", {
-        count: { type: "number" },
-        flag: { type: "boolean" },
-        label: { type: "string" },
-        content: { type: "string" },
+      makeSchemaTool("update", {
+        type: "object",
+        properties: {
+          count: { type: "number" },
+          flag: { type: "boolean" },
+          label: { type: ["string", "null"] },
+          content: { type: "string" },
+        },
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("update");
     const args = JSON.parse(tool.input);
     expect(args.count).toBe(42);
@@ -247,13 +299,8 @@ describe("parseGeneratedText JSON repair", () => {
     expect(hasToolOrError).toBe(true);
   });
 
-  it("repairs with knownArgKeys and drops unknown extra keys", () => {
+  it("preserves schema-unknown keys when additionalProperties is implicit", () => {
     const p = hermesProtocol();
-    // Schema knows "content" and "path"; the model also emits a
-    // schema-unknown "extra" key between them. The unknown boundary is
-    // still used to slice correctly (so "content" does not absorb the
-    // ,"extra":"debug", prefix into a corrupted value), and the unknown
-    // key is dropped from the final args object.
     const text =
       '<tool_call>{"name":"write","arguments":{"content":"He said "hi" there","extra":"debug","path":"/tmp/a"}}</tool_call>';
     const tools = [
@@ -263,26 +310,578 @@ describe("parseGeneratedText JSON repair", () => {
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     const args = JSON.parse(tool.input);
     expect(args.content).toBe('He said "hi" there');
     expect(args.path).toBe("/tmp/a");
-    // Schema-unknown key dropped from output
-    expect(args).not.toHaveProperty("extra");
+    expect(args.extra).toBe("debug");
+  });
+
+  it("preserves schema-unknown keys when additionalProperties is true", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"He said "hi" there","dynamic":"kept"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        true
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool).toBeTruthy();
+    if (tool?.type !== "tool-call") {
+      throw new Error("expected tool call");
+    }
+    const args = JSON.parse(tool.input);
+    expect(args.content).toBe('He said "hi" there');
+    expect(args.dynamic).toBe("kept");
+  });
+
+  it("calls onError for schema-unknown keys when additionalProperties is false", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"He said "hi" there","debug":"drop me","path":"/tmp/a"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects schema-unknown keys in strict repair even when arguments parse cleanly", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects schema-unknown keys for jsonSchema-wrapped strict schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        jsonSchema: {
+          type: "object",
+          properties: {
+            content: { type: "string" },
+            path: { type: "string" },
+          },
+          additionalProperties: false,
+        },
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects schema-unknown keys for clean strict JSON", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects clean strict JSON with prototype-sensitive argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","__proto__":{"polluted":true}}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects prototype-sensitive argument keys even when unknown keys are allowed", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","constructor":{"polluted":true}}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        true
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unquoted strict RJSON with prototype-sensitive argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{name:"write",arguments:{__proto__:{polluted:true},content:"ok"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unquoted prototype-sensitive RJSON keys after comments", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const tools = [makeTool("write", { content: { type: "string" } }, false)];
+    for (const prefix of ["/* comment */", "// comment\n"]) {
+      onError.mockClear();
+      const text = `<tool_call>{name:"write",arguments:{${prefix}__proto__:{polluted:true},content:"ok"}}</tool_call>`;
+      const out = p.parseGeneratedText({ text, tools, options: { onError } });
+      expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
+  it("rejects prototype-sensitive RJSON keys after leading comments", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const tools = [makeTool("write", { content: { type: "string" } }, true)];
+    const text =
+      '<tool_call>/*{}*/{name:"write",arguments:{__proto__:{polluted:true},content:"ok"}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects escaped single-quoted strict RJSON prototype-sensitive argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      "<tool_call>{name:\"write\",arguments:{'\\u005f\\u005fproto__':{polluted:true},content:\"ok\"}}</tool_call>";
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts coercible keys before strict schema validation", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"translate","arguments":{"text":"Ship","target_language":"fr","formality":"casual"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("translate", {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+          targetLanguage: { type: "string" },
+          formality: { type: "string" },
+        },
+        required: ["text", "targetLanguage", "formality"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool).toBeTruthy();
+    if (tool?.type !== "tool-call") {
+      throw new Error("expected tool call");
+    }
+    expect(JSON.parse(tool.input)).toEqual({
+      text: "Ship",
+      targetLanguage: "fr",
+      formality: "casual",
+    });
+  });
+
+  it("rejects __proto__ keys in strict repair bookkeeping", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"__proto__":{"content":"bypass"},"content":"He said "hi" there"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts common grouped and quantified patternProperties for strict schemas", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","x-debug":"kept","y-trace":"yes","z-123":"num","path":"/tmp/a"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        patternProperties: {
+          "^(x|y)-": { type: "string" },
+          "^z-[0-9]+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool).toBeTruthy();
+    if (tool?.type !== "tool-call") {
+      throw new Error("expected tool call");
+    }
+    const args = JSON.parse(tool.input);
+    expect(args["x-debug"]).toBe("kept");
+    expect(args["y-trace"]).toBe("yes");
+    expect(args["z-123"]).toBe("num");
+  });
+
+  it("accepts non-capturing patternProperties groups for strict schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"x-":"ok"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        patternProperties: {
+          "^(?:x-)+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      "x-": "ok",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects patternProperties false matches for strict schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","x-secret":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^x-": false,
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects false property schemas for strict schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","secret":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+          secret: false,
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe patternProperties without regex backtracking", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const slowKey = `${"a".repeat(24)}!`;
+    const text = `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const started = performance.now();
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe repeated patternProperties without groups", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const slowKey = `${"a".repeat(24)}!`;
+    const text = `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^a+a+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const started = performance.now();
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties when unknown keys are allowed", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const slowKey = `${"a".repeat(24)}!`;
+    const text = `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const started = performance.now();
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties with character classes", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","123":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a|[0-9])+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const started = performance.now();
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties with escaped literals", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","aaaa":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(\\x61+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties with unknown matchers", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","secret":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^([^\\n]+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("preserves allowed keys when an unsafe false pattern contains character classes", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","note":"safe"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a|[0-9])+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool).toBeTruthy();
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      content: "ok",
+      note: "safe",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("falls back to text instead of truncating content at schema-unknown key-like text", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"before "quoted" ,"debug":"inside after","path":"/tmp/a"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(
+      out.some((x) => x.type === "text" && x.text.includes("<tool_call>"))
+    ).toBe(true);
   });
 
   it("calls onError when arguments is not the last top-level property (backwards scan limitation)", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
-    // "id" comes after "arguments" — the backwards scan includes
-    // ,"id":"123" in argsBody, which corrupts the arguments object.
-    // This is a known limitation: repair only works when "arguments"
-    // is the last (or second-to-last) top-level property.
     const text =
       '<tool_call>{"name":"edit","arguments":{"content":"He said "hello" to me"},"id":"123"}</tool_call>';
     const tools = [makeTool("edit", { content: { type: "string" } })];
     p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("falls back instead of repairing arguments across trailing top-level fields", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"path":"/tmp/a"},"debug":"drop"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
   });
 
@@ -292,8 +891,7 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"x","arguments":{"a":1,"b":{"c":2}}}</tool_call>';
     const out = p.parseGeneratedText({ text, tools: [] });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     const args = JSON.parse(tool.input);
     expect(args.a).toBe(1);
     expect(args.b).toEqual({ c: 2 });
@@ -311,10 +909,14 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"write","arguments":{"foo":"He said "hi" there","bar":"b"}}</tool_call>';
     const tools = [
-      makeTool("write", {
-        content: { type: "string" },
-        path: { type: "string" },
-      }),
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
     ];
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
     const tool = out.find((x) => x.type === "tool-call");
@@ -352,5 +954,946 @@ describe("parseGeneratedText JSON repair", () => {
     const hasToolOrError =
       out.some((x) => x.type === "tool-call") || onError.mock.calls.length > 0;
     expect(hasToolOrError).toBe(true);
+  });
+
+  it("rejects prototype-sensitive argument keys without a schema policy", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"constructor":"pollute"}}</tool_call>';
+    const out = p.parseGeneratedText({
+      text,
+      tools: [],
+      options: { onError },
+    });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested prototype-sensitive argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"prototype":"pollute"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested __proto__ argument keys parsed onto prototypes", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"__proto__":{"polluted":true}}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects missing required argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text = '<tool_call>{"name":"write","arguments":{}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested schema-unknown argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"payload":{"value":"ok","secret":"blocked"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            additionalProperties: false,
+          },
+        },
+        required: ["payload"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested argument keys disallowed by false schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"payload":{"value":"ok","secret":"blocked"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              secret: false,
+              value: { type: "string" },
+            },
+            additionalProperties: true,
+          },
+        },
+        required: ["payload"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects top-level boolean false input schemas", () => {
+    const p = hermesProtocol();
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      false,
+      { jsonSchema: false },
+    ];
+    for (const inputSchema of schemas) {
+      const onError = vi.fn();
+      const text =
+        '<tool_call>{"name":"deny","arguments":{"content":"ok"}}</tool_call>';
+      const out = p.parseGeneratedText({
+        text,
+        tools: [makeSchemaTool("deny", inputSchema)],
+        options: { onError },
+      });
+      expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
+  it("rejects non-object arguments for top-level boolean false input schemas", () => {
+    const p = hermesProtocol();
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      false,
+      { jsonSchema: false },
+    ];
+    const argumentBodies = ["[]", "null", '"x"'];
+
+    for (const inputSchema of schemas) {
+      for (const argumentBody of argumentBodies) {
+        const onError = vi.fn();
+        const text = `<tool_call>{"name":"deny","arguments":${argumentBody}}</tool_call>`;
+        const out = p.parseGeneratedText({
+          text,
+          tools: [makeSchemaTool("deny", inputSchema)],
+          options: { onError },
+        });
+        expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+        expect(onError).toHaveBeenCalled();
+      }
+    }
+  });
+
+  it("rejects non-object arguments for object input schemas", () => {
+    const p = hermesProtocol();
+    const argumentBodies = ["[]", "null", '"x"'];
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+      },
+      {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+        additionalProperties: false,
+      },
+    ];
+    for (const inputSchema of schemas) {
+      for (const argumentBody of argumentBodies) {
+        const onError = vi.fn();
+        const text = `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`;
+        const out = p.parseGeneratedText({
+          text,
+          tools: [makeSchemaTool("write", inputSchema)],
+          options: { onError },
+        });
+        expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+        expect(onError).toHaveBeenCalled();
+      }
+    }
+  });
+
+  it("rejects null for non-nullable typed object properties", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":null}}</tool_call>';
+    const out = p.parseGeneratedText({
+      text,
+      tools: [
+        makeSchemaTool("write", {
+          type: "object",
+          properties: {
+            content: { type: "string" },
+          },
+          required: ["content"],
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts null for nullable object and array properties", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"payload":null,"rows":null}}</tool_call>';
+    const out = p.parseGeneratedText({
+      text,
+      tools: [
+        makeSchemaTool("write", {
+          type: "object",
+          properties: {
+            payload: {
+              type: ["object", "null"],
+              properties: { content: { type: "string" } },
+              required: ["content"],
+              additionalProperties: false,
+            },
+            rows: {
+              type: ["array", "null"],
+              items: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: ["payload", "rows"],
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: null,
+      rows: null,
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-object arguments for allOf-wrapped strict object input schemas", () => {
+    const p = hermesProtocol();
+    const argumentBodies = ["[]", '"scalar"'];
+    for (const argumentBody of argumentBodies) {
+      const onError = vi.fn();
+      const text = `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`;
+      const out = p.parseGeneratedText({
+        text,
+        tools: [
+          makeSchemaTool("write", {
+            allOf: [
+              {
+                type: "object",
+                properties: {
+                  content: { type: "string" },
+                },
+                required: ["content"],
+                additionalProperties: false,
+              },
+            ],
+          }),
+        ],
+        options: { onError },
+      });
+      expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
+  it("coerces keys before validating allOf-wrapped strict object schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"translate","arguments":{"target_language":"ko"}}</tool_call>';
+    const out = p.parseGeneratedText({
+      text,
+      tools: [
+        makeSchemaTool("translate", {
+          allOf: [
+            {
+              type: "object",
+              properties: {
+                targetLanguage: { type: "string" },
+              },
+              required: ["targetLanguage"],
+              additionalProperties: false,
+            },
+          ],
+        }),
+      ],
+      options: { onError },
+    });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      targetLanguage: "ko",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects strict primitive property values that cannot be coerced", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"count","arguments":{"count":"abc"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("count", {
+        type: "object",
+        properties: {
+          count: { type: "integer" },
+        },
+        required: ["count"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unknown keys through strict allOf schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"safe":"ok","secret":"leak"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        allOf: [
+          {
+            type: "object",
+            properties: {
+              safe: { type: "string" },
+            },
+            required: ["safe"],
+            additionalProperties: false,
+          },
+        ],
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested array item keys through allOf schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"payload":[{"value":"ok","secret":"leak"}]}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            allOf: [
+              {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    value: { type: "string" },
+                  },
+                  additionalProperties: false,
+                },
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested tuple item keys through draft-07 items arrays", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"rows":[{"value":"ok","secret":"leak"}]}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          rows: {
+            type: "array",
+            items: [
+              {
+                type: "object",
+                properties: {
+                  value: { type: "string" },
+                },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+            additionalItems: false,
+          },
+        },
+        required: ["rows"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects values that match multiple oneOf schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"payload":{"a":"ok"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts values that match a primitive oneOf branch", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":"abc"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { content: { type: "string" } },
+                required: ["content"],
+                additionalProperties: false,
+              },
+              { type: "string" },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: "abc",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("accepts oneOf object branches distinguished by nested primitive value types", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"value":"abc"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "number" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: { value: "abc" },
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does not count numeric strings as numeric oneOf matches", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"value":"123"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "integer" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: { value: "123" },
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-finite numeric strings for number and integer schemas", () => {
+    const p = hermesProtocol();
+    const cases = [
+      { schemaType: "number", value: "1e999" },
+      { schemaType: "integer", value: "9".repeat(400) },
+    ];
+    for (const { schemaType, value } of cases) {
+      const onError = vi.fn();
+      const text = `<tool_call>{"name":"edit","arguments":{"value":${JSON.stringify(value)}}}</tool_call>`;
+      const out = p.parseGeneratedText({
+        text,
+        tools: [
+          makeSchemaTool("edit", {
+            type: "object",
+            properties: {
+              value: { type: schemaType },
+            },
+            required: ["value"],
+            additionalProperties: false,
+          }),
+        ],
+        options: { onError },
+      });
+      expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
+  it("rejects decimal strings for integer oneOf branches", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"value":"1.5"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "integer" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts oneOf object branches distinguished by nested enum values", () => {
+    const p = hermesProtocol();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string", enum: ["a"] } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "string", enum: ["b"] } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    for (const value of ["a", "b"]) {
+      const onError = vi.fn();
+      const text = `<tool_call>{"name":"edit","arguments":{"payload":{"value":"${value}"}}}</tool_call>`;
+      const out = p.parseGeneratedText({ text, tools, options: { onError } });
+      const tool = out.find((x) => x.type === "tool-call");
+      expect(tool?.type).toBe("tool-call");
+      expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+        payload: { value },
+      });
+      expect(onError).not.toHaveBeenCalled();
+    }
+  });
+
+  it("accepts oneOf object branches distinguished by nested const values", () => {
+    const p = hermesProtocol();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "text" },
+                  value: { type: "string" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "count" },
+                  value: { type: "integer" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    for (const [kind, value] of [
+      ["text", '"hello"'],
+      ["count", "3"],
+    ]) {
+      const onError = vi.fn();
+      const text = `<tool_call>{"name":"edit","arguments":{"payload":{"kind":"${kind}","value":${value}}}}</tool_call>`;
+      const out = p.parseGeneratedText({ text, tools, options: { onError } });
+      const tool = out.find((x) => x.type === "tool-call");
+      expect(tool?.type).toBe("tool-call");
+      expect(onError).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rejects oneOf object branches with mismatched const values", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"kind":"count","value":"hello"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "text" },
+                  value: { type: "string" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "count" },
+                  value: { type: "integer" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("does not let primitive oneOf branches bypass object key constraints", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"content":"ok","extra":"bad"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { content: { type: "string" } },
+                required: ["content"],
+                additionalProperties: false,
+              },
+              { type: "string" },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("applies every matching property and pattern schema", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"other":"bad"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+        patternProperties: {
+          "^payload$": {
+            type: "object",
+            properties: {
+              must: { type: "string" },
+            },
+            required: ["must"],
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("preserves allowed extra argument keys when a denied pattern is unsafe", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","note":"safe"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool).toBeTruthy();
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      content: "ok",
+      note: "safe",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe positive patternProperties that may match constrained keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"aaaa":123}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        patternProperties: {
+          "^(a+)+$": { type: "string", enum: ["allowed"] },
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unsafe false patternProperties that may match key substrings", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","x-secret":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "(secret+)+": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unsafe false patternProperties that may match unanchored suffixes", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","ba":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "(a+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects keys that may match unsafe false patterns with escaped range endpoints", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","m":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          [String.raw`^([a-\x7a]+)+$`]: false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -915,6 +915,7 @@ describe("parseGeneratedText JSON repair", () => {
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
     const tool = out.find((x) => x.type === "tool-call");
     expect(tool).toBeUndefined();
+    expect(out).toContainEqual({ type: "text", text });
     expect(onError).toHaveBeenCalled();
   });
 

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -297,6 +297,29 @@ describe("parseGeneratedText JSON repair", () => {
     expect(args.b).toEqual({ c: 2 });
   });
 
+  it("bails out when all parsed keys are schema-unknown (no empty-args fallback)", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    // Tool schema knows "content" and "path", but the model hallucinates
+    // different key names ("foo", "bar") AND emits unescaped quotes so
+    // parseRJSON fails and repair runs. Without the guard, repair would
+    // skip every key via knownKeySet and return {name, arguments: {}} —
+    // emitting a tool call with empty args (worse than failing). The guard
+    // makes repair bail out to onError when no known key survives.
+    const text =
+      '<tool_call>{"name":"write","arguments":{"foo":"He said "hi" there","bar":"b"}}</tool_call>';
+    const tools = [
+      makeTool("write", {
+        content: { type: "string" },
+        path: { type: "string" },
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("bails out on arguments body larger than 100KB", () => {
     const onError = vi.fn();
     const p = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -322,6 +322,24 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("falls through to text when malformed input uses relaxed-JSON syntax (repair is strict-JSON only)", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    // Unquoted `name` / `arguments` keys (relaxed JSON) combined with an
+    // unescaped quote inside a value. parseRJSON rejects the unescaped
+    // quote, and the strict-JSON repair path cannot locate top-level keys
+    // without double quotes. Expected behavior: same as pre-repair — the
+    // segment falls through to text output via onError. This pins the
+    // documented limitation; extending repair to relaxed JSON is out of scope.
+    const text =
+      '<tool_call>{name:"edit",arguments:{content:"He said "hi" there"}}</tool_call>';
+    const tools = [makeTool("edit", { content: { type: "string" } })];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("bails out on arguments body larger than 100KB", () => {
     const onError = vi.fn();
     const p = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -1851,6 +1851,36 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("rejects null arguments without a matching nullable schema", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"write","arguments":null}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expectNoToolInputLifecycle(out);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts null for nullable object and array properties", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -1,0 +1,114 @@
+import type {
+  LanguageModelV3FunctionTool,
+  LanguageModelV3StreamPart,
+} from "@ai-sdk/provider";
+import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
+import { describe, expect, it, vi } from "vitest";
+import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
+import {
+  pipeWithTransformer,
+  stopFinishReason,
+  zeroUsage,
+} from "../../../test-helpers";
+
+function makeTool(
+  name: string,
+  properties: Record<string, { type: string }>
+): LanguageModelV3FunctionTool {
+  return {
+    type: "function",
+    name,
+    inputSchema: {
+      type: "object",
+      properties,
+    },
+  };
+}
+
+describe("hermesProtocol streaming JSON repair", () => {
+  it("repairs streaming tool call with unescaped quotes and emits tool-call", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools: [] });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"content":"He said "hello" to me"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("edit");
+    const args = JSON.parse(tool.input);
+    expect(args.content).toBe('He said "hello" to me');
+    // Should not emit any text-delta with raw tool call markup
+    const textDeltas = out
+      .filter((c) => c.type === "text-delta")
+      .map((c: any) => c.delta)
+      .join("");
+    expect(textDeltas).not.toContain("<tool_call>");
+  });
+
+  it("repairs with known tool schema (tools parameter provided)", async () => {
+    const tools = [
+      makeTool("write", {
+        path: { type: "string" },
+        content: { type: "string" },
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: "<tool_call>",
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '{"name":"write","arguments":{"path":"/tmp/test.js","content":"var x = "hello";',
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '"}}',
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: "</tool_call>",
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    expect(tool.toolName).toBe("write");
+    const args = JSON.parse(tool.input);
+    expect(args.path).toBe("/tmp/test.js");
+    expect(args.content).toContain('"hello"');
+  });
+});

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -157,6 +157,9 @@ describe("hermesProtocol streaming JSON repair", () => {
   it("fails closed instead of throwing for deeply nested arguments", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();
+    const text = `<tool_call>{"name":"deep","arguments":{"data":${makeDeepArrayJson(
+      20_000
+    )}}}</tool_call>`;
     const transformer = protocol.createStreamParser({
       tools: [],
       options: { onError, emitRawToolCallTextOnError: true },
@@ -166,9 +169,7 @@ describe("hermesProtocol streaming JSON repair", () => {
         ctrl.enqueue({
           type: "text-delta",
           id: "1",
-          delta: `<tool_call>{"name":"deep","arguments":{"data":${makeDeepArrayJson(
-            20_000
-          )}}}</tool_call>`,
+          delta: text,
         });
         ctrl.enqueue({
           type: "finish",
@@ -185,7 +186,7 @@ describe("hermesProtocol streaming JSON repair", () => {
 
     expect(out.find(isToolCallPart)).toBeUndefined();
     expectNoToolInputLifecycle(out);
-    expect(collectTextDeltas(out)).toContain('<tool_call>{"name":"deep"');
+    expect(collectTextDeltas(out)).toContain(text);
     expect(onError).toHaveBeenCalled();
   });
 

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -43,6 +43,44 @@ function hasStringToolCallId(value: unknown): value is { toolCallId: string } {
   );
 }
 
+type ToolCallPart = Extract<LanguageModelV3StreamPart, { type: "tool-call" }>;
+type TextDeltaPart = Extract<LanguageModelV3StreamPart, { type: "text-delta" }>;
+
+function isToolCallPart(part: LanguageModelV3StreamPart): part is ToolCallPart {
+  return part.type === "tool-call";
+}
+
+function isTextDeltaPart(
+  part: LanguageModelV3StreamPart
+): part is TextDeltaPart {
+  return part.type === "text-delta";
+}
+
+function makeDeepArrayJson(depth: number): string {
+  let value = "0";
+  for (let index = 0; index < depth; index += 1) {
+    value = `[${value}]`;
+  }
+  return value;
+}
+
+function expectNoToolInputLifecycle(
+  parts: readonly LanguageModelV3StreamPart[]
+): void {
+  expect(parts.some((part) => part.type === "tool-input-start")).toBe(false);
+  expect(parts.some((part) => part.type === "tool-input-delta")).toBe(false);
+  expect(parts.some((part) => part.type === "tool-input-end")).toBe(false);
+}
+
+function collectTextDeltas(
+  parts: readonly LanguageModelV3StreamPart[]
+): string {
+  return parts
+    .filter(isTextDeltaPart)
+    .map((part) => part.delta)
+    .join("");
+}
+
 describe("hermesProtocol streaming JSON repair", () => {
   it("repairs streaming tool call with unescaped quotes and emits tool-call", async () => {
     const protocol = hermesProtocol();
@@ -66,17 +104,89 @@ describe("hermesProtocol streaming JSON repair", () => {
     const out = await convertReadableStreamToArray(
       pipeWithTransformer(rs, transformer)
     );
-    const tool = out.find((c) => c.type === "tool-call") as any;
+    const tool = out.find(isToolCallPart);
     expect(tool).toBeTruthy();
-    expect(tool.toolName).toBe("edit");
-    const args = JSON.parse(tool.input);
+    expect(tool?.toolName).toBe("edit");
+    const args = JSON.parse(tool?.input ?? "{}");
     expect(args.content).toBe('He said "hello" to me');
     // Should not emit any text-delta with raw tool call markup
-    const textDeltas = out
-      .filter((c) => c.type === "text-delta")
-      .map((c: any) => c.delta)
-      .join("");
-    expect(textDeltas).not.toContain("<tool_call>");
+    expect(collectTextDeltas(out)).not.toContain("<tool_call>");
+  });
+
+  it("does not repair relaxed top-level keys even when argument keys are strict JSON", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool("write", {
+        content: { type: "string" },
+        path: { type: "string" },
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError, emitRawToolCallTextOnError: true },
+    });
+    const text =
+      '<tool_call>{name:"write",arguments:{"content":"He said "hi" there","path":"/tmp/a"}}</tool_call>';
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: text,
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+
+    expect(out.find(isToolCallPart)).toBeUndefined();
+    expectNoToolInputLifecycle(out);
+    expect(collectTextDeltas(out)).toContain(text);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed instead of throwing for deeply nested arguments", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [],
+      options: { onError, emitRawToolCallTextOnError: true },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: `<tool_call>{"name":"deep","arguments":{"data":${makeDeepArrayJson(
+            20_000
+          )}}}</tool_call>`,
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+
+    expect(out.find(isToolCallPart)).toBeUndefined();
+    expectNoToolInputLifecycle(out);
+    expect(collectTextDeltas(out)).toContain('<tool_call>{"name":"deep"');
+    expect(onError).toHaveBeenCalled();
   });
 
   it("repairs streaming unescaped quotes before a right brace character", async () => {
@@ -154,10 +264,10 @@ describe("hermesProtocol streaming JSON repair", () => {
     const out = await convertReadableStreamToArray(
       pipeWithTransformer(rs, transformer)
     );
-    const tool = out.find((c) => c.type === "tool-call") as any;
+    const tool = out.find(isToolCallPart);
     expect(tool).toBeTruthy();
-    expect(tool.toolName).toBe("write");
-    const args = JSON.parse(tool.input);
+    expect(tool?.toolName).toBe("write");
+    const args = JSON.parse(tool?.input ?? "{}");
     expect(args.path).toBe("/tmp/test.js");
     expect(args.content).toContain('"hello"');
   });
@@ -898,11 +1008,9 @@ describe("hermesProtocol streaming JSON repair", () => {
         ctrl.close();
       },
     });
-    const started = performance.now();
     const out = await convertReadableStreamToArray(
       pipeWithTransformer(rs, transformer)
     );
-    expect(performance.now() - started).toBeLessThan(150);
     expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
     expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
@@ -945,11 +1053,9 @@ describe("hermesProtocol streaming JSON repair", () => {
         ctrl.close();
       },
     });
-    const started = performance.now();
     const out = await convertReadableStreamToArray(
       pipeWithTransformer(rs, transformer)
     );
-    expect(performance.now() - started).toBeLessThan(150);
     expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
     expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
@@ -992,11 +1098,9 @@ describe("hermesProtocol streaming JSON repair", () => {
         ctrl.close();
       },
     });
-    const started = performance.now();
     const out = await convertReadableStreamToArray(
       pipeWithTransformer(rs, transformer)
     );
-    expect(performance.now() - started).toBeLessThan(150);
     expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
     expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
@@ -1141,6 +1245,46 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("accepts unconstrained unsafe patternProperties when unknown keys are allowed", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        patternProperties: {
+          "^(a+)+$": {},
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"aaaa":"ok"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find(isToolCallPart);
+    expect(tool?.input).toBe('{"aaaa":"ok"}');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("fails closed for unsafe repeated patternProperties without groups", async () => {
     const onError = vi.fn();
     const slowKey = `${"a".repeat(24)}!`;
@@ -1176,11 +1320,9 @@ describe("hermesProtocol streaming JSON repair", () => {
         ctrl.close();
       },
     });
-    const started = performance.now();
     const out = await convertReadableStreamToArray(
       pipeWithTransformer(rs, transformer)
     );
-    expect(performance.now() - started).toBeLessThan(150);
     expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
     expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
@@ -1590,6 +1732,42 @@ describe("hermesProtocol streaming JSON repair", () => {
     }
   });
 
+  it("accepts omitted arguments for no-input tool calls", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [
+        makeSchemaTool("ping", {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"ping"}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find(isToolCallPart);
+    expect(tool?.input).toBe("{}");
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("rejects null for non-nullable typed object properties", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();
@@ -1630,6 +1808,47 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
     expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
     expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts null arguments when the top-level schema allows null", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [
+        makeSchemaTool("write", {
+          type: ["object", "null"],
+          properties: {
+            content: { type: "string" },
+          },
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"write","arguments":null}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find(isToolCallPart);
+    expect(tool?.input).toBe("null");
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("accepts null for nullable object and array properties", async () => {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -3,7 +3,7 @@ import type {
   LanguageModelV3StreamPart,
 } from "@ai-sdk/provider";
 import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
 import {
   pipeWithTransformer,

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -3,7 +3,7 @@ import type {
   LanguageModelV3StreamPart,
 } from "@ai-sdk/provider";
 import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
 import {
   pipeWithTransformer,
@@ -13,7 +13,8 @@ import {
 
 function makeTool(
   name: string,
-  properties: Record<string, { type: string }>
+  properties: Record<string, { type: string }>,
+  additionalProperties?: boolean
 ): LanguageModelV3FunctionTool {
   return {
     type: "function",
@@ -21,8 +22,25 @@ function makeTool(
     inputSchema: {
       type: "object",
       properties,
+      ...(additionalProperties === undefined ? {} : { additionalProperties }),
     },
   };
+}
+
+function makeSchemaTool(
+  name: string,
+  inputSchema: LanguageModelV3FunctionTool["inputSchema"]
+): LanguageModelV3FunctionTool {
+  return { type: "function", name, inputSchema };
+}
+
+function hasStringToolCallId(value: unknown): value is { toolCallId: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "toolCallId" in value &&
+    typeof value.toolCallId === "string"
+  );
 }
 
 describe("hermesProtocol streaming JSON repair", () => {
@@ -59,6 +77,38 @@ describe("hermesProtocol streaming JSON repair", () => {
       .map((c: any) => c.delta)
       .join("");
     expect(textDeltas).not.toContain("<tool_call>");
+  });
+
+  it("repairs streaming unescaped quotes before a right brace character", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [makeTool("edit", { content: { type: "string" } }, false)],
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"content":"He said "}" there"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    if (tool?.type !== "tool-call") {
+      throw new Error("Expected repaired tool call");
+    }
+    expect(JSON.parse(tool.input)).toEqual({ content: 'He said "}" there' });
   });
 
   it("repairs with known tool schema (tools parameter provided)", async () => {
@@ -110,5 +160,2737 @@ describe("hermesProtocol streaming JSON repair", () => {
     const args = JSON.parse(tool.input);
     expect(args.path).toBe("/tmp/test.js");
     expect(args.content).toContain('"hello"');
+  });
+
+  it("calls onError for schema-unknown keys when additionalProperties is false", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          path: { type: "string" },
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"He said "hi" there","debug":"drop me","path":"/tmp/a"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects schema-unknown keys in strict repair even when arguments parse cleanly", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          path: { type: "string" },
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects schema-unknown keys for jsonSchema-wrapped strict schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        jsonSchema: {
+          type: "object",
+          properties: {
+            path: { type: "string" },
+            content: { type: "string" },
+          },
+          additionalProperties: false,
+        },
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects clean strict JSON without leaking tool-input lifecycle events", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          path: { type: "string" },
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects clean strict JSON with prototype-sensitive argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","__proto__":{"polluted":true}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unquoted strict RJSON with prototype-sensitive argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{name:"write",arguments:{__proto__:{polluted:true},content:"ok"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unquoted prototype-sensitive RJSON keys after comments", async () => {
+    const tools = [makeTool("write", { content: { type: "string" } }, false)];
+    for (const prefix of ["/* comment */", "// comment\n"]) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools,
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: `<tool_call>{name:"write",arguments:{${prefix}__proto__:{polluted:true},content:"ok"}}</tool_call>`,
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
+  it("rejects prototype-sensitive RJSON keys after leading comments", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [makeTool("write", { content: { type: "string" } }, true)],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>/*{}*/{name:"write",arguments:{__proto__:{polluted:true},content:"ok"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects prototype-sensitive argument keys even when unknown keys are allowed", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        true
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","constructor":{"polluted":true}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects escaped single-quoted strict RJSON prototype-sensitive argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            "<tool_call>{name:\"write\",arguments:{'\\u005f\\u005fproto__':{polluted:true},content:\"ok\"}}</tool_call>",
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts coercible keys before strict schema validation", async () => {
+    const tools = [
+      makeSchemaTool("translate", {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+          targetLanguage: { type: "string" },
+          formality: { type: "string" },
+        },
+        required: ["text", "targetLanguage", "formality"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"translate","arguments":{"text":"Ship","target_language":"fr","formality":"casual"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool).toBeTruthy();
+    if (tool?.type !== "tool-call") {
+      throw new Error("expected tool call");
+    }
+    expect(JSON.parse(tool.input)).toEqual({
+      text: "Ship",
+      targetLanguage: "fr",
+      formality: "casual",
+    });
+  });
+
+  it("rejects inherited tool call fields from __proto__ wrappers", async () => {
+    const onError = vi.fn();
+    const tools = [makeTool("write", { content: { type: "string" } })];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"__proto__":{"name":"write","arguments":{"content":"ok"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects __proto__ keys in strict repair bookkeeping", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"__proto__":{"content":"bypass"},"content":"He said "hi" there"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts common grouped and quantified patternProperties for strict schemas", async () => {
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(x|y)-": { type: "string" },
+          "^z-[0-9]+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","x-debug":"kept","y-trace":"yes","z-123":"num","path":"/tmp/a"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool).toBeTruthy();
+    if (tool?.type !== "tool-call") {
+      throw new Error("expected tool call");
+    }
+    const args = JSON.parse(tool.input);
+    expect(args["x-debug"]).toBe("kept");
+    expect(args["y-trace"]).toBe("yes");
+    expect(args["z-123"]).toBe("num");
+  });
+
+  it("accepts non-capturing patternProperties groups for strict schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        patternProperties: {
+          "^(?:x-)+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"write","arguments":{"x-":"ok"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      "x-": "ok",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects patternProperties false matches for strict schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^x-": false,
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","x-secret":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects false property schemas for strict schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+          secret: false,
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","secret":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe patternProperties without leaking tool-input events", async () => {
+    const onError = vi.fn();
+    const slowKey = `${"a".repeat(24)}!`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`,
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const started = performance.now();
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties when unknown keys are allowed", async () => {
+    const onError = vi.fn();
+    const slowKey = `${"a".repeat(24)}!`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`,
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const started = performance.now();
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties with character classes", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a|[0-9])+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","123":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const started = performance.now();
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties with escaped literals", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(\\x61+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","aaaa":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties with unknown matchers", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^([^\\n]+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","secret":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("preserves allowed keys when an unsafe false pattern contains character classes", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a|[0-9])+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","note":"safe"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool).toBeTruthy();
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      content: "ok",
+      note: "safe",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe repeated patternProperties without groups", async () => {
+    const onError = vi.fn();
+    const slowKey = `${"a".repeat(24)}!`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^a+a+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`,
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const started = performance.now();
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects prototype-sensitive argument keys without a schema policy", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"constructor":"pollute"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested prototype-sensitive argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"prototype":"pollute"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested __proto__ argument keys parsed onto prototypes", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"__proto__":{"polluted":true}}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects missing required argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"write","arguments":{}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested schema-unknown argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            additionalProperties: false,
+          },
+        },
+        required: ["payload"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"payload":{"value":"ok","secret":"blocked"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested argument keys disallowed by false schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              secret: false,
+              value: { type: "string" },
+            },
+            additionalProperties: true,
+          },
+        },
+        required: ["payload"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"payload":{"value":"ok","secret":"blocked"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects top-level boolean false input schemas", async () => {
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      false,
+      { jsonSchema: false },
+    ];
+    for (const inputSchema of schemas) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools: [makeSchemaTool("deny", inputSchema)],
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta:
+              '<tool_call>{"name":"deny","arguments":{"content":"ok"}}</tool_call>',
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
+  it("rejects non-object arguments for top-level boolean false input schemas", async () => {
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      false,
+      { jsonSchema: false },
+    ];
+    const argumentBodies = ["[]", "null", '"x"'];
+
+    for (const inputSchema of schemas) {
+      for (const argumentBody of argumentBodies) {
+        const onError = vi.fn();
+        const protocol = hermesProtocol();
+        const transformer = protocol.createStreamParser({
+          tools: [makeSchemaTool("deny", inputSchema)],
+          options: { onError },
+        });
+        const rs = new ReadableStream<LanguageModelV3StreamPart>({
+          start(ctrl) {
+            ctrl.enqueue({
+              type: "text-delta",
+              id: "1",
+              delta: `<tool_call>{"name":"deny","arguments":${argumentBody}}</tool_call>`,
+            });
+            ctrl.enqueue({
+              type: "finish",
+              finishReason: stopFinishReason,
+              usage: zeroUsage,
+            });
+            ctrl.close();
+          },
+        });
+        const out = await convertReadableStreamToArray(
+          pipeWithTransformer(rs, transformer)
+        );
+        expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+        expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+        expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+        expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+        expect(onError).toHaveBeenCalled();
+      }
+    }
+  });
+
+  it("rejects non-object arguments for object input schemas", async () => {
+    const argumentBodies = ["[]", "null", '"x"'];
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+      },
+      {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+        additionalProperties: false,
+      },
+    ];
+    for (const inputSchema of schemas) {
+      for (const argumentBody of argumentBodies) {
+        const onError = vi.fn();
+        const protocol = hermesProtocol();
+        const transformer = protocol.createStreamParser({
+          tools: [makeSchemaTool("write", inputSchema)],
+          options: { onError },
+        });
+        const rs = new ReadableStream<LanguageModelV3StreamPart>({
+          start(ctrl) {
+            ctrl.enqueue({
+              type: "text-delta",
+              id: "1",
+              delta: `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`,
+            });
+            ctrl.enqueue({
+              type: "finish",
+              finishReason: stopFinishReason,
+              usage: zeroUsage,
+            });
+            ctrl.close();
+          },
+        });
+        const out = await convertReadableStreamToArray(
+          pipeWithTransformer(rs, transformer)
+        );
+        expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+        expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+        expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+        expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+        expect(onError).toHaveBeenCalled();
+      }
+    }
+  });
+
+  it("rejects null for non-nullable typed object properties", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [
+        makeSchemaTool("write", {
+          type: "object",
+          properties: {
+            content: { type: "string" },
+          },
+          required: ["content"],
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":null}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts null for nullable object and array properties", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [
+        makeSchemaTool("write", {
+          type: "object",
+          properties: {
+            payload: {
+              type: ["object", "null"],
+              properties: { content: { type: "string" } },
+              required: ["content"],
+              additionalProperties: false,
+            },
+            rows: {
+              type: ["array", "null"],
+              items: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: ["payload", "rows"],
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"payload":null,"rows":null}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: null,
+      rows: null,
+    });
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-object arguments for allOf-wrapped strict object input schemas", async () => {
+    const argumentBodies = ["[]", '"scalar"'];
+    for (const argumentBody of argumentBodies) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools: [
+          makeSchemaTool("write", {
+            allOf: [
+              {
+                type: "object",
+                properties: {
+                  content: { type: "string" },
+                },
+                required: ["content"],
+                additionalProperties: false,
+              },
+            ],
+          }),
+        ],
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`,
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
+  it("coerces keys before validating allOf-wrapped strict object schemas", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [
+        makeSchemaTool("translate", {
+          allOf: [
+            {
+              type: "object",
+              properties: {
+                targetLanguage: { type: "string" },
+              },
+              required: ["targetLanguage"],
+              additionalProperties: false,
+            },
+          ],
+        }),
+      ],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"translate","arguments":{"target_language":"ko"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      targetLanguage: "ko",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects strict primitive property values that cannot be coerced", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("count", {
+        type: "object",
+        properties: {
+          count: { type: "integer" },
+        },
+        required: ["count"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"count","arguments":{"count":"abc"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unknown keys through strict allOf schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        allOf: [
+          {
+            type: "object",
+            properties: {
+              safe: { type: "string" },
+            },
+            required: ["safe"],
+            additionalProperties: false,
+          },
+        ],
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"safe":"ok","secret":"leak"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested array item keys through allOf schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            allOf: [
+              {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    value: { type: "string" },
+                  },
+                  additionalProperties: false,
+                },
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"payload":[{"value":"ok","secret":"leak"}]}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested tuple item keys through draft-07 items arrays", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          rows: {
+            type: "array",
+            items: [
+              {
+                type: "object",
+                properties: {
+                  value: { type: "string" },
+                },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+            additionalItems: false,
+          },
+        },
+        required: ["rows"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"rows":[{"value":"ok","secret":"leak"}]}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects values that match multiple oneOf schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"payload":{"a":"ok"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts values that match a primitive oneOf branch", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { content: { type: "string" } },
+                required: ["content"],
+                additionalProperties: false,
+              },
+              { type: "string" },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":"abc"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: "abc",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("accepts oneOf object branches distinguished by nested primitive value types", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "number" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"value":"abc"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: { value: "abc" },
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does not count numeric strings as numeric oneOf matches", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "integer" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"value":"123"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: { value: "123" },
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-finite numeric strings for number and integer schemas", async () => {
+    const cases = [
+      { schemaType: "number", value: "1e999" },
+      { schemaType: "integer", value: "9".repeat(400) },
+    ];
+    for (const { schemaType, value } of cases) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools: [
+          makeSchemaTool("edit", {
+            type: "object",
+            properties: {
+              value: { type: schemaType },
+            },
+            required: ["value"],
+            additionalProperties: false,
+          }),
+        ],
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: `<tool_call>{"name":"edit","arguments":{"value":${JSON.stringify(value)}}}</tool_call>`,
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
+  it("rejects decimal strings for integer oneOf branches", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "integer" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"value":"1.5"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts oneOf object branches distinguished by nested enum values", async () => {
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string", enum: ["a"] } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "string", enum: ["b"] } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    for (const value of ["a", "b"]) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools,
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: `<tool_call>{"name":"edit","arguments":{"payload":{"value":"${value}"}}}</tool_call>`,
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      const tool = out.find((c) => c.type === "tool-call");
+      expect(tool?.type).toBe("tool-call");
+      expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+        payload: { value },
+      });
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
+      expect(onError).not.toHaveBeenCalled();
+    }
+  });
+
+  it("accepts oneOf object branches distinguished by nested const values", async () => {
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "text" },
+                  value: { type: "string" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "count" },
+                  value: { type: "integer" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    for (const [kind, value] of [
+      ["text", '"hello"'],
+      ["count", "3"],
+    ]) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools,
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: `<tool_call>{"name":"edit","arguments":{"payload":{"kind":"${kind}","value":${value}}}}</tool_call>`,
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      const tool = out.find((c) => c.type === "tool-call");
+      expect(tool?.type).toBe("tool-call");
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
+      expect(onError).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rejects oneOf object branches with mismatched const values", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "text" },
+                  value: { type: "string" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "count" },
+                  value: { type: "integer" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"kind":"count","value":"hello"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("does not let primitive oneOf branches bypass object key constraints", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { content: { type: "string" } },
+                required: ["content"],
+                additionalProperties: false,
+              },
+              { type: "string" },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"content":"ok","extra":"bad"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("applies every matching property and pattern schema", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+        patternProperties: {
+          "^payload$": {
+            type: "object",
+            properties: {
+              must: { type: "string" },
+            },
+            required: ["must"],
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"other":"bad"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("preserves allowed extra argument keys when a denied pattern is unsafe", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","note":"safe"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool).toBeTruthy();
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      content: "ok",
+      note: "safe",
+    });
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe positive patternProperties that may match constrained keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        patternProperties: {
+          "^(a+)+$": { type: "string", enum: ["allowed"] },
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"write","arguments":{"aaaa":123}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unsafe false patternProperties that may match key substrings", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "(secret+)+": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","x-secret":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unsafe false patternProperties that may match unanchored suffixes", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "(a+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","ba":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("does not emit stale speculative tool-calls after later invalid chunks", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [],
+      options: { onError },
+    });
+    const input = new TransformStream<
+      LanguageModelV3StreamPart,
+      LanguageModelV3StreamPart
+    >();
+    const out: LanguageModelV3StreamPart[] = [];
+    const done = input.readable.pipeThrough(transformer).pipeTo(
+      new WritableStream<LanguageModelV3StreamPart>({
+        write(part) {
+          out.push(part);
+        },
+      })
+    );
+    const writer = input.writable.getWriter();
+
+    await writer.write({
+      type: "text-delta",
+      id: "1",
+      delta: '<tool_call>{"name":"edit","arguments":{"content":"ok"}}',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await writer.write({
+      type: "text-delta",
+      id: "1",
+      delta: ',"dangling":</tool_call>',
+    });
+    await writer.write({
+      type: "finish",
+      finishReason: stopFinishReason,
+      usage: zeroUsage,
+    });
+    await writer.close();
+    await done;
+
+    const start = out.find((c) => c.type === "tool-input-start");
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(start).toBeTruthy();
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
+    expect(onError).toHaveBeenCalled();
+    const metadata = onError.mock.calls[0]?.[1];
+    expect(hasStringToolCallId(metadata)).toBe(true);
+    if (!hasStringToolCallId(metadata)) {
+      throw new Error("Expected onError metadata with a toolCallId");
+    }
+    expect(metadata.toolCallId).toBe(
+      start?.type === "tool-input-start" ? start.id : undefined
+    );
+  });
+
+  it("rejects keys that may match unsafe false patterns with escaped range endpoints", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          [String.raw`^([a-\x7a]+)+$`]: false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","m":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/parsing-and-errors.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/parsing-and-errors.test.ts
@@ -610,35 +610,4 @@ describe("hermesProtocol streaming parsing and error policy", () => {
     expect(textOutput).toContain("</tool_call>");
   });
 
-  it("does not attempt to recover JSON with unescaped double quotes in string values (#298 proposal-2 is NOT implemented)", async () => {
-    const onError = vi.fn();
-    const protocol = hermesProtocol();
-    const transformer = protocol.createStreamParser({
-      tools: [],
-      options: { onError },
-    });
-    const rs = new ReadableStream<LanguageModelV3StreamPart>({
-      start(ctrl) {
-        ctrl.enqueue({
-          type: "text-delta",
-          id: "1",
-          delta:
-            '<tool_call>{"name":"edit","arguments":{"content":"He said "hello" to me"}}</tool_call>',
-        });
-        ctrl.enqueue({
-          type: "finish",
-          finishReason: stopFinishReason,
-          usage: zeroUsage,
-        });
-        ctrl.close();
-      },
-    });
-    const out = await convertReadableStreamToArray(
-      pipeWithTransformer(rs, transformer)
-    );
-    expect(out.some((c) => c.type === "tool-call")).toBe(false);
-    expect(onError).toHaveBeenCalledTimes(1);
-    const [, metadata] = onError.mock.calls[0];
-    expect(metadata.dropReason).toBe("malformed-tool-call-body");
-  });
 });

--- a/src/__tests__/schema-coerce/pattern-property-regex.unit.test.ts
+++ b/src/__tests__/schema-coerce/pattern-property-regex.unit.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { compileSafePatternPropertyRegex } from "../../schema-coerce";
+
+describe("compileSafePatternPropertyRegex", () => {
+  it("accepts non-capturing group prefixes as safe syntax", () => {
+    const regex = compileSafePatternPropertyRegex("^(?:x-)+$");
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(regex?.test("x-")).toBe(true);
+  });
+});

--- a/src/__tests__/stream-handler/coercion.test.ts
+++ b/src/__tests__/stream-handler/coercion.test.ts
@@ -867,8 +867,8 @@ describe("wrapStream tool-call coercion", () => {
           type: "object",
           properties: {
             finite_int: { type: "integer" },
-            overflow_num: { type: "number" },
-            huge_int: { type: "integer" },
+            overflow_num: { type: ["number", "string"] },
+            huge_int: { type: ["integer", "string"] },
           },
           required: ["finite_int", "overflow_num", "huge_int"],
         },

--- a/src/__tests__/stream-handler/null-input-coercion.test.ts
+++ b/src/__tests__/stream-handler/null-input-coercion.test.ts
@@ -1,0 +1,107 @@
+import type { LanguageModelV3FunctionTool } from "@ai-sdk/provider";
+import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
+import { describe, expect, it, vi } from "vitest";
+
+import type { TCMCoreProtocol } from "../../core/protocols/protocol-interface";
+import { originalToolsSchema } from "../../core/utils/provider-options";
+import { wrapStream } from "../../stream-handler";
+
+const passthroughProtocol: TCMCoreProtocol = {
+  formatTools: ({ toolSystemPromptTemplate }) => toolSystemPromptTemplate([]),
+  formatToolCall: () => "",
+  parseGeneratedText: () => [],
+  createStreamParser: () => new TransformStream(),
+};
+
+describe("wrapStream null input coercion", () => {
+  it("leaves streamed null tool-call input unchanged for non-nullable schemas", async () => {
+    const tools: LanguageModelV3FunctionTool[] = [
+      {
+        type: "function",
+        name: "calc",
+        inputSchema: {
+          type: "object",
+          properties: { a: { type: "number" } },
+        },
+      },
+    ];
+
+    const malformedToolCall = {
+      type: "tool-call",
+      toolCallId: "id",
+      toolName: "calc",
+      input: null,
+    };
+    const doStream = vi.fn().mockResolvedValue({
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue(malformedToolCall);
+          controller.close();
+        },
+      }),
+    });
+
+    const result = await wrapStream({
+      protocol: passthroughProtocol,
+      doStream,
+      doGenerate: vi.fn(),
+      params: {
+        providerOptions: {
+          toolCallMiddleware: {
+            originalTools: originalToolsSchema.encode(tools),
+          },
+        },
+      },
+    });
+    const parts = await convertReadableStreamToArray(result.stream);
+
+    expect(parts[0]).toBe(malformedToolCall);
+  });
+
+  it("preserves streamed null tool-call input for nullable schemas", async () => {
+    const tools: LanguageModelV3FunctionTool[] = [
+      {
+        type: "function",
+        name: "calc",
+        inputSchema: {
+          type: ["object", "null"],
+          properties: { a: { type: "number" } },
+        },
+      },
+    ];
+
+    const doStream = vi.fn().mockResolvedValue({
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            type: "tool-call",
+            toolCallId: "id",
+            toolName: "calc",
+            input: null,
+          });
+          controller.close();
+        },
+      }),
+    });
+
+    const result = await wrapStream({
+      protocol: passthroughProtocol,
+      doStream,
+      doGenerate: vi.fn(),
+      params: {
+        providerOptions: {
+          toolCallMiddleware: {
+            originalTools: originalToolsSchema.encode(tools),
+          },
+        },
+      },
+    });
+    const parts = await convertReadableStreamToArray(result.stream);
+
+    expect(parts[0]).toMatchObject({
+      type: "tool-call",
+      toolName: "calc",
+      input: "null",
+    });
+  });
+});

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -1,6 +1,7 @@
 import {
   compileSafePatternPropertyRegex,
   getSchemaType,
+  schemaIsUnconstrained,
   unwrapJsonSchema,
 } from "../../schema-coerce";
 import { unsafeDeniedPatternMayMatchKey } from "./hermes-unsafe-pattern";
@@ -10,8 +11,37 @@ interface PatternSchemaMatches {
   unsafeDeniedPatterns: string[];
 }
 
+interface CompiledPatternSchema {
+  pattern: string;
+  regex: RegExp | null;
+  schema: unknown;
+}
+
+const patternSchemaCache = new WeakMap<
+  Record<string, unknown>,
+  CompiledPatternSchema[]
+>();
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getCompiledPatternSchemas(
+  patternProperties: Record<string, unknown>
+): CompiledPatternSchema[] {
+  const cached = patternSchemaCache.get(patternProperties);
+  if (cached) {
+    return cached;
+  }
+  const compiled = Object.entries(patternProperties).map(
+    ([pattern, schema]) => ({
+      pattern,
+      regex: compileSafePatternPropertyRegex(pattern),
+      schema,
+    })
+  );
+  patternSchemaCache.set(patternProperties, compiled);
+  return compiled;
 }
 
 function getPatternSchemaMatches(
@@ -23,16 +53,17 @@ function getPatternSchemaMatches(
   }
   const schemas: unknown[] = [];
   const unsafeDeniedPatterns: string[] = [];
-  for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
-    const regex = compileSafePatternPropertyRegex(pattern);
+  for (const { pattern, regex, schema } of getCompiledPatternSchemas(
+    patternProperties
+  )) {
     if (!regex) {
-      if (patternSchema !== true) {
+      if (schema === false || !schemaIsUnconstrained(schema)) {
         unsafeDeniedPatterns.push(pattern);
       }
       continue;
     }
     if (regex.test(key)) {
-      schemas.push(patternSchema);
+      schemas.push(schema);
     }
   }
   return { schemas, unsafeDeniedPatterns };
@@ -259,7 +290,7 @@ function arrayMatchesSchemaKeyShape(
       return argumentValueMatchesSchemaKeyShape(
         item,
         itemSchema,
-        seen,
+        new Set(seen),
         enforceValueKinds
       );
     });
@@ -268,7 +299,7 @@ function arrayMatchesSchemaKeyShape(
     argumentValueMatchesSchemaKeyShape(
       item,
       schema.items,
-      seen,
+      new Set(seen),
       enforceValueKinds
     )
   );

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -6,6 +6,17 @@ import {
 } from "../../schema-coerce";
 import { unsafeDeniedPatternMayMatchKey } from "./hermes-unsafe-pattern";
 
+/**
+ * Maximum recursion depth when validating a parsed argument value against a
+ * tool's JSON schema. This is far above any realistic tool-argument nesting,
+ * so legitimate inputs are always fully validated; beyond it we fail closed
+ * (treat the value as non-matching) so a recursive/cyclic `inputSchema`
+ * combined with a deeply nested value cannot overflow the stack. The caller
+ * then routes the tool call to its `onError` / original-text fallback instead
+ * of throwing an uncaught `RangeError`.
+ */
+const MAX_ARGUMENT_SHAPE_DEPTH = 256;
+
 interface PatternSchemaMatches {
   schemas: unknown[];
   unsafeDeniedPatterns: string[];
@@ -199,7 +210,8 @@ function objectMatchesSchemaKeyShape(
   value: Record<string, unknown>,
   schema: Record<string, unknown>,
   seen: Set<object>,
-  enforceValueKinds: boolean
+  enforceValueKinds: boolean,
+  depth: number
 ): boolean {
   if (requiredKeys(schema).some((key) => !Object.hasOwn(value, key))) {
     return false;
@@ -238,7 +250,8 @@ function objectMatchesSchemaKeyShape(
             nestedValue,
             nestedSchema,
             new Set(seen),
-            enforceValueKinds
+            enforceValueKinds,
+            depth + 1
           )
         )
       ) {
@@ -257,7 +270,8 @@ function objectMatchesSchemaKeyShape(
         nestedValue,
         additionalSchema,
         new Set(seen),
-        enforceValueKinds
+        enforceValueKinds,
+        depth + 1
       )
     ) {
       return false;
@@ -271,7 +285,8 @@ function arrayMatchesSchemaKeyShape(
   value: unknown[],
   schema: Record<string, unknown>,
   seen: Set<object>,
-  enforceValueKinds: boolean
+  enforceValueKinds: boolean,
+  depth: number
 ): boolean {
   let tupleItems: unknown[] | undefined;
   if (Array.isArray(schema.prefixItems)) {
@@ -291,7 +306,8 @@ function arrayMatchesSchemaKeyShape(
         item,
         itemSchema,
         new Set(seen),
-        enforceValueKinds
+        enforceValueKinds,
+        depth + 1
       );
     });
   }
@@ -300,7 +316,8 @@ function arrayMatchesSchemaKeyShape(
       item,
       schema.items,
       new Set(seen),
-      enforceValueKinds
+      enforceValueKinds,
+      depth + 1
     )
   );
 }
@@ -308,7 +325,8 @@ function arrayMatchesSchemaKeyShape(
 function schemaCombinatorsMatch(
   value: unknown,
   schema: Record<string, unknown>,
-  seen: Set<object>
+  seen: Set<object>,
+  depth: number
 ): boolean {
   const branchSeen = () => {
     const nextSeen = new Set(seen);
@@ -326,7 +344,8 @@ function schemaCombinatorsMatch(
       value,
       subSchema,
       branchSeen(),
-      true
+      true,
+      depth + 1
     );
   };
   const allOf = Array.isArray(schema.allOf) ? schema.allOf : undefined;
@@ -356,8 +375,12 @@ export function argumentValueMatchesSchemaKeyShape(
   value: unknown,
   schema: unknown,
   seen = new Set<object>(),
-  enforceValueKinds = false
+  enforceValueKinds = false,
+  depth = 0
 ): boolean {
+  if (depth > MAX_ARGUMENT_SHAPE_DEPTH) {
+    return false;
+  }
   const unwrapped = unwrapJsonSchema(schema);
   if (unwrapped === false) {
     return false;
@@ -374,7 +397,7 @@ export function argumentValueMatchesSchemaKeyShape(
     }
     seen.add(value);
   }
-  if (!schemaCombinatorsMatch(value, unwrapped, seen)) {
+  if (!schemaCombinatorsMatch(value, unwrapped, seen, depth)) {
     return false;
   }
   if (value === null && explicitSchemaTypes(unwrapped).includes("null")) {
@@ -391,7 +414,8 @@ export function argumentValueMatchesSchemaKeyShape(
       value,
       unwrapped,
       seen,
-      enforceValueKinds
+      enforceValueKinds,
+      depth
     );
   }
   if (isRecord(value) && isObjectSchema(unwrapped)) {
@@ -399,7 +423,8 @@ export function argumentValueMatchesSchemaKeyShape(
       value,
       unwrapped,
       seen,
-      enforceValueKinds
+      enforceValueKinds,
+      depth
     );
   }
   return true;

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -1,0 +1,368 @@
+import {
+  compileSafePatternPropertyRegex,
+  getSchemaType,
+  unwrapJsonSchema,
+} from "../../schema-coerce";
+import { unsafeDeniedPatternMayMatchKey } from "./hermes-unsafe-pattern";
+
+interface PatternSchemaMatches {
+  schemas: unknown[];
+  unsafeDeniedPatterns: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getPatternSchemaMatches(
+  patternProperties: unknown,
+  key: string
+): PatternSchemaMatches {
+  if (!isRecord(patternProperties)) {
+    return { schemas: [], unsafeDeniedPatterns: [] };
+  }
+  const schemas: unknown[] = [];
+  const unsafeDeniedPatterns: string[] = [];
+  for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
+    const regex = compileSafePatternPropertyRegex(pattern);
+    if (!regex) {
+      if (patternSchema !== true) {
+        unsafeDeniedPatterns.push(pattern);
+      }
+      continue;
+    }
+    if (regex.test(key)) {
+      schemas.push(patternSchema);
+    }
+  }
+  return { schemas, unsafeDeniedPatterns };
+}
+
+function isObjectSchema(schema: Record<string, unknown>): boolean {
+  return (
+    getSchemaType(schema) === "object" ||
+    isRecord(schema.properties) ||
+    isRecord(schema.patternProperties) ||
+    Array.isArray(schema.required) ||
+    Object.hasOwn(schema, "additionalProperties")
+  );
+}
+
+function isArraySchema(schema: Record<string, unknown>): boolean {
+  return (
+    getSchemaType(schema) === "array" ||
+    Array.isArray(schema.prefixItems) ||
+    Array.isArray(schema.items)
+  );
+}
+
+function explicitSchemaTypes(schema: Record<string, unknown>): string[] {
+  const schemaType = schema.type;
+  if (typeof schemaType === "string") {
+    return [schemaType];
+  }
+  if (!Array.isArray(schemaType)) {
+    return [];
+  }
+  return schemaType.filter((type): type is string => typeof type === "string");
+}
+
+function valueMatchesSchemaType(value: unknown, schemaType: string): boolean {
+  switch (schemaType) {
+    case "array":
+      return Array.isArray(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "null":
+      return value === null;
+    case "number":
+      return typeof value === "number" && Number.isFinite(value);
+    case "object":
+      return isRecord(value);
+    case "string":
+      return typeof value === "string";
+    default:
+      return true;
+  }
+}
+
+function jsonValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((item, index) => jsonValuesEqual(item, right[index]))
+    );
+  }
+  if (!isRecord(left) || !isRecord(right)) {
+    return false;
+  }
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) => Object.hasOwn(right, key) && jsonValuesEqual(left[key], right[key])
+    )
+  );
+}
+
+function valueMatchesSchemaKind(
+  value: unknown,
+  schema: Record<string, unknown>
+): boolean {
+  if (Object.hasOwn(schema, "const") && !jsonValuesEqual(value, schema.const)) {
+    return false;
+  }
+  if (
+    Array.isArray(schema.enum) &&
+    !schema.enum.some((allowed) => jsonValuesEqual(value, allowed))
+  ) {
+    return false;
+  }
+  const schemaTypes = explicitSchemaTypes(schema);
+  if (schemaTypes.length > 0) {
+    return schemaTypes.some((schemaType) =>
+      valueMatchesSchemaType(value, schemaType)
+    );
+  }
+  if (value === null) {
+    return true;
+  }
+  if (isObjectSchema(schema)) {
+    return isRecord(value);
+  }
+  if (isArraySchema(schema)) {
+    return Array.isArray(value);
+  }
+  return true;
+}
+
+function getPropertySchema(
+  schema: Record<string, unknown>,
+  key: string
+): unknown | undefined {
+  const properties = schema.properties;
+  if (!isRecord(properties) || !Object.hasOwn(properties, key)) {
+    return;
+  }
+  return properties[key];
+}
+
+function requiredKeys(schema: Record<string, unknown>): string[] {
+  return Array.isArray(schema.required)
+    ? schema.required.filter(
+        (key): key is string => typeof key === "string" && key.length > 0
+      )
+    : [];
+}
+
+function objectMatchesSchemaKeyShape(
+  value: Record<string, unknown>,
+  schema: Record<string, unknown>,
+  seen: Set<object>,
+  enforceValueKinds: boolean
+): boolean {
+  if (requiredKeys(schema).some((key) => !Object.hasOwn(value, key))) {
+    return false;
+  }
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const propertySchema = getPropertySchema(schema, key);
+    if (propertySchema === false) {
+      return false;
+    }
+
+    const patternMatches = getPatternSchemaMatches(
+      schema.patternProperties,
+      key
+    );
+    const patternSchemas = patternMatches.schemas;
+    if (patternSchemas.some((patternSchema) => patternSchema === false)) {
+      return false;
+    }
+    if (
+      patternMatches.unsafeDeniedPatterns.some((pattern) =>
+        unsafeDeniedPatternMayMatchKey(pattern, key)
+      )
+    ) {
+      return false;
+    }
+
+    const schemasToValidate = [
+      ...(propertySchema === undefined ? [] : [propertySchema]),
+      ...patternSchemas.filter((patternSchema) => patternSchema !== false),
+    ];
+    if (schemasToValidate.length > 0) {
+      if (
+        !schemasToValidate.every((nestedSchema) =>
+          argumentValueMatchesSchemaKeyShape(
+            nestedValue,
+            nestedSchema,
+            new Set(seen),
+            enforceValueKinds
+          )
+        )
+      ) {
+        return false;
+      }
+      continue;
+    }
+
+    const additionalSchema = schema.additionalProperties;
+    if (additionalSchema === false) {
+      return false;
+    }
+    if (
+      isRecord(additionalSchema) &&
+      !argumentValueMatchesSchemaKeyShape(
+        nestedValue,
+        additionalSchema,
+        new Set(seen),
+        enforceValueKinds
+      )
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function arrayMatchesSchemaKeyShape(
+  value: unknown[],
+  schema: Record<string, unknown>,
+  seen: Set<object>,
+  enforceValueKinds: boolean
+): boolean {
+  const tupleItems = Array.isArray(schema.prefixItems)
+    ? schema.prefixItems
+    : Array.isArray(schema.items)
+      ? schema.items
+      : undefined;
+  if (tupleItems) {
+    return value.every((item, index) => {
+      const itemSchema =
+        tupleItems[index] ??
+        (Array.isArray(schema.items) ? schema.additionalItems : schema.items);
+      if (itemSchema === false) {
+        return false;
+      }
+      return argumentValueMatchesSchemaKeyShape(
+        item,
+        itemSchema,
+        seen,
+        enforceValueKinds
+      );
+    });
+  }
+  return value.every((item) =>
+    argumentValueMatchesSchemaKeyShape(
+      item,
+      schema.items,
+      seen,
+      enforceValueKinds
+    )
+  );
+}
+
+function schemaCombinatorsMatch(
+  value: unknown,
+  schema: Record<string, unknown>,
+  seen: Set<object>
+): boolean {
+  const branchSeen = () => {
+    const nextSeen = new Set(seen);
+    if (isRecord(value) || Array.isArray(value)) {
+      nextSeen.delete(value);
+    }
+    return nextSeen;
+  };
+  const branchMatches = (subSchema: unknown) => {
+    const unwrapped = unwrapJsonSchema(subSchema);
+    if (isRecord(unwrapped) && !valueMatchesSchemaKind(value, unwrapped)) {
+      return false;
+    }
+    return argumentValueMatchesSchemaKeyShape(
+      value,
+      subSchema,
+      branchSeen(),
+      true
+    );
+  };
+  const allOf = Array.isArray(schema.allOf) ? schema.allOf : undefined;
+  if (allOf && !allOf.every((subSchema) => branchMatches(subSchema))) {
+    return false;
+  }
+
+  const anyOf = Array.isArray(schema.anyOf) ? schema.anyOf : undefined;
+  if (anyOf && !anyOf.some((subSchema) => branchMatches(subSchema))) {
+    return false;
+  }
+
+  const oneOf = Array.isArray(schema.oneOf) ? schema.oneOf : undefined;
+  if (oneOf) {
+    const matchCount = oneOf.filter((subSchema) =>
+      branchMatches(subSchema)
+    ).length;
+    if (matchCount !== 1) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function argumentValueMatchesSchemaKeyShape(
+  value: unknown,
+  schema: unknown,
+  seen = new Set<object>(),
+  enforceValueKinds = false
+): boolean {
+  const unwrapped = unwrapJsonSchema(schema);
+  if (unwrapped === false) {
+    return false;
+  }
+  if (!isRecord(unwrapped)) {
+    return true;
+  }
+  if (enforceValueKinds && !valueMatchesSchemaKind(value, unwrapped)) {
+    return false;
+  }
+  if (isRecord(value) || Array.isArray(value)) {
+    if (seen.has(value)) {
+      return true;
+    }
+    seen.add(value);
+  }
+  if (!schemaCombinatorsMatch(value, unwrapped, seen)) {
+    return false;
+  }
+  if (value === null && explicitSchemaTypes(unwrapped).includes("null")) {
+    return true;
+  }
+  if (isObjectSchema(unwrapped) && !isRecord(value)) {
+    return false;
+  }
+  if (isArraySchema(unwrapped) && !Array.isArray(value)) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return arrayMatchesSchemaKeyShape(value, unwrapped, seen, enforceValueKinds);
+  }
+  if (isRecord(value) && isObjectSchema(unwrapped)) {
+    return objectMatchesSchemaKeyShape(
+      value,
+      unwrapped,
+      seen,
+      enforceValueKinds
+    );
+  }
+  return true;
+}

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -1669,15 +1669,26 @@ function repairToolCallJsonForTools(
   raw: string,
   tools: LanguageModelV3FunctionTool[]
 ): { name: string; arguments: Record<string, unknown> } | null {
-  const toolName = extractStrictTopLevelStringProperty(raw, "name");
-  if (!toolName) {
+  try {
+    const toolName = extractStrictTopLevelStringProperty(raw, "name");
+    if (!toolName) {
+      return null;
+    }
+    return repairToolCallJson(
+      raw,
+      toolName,
+      extractArgumentKeyPolicy(tools, toolName)
+    );
+  } catch {
+    // Repair is best-effort: any failure — including a RangeError from a
+    // pathologically deep value validated against a recursive/cyclic tool
+    // schema — means repair is not possible. Return null so the caller falls
+    // through to its onError / original-text fallback instead of letting the
+    // error escape parseGeneratedText or the streaming transform. This is the
+    // catch-all backstop; the primary guard is MAX_ARGUMENT_SHAPE_DEPTH in
+    // hermes-argument-schema.ts.
     return null;
   }
-  return repairToolCallJson(
-    raw,
-    toolName,
-    extractArgumentKeyPolicy(tools, toolName)
-  );
 }
 
 function processToolCallJson(

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -773,6 +773,10 @@ function repairToolCallJson(
       return null;
     }
   }
+  // Guard: if the schema filter skipped every parsed key, we have nothing
+  // meaningful to emit. Returning {arguments: {}} here would trigger a
+  // tool invocation with empty args — worse than reporting parse failure.
+  if (knownKeySet && Object.keys(args).length === 0) return null;
   return { name: toolName, arguments: args };
 }
 

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -495,10 +495,252 @@ function normalizeJsonStringCtrl(json: string): string {
   return parts.join("");
 }
 
+/**
+ * Extract known argument key names from the tool schema matching the
+ * tool name found in a (possibly malformed) JSON string.
+ */
+function extractKnownArgKeys(
+  tools: LanguageModelV3FunctionTool[],
+  toolCallJson: string
+): string[] | undefined {
+  const nameMatch = toolCallJson.match(/"name"\s*:\s*"([^"]+)"/);
+  if (!nameMatch) return undefined;
+  const tool = tools.find((t) => t.name === nameMatch[1]);
+  if (!tool?.inputSchema?.properties) return undefined;
+  return Object.keys(
+    tool.inputSchema.properties as Record<string, unknown>
+  );
+}
+
+/**
+ * Attempt to repair a malformed tool-call JSON string where the model
+ * failed to escape double-quotes inside string values.  Returns the
+ * parsed result or null when repair is not possible.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: JSON repair requires manual character-level scanning with multiple heuristic passes.
+function repairToolCallJson(
+  raw: string,
+  knownArgKeys?: string[]
+): { name: string; arguments: Record<string, unknown> } | null {
+  // 1. Extract tool name
+  const nameMatch = raw.match(/"name"\s*:\s*"([^"]+)"/);
+  if (!nameMatch) return null;
+  const toolName = nameMatch[1];
+
+  // 2. Find arguments object boundaries
+  const argsMatch = raw.match(/"arguments"\s*:\s*\{/);
+  if (!argsMatch || argsMatch.index === undefined) return null;
+  const argsStart = argsMatch.index + argsMatch[0].length;
+
+  // 3. Find closing braces from end (arguments + outer object)
+  let outerClose = -1;
+  for (let i = raw.length - 1; i >= argsStart; i--) {
+    if (raw.charAt(i) === "}") {
+      outerClose = i;
+      break;
+    }
+    if (!/\s/.test(raw.charAt(i))) break;
+  }
+  if (outerClose === -1) return null;
+
+  let argsClose = -1;
+  for (let j = outerClose - 1; j >= argsStart; j--) {
+    if (raw.charAt(j) === "}") {
+      argsClose = j;
+      break;
+    }
+    if (!/\s/.test(raw.charAt(j))) break;
+  }
+  if (argsClose === -1) return null;
+
+  const argsBody = raw.substring(argsStart, argsClose);
+
+  // 4. Try standard parse first
+  try {
+    return {
+      name: toolName,
+      arguments: JSON.parse(`{${argsBody}}`) as Record<string, unknown>,
+    };
+  } catch {
+    /* fall through to repair */
+  }
+
+  // 5. Collect key positions
+  const firstKeyMatch = argsBody.match(/^\s*"([^"]+)"\s*:\s*/);
+  if (!firstKeyMatch) return null;
+  let allKeys: Array<{
+    key: string;
+    matchStart: number;
+    valueStart: number;
+  }> = [
+    {
+      key: firstKeyMatch[1],
+      matchStart: 0,
+      valueStart: firstKeyMatch[0].length,
+    },
+  ];
+  const kvPattern = /,\s*"([^"]+)"\s*:\s*/g;
+  let m: RegExpExecArray | null;
+  while ((m = kvPattern.exec(argsBody)) !== null) {
+    allKeys.push({
+      key: m[1],
+      matchStart: m.index,
+      valueStart: m.index + m[0].length,
+    });
+  }
+
+  // 6. Filter by known keys if provided
+  if (knownArgKeys && knownArgKeys.length > 0) {
+    const known = new Set(knownArgKeys);
+    allKeys = allKeys.filter((entry) => known.has(entry.key));
+  }
+
+  // 7. Handle duplicate key names with scoring heuristic
+  const firstByKey: Record<string, number> = {};
+  const lastByKey: Record<string, number> = {};
+  for (let idx = 0; idx < allKeys.length; idx++) {
+    if (!(allKeys[idx].key in firstByKey))
+      firstByKey[allKeys[idx].key] = idx;
+    lastByKey[allKeys[idx].key] = idx;
+  }
+  const firstPositions = allKeys.filter(
+    (_, i) => firstByKey[allKeys[i].key] === i
+  );
+  const lastPositions = allKeys.filter(
+    (_, i) => lastByKey[allKeys[i].key] === i
+  );
+
+  let keyPositions: typeof allKeys;
+  if (
+    firstPositions.length === lastPositions.length &&
+    firstPositions.every(
+      (fp, i) => fp.matchStart === lastPositions[i].matchStart
+    )
+  ) {
+    keyPositions = firstPositions;
+  } else {
+    function scorePositions(
+      positions: typeof allKeys
+    ): [number, number] {
+      let rawOk = 0;
+      let repaired = 0;
+      for (let si = 0; si < positions.length; si++) {
+        const svs = positions[si].valueStart;
+        const sve =
+          si + 1 < positions.length
+            ? positions[si + 1].matchStart
+            : argsBody.length;
+        const srv = argsBody.substring(svs, sve).replace(/,\s*$/, "");
+        try {
+          JSON.parse(srv);
+          rawOk++;
+          continue;
+        } catch {
+          /* skip */
+        }
+        if (srv.charAt(0) === '"') {
+          let seq = srv.length - 1;
+          while (seq > 0 && srv.charAt(seq) !== '"') seq--;
+          if (seq > 0) {
+            const sinner = srv.substring(1, seq);
+            let sesc = "";
+            let sbs = 0;
+            for (const sch of sinner) {
+              if (sch === "\\") {
+                sbs++;
+                sesc += sch;
+              } else if (sch === '"' && sbs % 2 === 0) {
+                sbs = 0;
+                sesc += '\\"';
+              } else {
+                sbs = 0;
+                sesc += sch;
+              }
+            }
+            sesc = sesc
+              .replace(/\n/g, "\\n")
+              .replace(/\r/g, "\\r")
+              .replace(/\t/g, "\\t");
+            try {
+              JSON.parse(`"${sesc}"`);
+              repaired++;
+            } catch {
+              /* skip */
+            }
+          }
+        }
+      }
+      return [rawOk, repaired];
+    }
+    const fs = scorePositions(firstPositions);
+    const ls = scorePositions(lastPositions);
+    keyPositions =
+      ls[0] > fs[0] || (ls[0] === fs[0] && ls[1] > fs[1])
+        ? lastPositions
+        : firstPositions;
+  }
+  allKeys = keyPositions;
+  if (allKeys.length === 0) return null;
+
+  // 8. Repair each value by escaping unescaped quotes
+  const args: Record<string, unknown> = {};
+  for (let i = 0; i < allKeys.length; i++) {
+    const kp = allKeys[i];
+    const vs = kp.valueStart;
+    const ve =
+      i + 1 < allKeys.length
+        ? allKeys[i + 1].matchStart
+        : argsBody.length;
+    let rv = argsBody.substring(vs, ve).replace(/,\s*$/, "");
+    try {
+      args[kp.key] = JSON.parse(rv);
+      continue;
+    } catch {
+      /* needs repair */
+    }
+    if (rv.charAt(0) === '"') {
+      let eq = rv.length - 1;
+      while (eq > 0 && rv.charAt(eq) !== '"') eq--;
+      if (eq <= 0) {
+        args[kp.key] = rv;
+        continue;
+      }
+      const inner = rv.substring(1, eq);
+      let esc = "";
+      let bs = 0;
+      for (const ch of inner) {
+        if (ch === "\\") {
+          bs++;
+          esc += ch;
+        } else if (ch === '"' && bs % 2 === 0) {
+          bs = 0;
+          esc += '\\"';
+        } else {
+          bs = 0;
+          esc += ch;
+        }
+      }
+      esc = esc
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r")
+        .replace(/\t/g, "\\t");
+      try {
+        args[kp.key] = JSON.parse(`"${esc}"`);
+      } catch {
+        args[kp.key] = inner;
+      }
+    } else {
+      args[kp.key] = rv;
+    }
+  }
+  return { name: toolName, arguments: args };
+}
+
 function processToolCallJson(
   toolCallJson: string,
   fullMatch: string,
   processedElements: LanguageModelV3Content[],
+  tools: LanguageModelV3FunctionTool[],
   options?: ParserOptions
 ) {
   try {
@@ -515,6 +757,20 @@ function processToolCallJson(
       input: canonicalizeToolInput(parsedToolCall.arguments),
     });
   } catch (error) {
+    // Attempt repair for unescaped quotes
+    const repaired = repairToolCallJson(
+      toolCallJson,
+      extractKnownArgKeys(tools, toolCallJson)
+    );
+    if (repaired) {
+      processedElements.push({
+        type: "tool-call",
+        toolCallId: generateToolCallId(),
+        toolName: repaired.name,
+        input: canonicalizeToolInput(repaired.arguments),
+      });
+      return;
+    }
     const salvagedToolName =
       extractStreamingToolCallProgress(toolCallJson).toolName;
     const salvagedToolCallId = generateToolCallId();
@@ -1010,6 +1266,17 @@ function emitIncompleteToolCall(
       state.isInsideToolCall = false;
       return;
     } catch {
+      // Attempt repair for unescaped quotes
+      const repaired = repairToolCallJson(
+        state.currentToolCallJson,
+        extractKnownArgKeys(tools, state.currentToolCallJson)
+      );
+      if (repaired) {
+        emitToolCallFromParsed(state, controller, repaired, tools);
+        state.currentToolCallJson = "";
+        state.isInsideToolCall = false;
+        return;
+      }
       // fall through to text fallback
     }
   }
@@ -1136,6 +1403,16 @@ function emitToolCall(context: TagProcessingContext) {
     };
     emitToolCallFromParsed(state, controller, parsedToolCall, tools);
   } catch (error) {
+    // Attempt repair for unescaped quotes
+    const repaired = repairToolCallJson(
+      state.currentToolCallJson,
+      extractKnownArgKeys(tools, state.currentToolCallJson)
+    );
+    if (repaired) {
+      emitToolCallFromParsed(state, controller, repaired, tools);
+      return;
+    }
+
     const errorContent = `${toolCallStart}${state.currentToolCallJson}${toolCallEnd}`;
     const shouldEmitRawFallback = shouldEmitRawToolCallTextOnError(options);
     const streamingToolCallId =
@@ -1412,6 +1689,7 @@ export const hermesProtocol = ({
 
   parseGeneratedText({
     text,
+    tools,
     options,
   }: {
     text: string;
@@ -1458,7 +1736,13 @@ export const hermesProtocol = ({
         );
       }
 
-      processToolCallJson(toolCallJson, fullMatch, processedElements, options);
+      processToolCallJson(
+        toolCallJson,
+        fullMatch,
+        processedElements,
+        tools,
+        options
+      );
       currentIndex = span.endIdx + toolCallEnd.length;
       searchFrom = currentIndex;
     }

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -5,6 +5,12 @@ import type {
   LanguageModelV3ToolCall,
 } from "@ai-sdk/provider";
 import { parse as parseRJSON } from "../../rjson";
+import {
+  coerceBySchema,
+  compileSafePatternPropertyRegex,
+  getSchemaType,
+  unwrapJsonSchema,
+} from "../../schema-coerce";
 import { logParseFailure } from "../utils/debug";
 import { getPotentialStartIndex } from "../utils/get-potential-start-index";
 import { generateId, generateToolCallId } from "../utils/id";
@@ -17,6 +23,10 @@ import {
   shouldEmitRawToolCallTextOnError,
   stringifyToolInputWithSchema,
 } from "../utils/tool-input-streaming";
+import {
+  argumentValueMatchesSchemaKeyShape,
+} from "./hermes-argument-schema";
+import { unsafeDeniedPatternMayMatchKey } from "./hermes-unsafe-pattern";
 import type { ParserOptions, TCMProtocol } from "./protocol-interface";
 
 interface HermesProtocolOptions {
@@ -297,6 +307,20 @@ function canonicalizeToolInput(argumentsValue: unknown): string {
   return JSON.stringify(argumentsValue ?? {});
 }
 
+function isParsedToolCallRecord(
+  value: unknown
+): value is { name: string; arguments: unknown } {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    Object.prototype.hasOwnProperty.call(record, "name") &&
+    Object.prototype.hasOwnProperty.call(record, "arguments") &&
+    typeof record.name === "string"
+  );
+}
+
 const CHAR_CODE_BACKSLASH = 0x5c;
 const CHAR_CODE_QUOTE = 0x22;
 const CHAR_CODE_LF = 0x0a;
@@ -495,23 +519,548 @@ function normalizeJsonStringCtrl(json: string): string {
   return parts.join("");
 }
 
-/**
- * Extract known argument key names from the tool schema matching the
- * tool name found in a (possibly malformed) JSON string.
- */
-function extractKnownArgKeys(
+interface ArgumentKeyPolicy {
+  allowUnknownKeys: boolean;
+  deniedKeys: Set<string>;
+  deniedPatterns: RegExp[];
+  keyPatterns: RegExp[];
+  knownKeys: Set<string>;
+  rejectAll: boolean;
+  rejectNonRecordArguments: boolean;
+  schema: unknown;
+  unsafeDeniedPatterns: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function schemaRejectsNonRecordArguments(
+  schema: unknown,
+  seen = new Set<object>()
+): boolean {
+  const unwrapped = unwrapJsonSchema(schema);
+  if (unwrapped === false) {
+    return true;
+  }
+  if (!isRecord(unwrapped)) {
+    return false;
+  }
+  if (seen.has(unwrapped)) {
+    return false;
+  }
+  seen.add(unwrapped);
+  if (
+    getSchemaType(unwrapped) === "object" ||
+    isRecord(unwrapped.properties) ||
+    isRecord(unwrapped.patternProperties) ||
+    Array.isArray(unwrapped.required) ||
+    Object.hasOwn(unwrapped, "additionalProperties")
+  ) {
+    return true;
+  }
+
+  const allOf = Array.isArray(unwrapped.allOf) ? unwrapped.allOf : undefined;
+  if (
+    allOf?.some((subSchema) =>
+      schemaRejectsNonRecordArguments(subSchema, new Set(seen))
+    )
+  ) {
+    return true;
+  }
+
+  const anyOf = Array.isArray(unwrapped.anyOf) ? unwrapped.anyOf : undefined;
+  if (
+    anyOf &&
+    anyOf.length > 0 &&
+    anyOf.every((subSchema) =>
+      schemaRejectsNonRecordArguments(subSchema, new Set(seen))
+    )
+  ) {
+    return true;
+  }
+
+  const oneOf = Array.isArray(unwrapped.oneOf) ? unwrapped.oneOf : undefined;
+  return (
+    oneOf !== undefined &&
+    oneOf.length > 0 &&
+    oneOf.every((subSchema) =>
+      schemaRejectsNonRecordArguments(subSchema, new Set(seen))
+    )
+  );
+}
+
+function extractArgumentKeyPolicy(
   tools: LanguageModelV3FunctionTool[],
-  toolCallJson: string
-): string[] | undefined {
-  const toolName = extractTopLevelStringProperty(toolCallJson, "name");
-  if (!toolName) {
-    return undefined;
-  }
+  toolName: string
+): ArgumentKeyPolicy | undefined {
   const tool = tools.find((t) => t.name === toolName);
-  if (!tool?.inputSchema?.properties) {
+  const schema = unwrapJsonSchema(tool?.inputSchema);
+  if (schema === false) {
+    return {
+      allowUnknownKeys: false,
+      deniedKeys: new Set(),
+      deniedPatterns: [],
+      keyPatterns: [],
+      knownKeys: new Set(),
+      rejectAll: true,
+      rejectNonRecordArguments: true,
+      schema,
+      unsafeDeniedPatterns: [],
+    };
+  }
+  if (!isRecord(schema)) {
     return undefined;
   }
-  return Object.keys(tool.inputSchema.properties as Record<string, unknown>);
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  const patternProperties = isRecord(schema.patternProperties)
+    ? schema.patternProperties
+    : {};
+  const deniedPatterns: RegExp[] = [];
+  const keyPatterns: RegExp[] = [];
+  const unsafeDeniedPatterns: string[] = [];
+  for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
+    const regex = compileSafePatternPropertyRegex(pattern);
+    if (patternSchema === false) {
+      if (regex) {
+        deniedPatterns.push(regex);
+      } else {
+        unsafeDeniedPatterns.push(pattern);
+      }
+      continue;
+    }
+    if (regex) {
+      keyPatterns.push(regex);
+    } else if (patternSchema !== true) {
+      unsafeDeniedPatterns.push(pattern);
+    }
+  }
+  const propertyEntries = Object.entries(properties);
+  return {
+    allowUnknownKeys: schema.additionalProperties !== false,
+    deniedKeys: new Set(
+      propertyEntries
+        .filter(([, propertySchema]) => propertySchema === false)
+        .map(([key]) => key)
+    ),
+    deniedPatterns,
+    keyPatterns,
+    knownKeys: new Set(
+      propertyEntries
+        .filter(([, propertySchema]) => propertySchema !== false)
+        .map(([key]) => key)
+    ),
+    rejectAll: false,
+    rejectNonRecordArguments: schemaRejectsNonRecordArguments(schema),
+    schema,
+    unsafeDeniedPatterns,
+  };
+}
+
+function applyArgumentKeyPolicy(
+  args: Record<string, unknown>,
+  keyPolicy?: ArgumentKeyPolicy
+): Record<string, unknown> | null {
+  if (keyPolicy?.rejectAll) {
+    return null;
+  }
+  if (containsPrototypeSensitiveArgumentKey(args)) {
+    return null;
+  }
+  if (
+    keyPolicy &&
+    Object.keys(args).some((key) => argumentKeyDeniedByPolicy(key, keyPolicy))
+  ) {
+    return null;
+  }
+  const policyArgs = coerceArgsForKeyPolicy(args, keyPolicy);
+  if (!isRecord(policyArgs)) {
+    return null;
+  }
+  if (containsPrototypeSensitiveArgumentKey(policyArgs)) {
+    return null;
+  }
+  if (
+    keyPolicy &&
+    Object.keys(policyArgs).some((key) =>
+      argumentKeyDeniedByPolicy(key, keyPolicy)
+    )
+  ) {
+    return null;
+  }
+  if (keyPolicy && !keyPolicy.allowUnknownKeys) {
+    const rawUnknownKeys = Object.keys(args).filter(
+      (key) => !argumentKeyMatchesPolicy(key, keyPolicy)
+    );
+    const rawKnownKeys = new Set(
+      Object.keys(args).filter((key) =>
+        argumentKeyMatchesPolicy(key, keyPolicy)
+      )
+    );
+    const coercedKnownKeys = Object.keys(policyArgs).filter((key) =>
+      argumentKeyMatchesPolicy(key, keyPolicy)
+    );
+    const newCoercedKnownKeys = coercedKnownKeys.filter(
+      (key) => !rawKnownKeys.has(key)
+    );
+    if (newCoercedKnownKeys.length < rawUnknownKeys.length) {
+      return null;
+    }
+  }
+  if (
+    keyPolicy &&
+    !argumentValueMatchesSchemaKeyShape(
+      policyArgs,
+      keyPolicy.schema,
+      new Set(),
+      true
+    )
+  ) {
+    return null;
+  }
+  return policyArgs;
+}
+
+function coerceArgsForKeyPolicy(
+  args: Record<string, unknown>,
+  keyPolicy?: ArgumentKeyPolicy
+): unknown {
+  return keyPolicy ? coerceBySchema(args, keyPolicy.schema) : args;
+}
+
+function argumentKeyDeniedByPolicy(
+  key: string,
+  keyPolicy: ArgumentKeyPolicy
+): boolean {
+  return (
+    PROTOTYPE_SENSITIVE_ARGUMENT_KEYS.has(key) ||
+    keyPolicy.deniedKeys.has(key) ||
+    keyPolicy.deniedPatterns.some((pattern) => pattern.test(key)) ||
+    keyPolicy.unsafeDeniedPatterns.some((pattern) =>
+      unsafeDeniedPatternMayMatchKey(pattern, key)
+    )
+  );
+}
+
+function argumentKeyMatchesPolicy(
+  key: string,
+  keyPolicy: ArgumentKeyPolicy
+): boolean {
+  return (
+    keyPolicy.knownKeys.has(key) ||
+    keyPolicy.keyPatterns.some((pattern) => pattern.test(key))
+  );
+}
+
+const PROTOTYPE_SENSITIVE_ARGUMENT_KEYS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+function containsPrototypeSensitiveArgumentKey(
+  value: unknown,
+  seen = new Set<object>()
+): boolean {
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return false;
+    }
+    seen.add(value);
+    return value.some((item) =>
+      containsPrototypeSensitiveArgumentKey(item, seen)
+    );
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+  return Object.keys(value).some(
+    (key) =>
+      PROTOTYPE_SENSITIVE_ARGUMENT_KEYS.has(key) ||
+      containsPrototypeSensitiveArgumentKey(value[key], seen)
+  );
+}
+
+function hasPrototypeSensitiveKeyInJsonLikeObject(text: string): boolean {
+  let firstBrace = skipJsonWhitespace(text, 0);
+  while (true) {
+    const commentEnd = skipJsonComment(text, firstBrace);
+    if (commentEnd === null) {
+      break;
+    }
+    firstBrace = skipJsonWhitespace(text, commentEnd + 1);
+  }
+  if (text.charAt(firstBrace) !== "{") {
+    firstBrace = text.indexOf("{", firstBrace);
+  }
+  if (firstBrace === -1) {
+    return false;
+  }
+  return (collectObjectKeys(text, firstBrace, true) ?? []).some((key) =>
+    PROTOTYPE_SENSITIVE_ARGUMENT_KEYS.has(key)
+  );
+}
+
+function isUnquotedRjsonKeyStart(char: string): boolean {
+  return (
+    char === "_" ||
+    char === "$" ||
+    (char >= "A" && char <= "Z") ||
+    (char >= "a" && char <= "z")
+  );
+}
+
+function isUnquotedRjsonKeyChar(char: string): boolean {
+  return (
+    isUnquotedRjsonKeyStart(char) ||
+    (char >= "0" && char <= "9") ||
+    char === "-"
+  );
+}
+
+function parseQuotedObjectKey(text: string, keyStart: number): {
+  key: string;
+  end: number;
+} | null {
+  const quote = text.charAt(keyStart);
+  let index = keyStart + 1;
+  let escaped = false;
+  while (index < text.length) {
+    const char = text.charAt(index);
+    if (escaped) {
+      escaped = false;
+    } else if (char === "\\") {
+      escaped = true;
+    } else if (char === quote) {
+      if (quote === '"') {
+        try {
+          return {
+            key: JSON.parse(text.slice(keyStart, index + 1)),
+            end: index,
+          };
+        } catch {
+          return null;
+        }
+      }
+      return {
+        key: parseSingleQuotedObjectKey(text.slice(keyStart + 1, index)),
+        end: index,
+      };
+    }
+    index += 1;
+  }
+  return null;
+}
+
+function parseSingleQuotedObjectKey(body: string): string {
+  let result = "";
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body.charAt(index);
+    if (char !== "\\" || index === body.length - 1) {
+      result += char;
+      continue;
+    }
+
+    const escaped = body.charAt(index + 1);
+    if (escaped === "u") {
+      const hex = body.slice(index + 2, index + 6);
+      if (/^[0-9A-Fa-f]{4}$/.test(hex)) {
+        result += String.fromCharCode(Number.parseInt(hex, 16));
+        index += 5;
+        continue;
+      }
+    }
+
+    const decoded = SINGLE_QUOTED_KEY_ESCAPES.get(escaped);
+    result += decoded ?? escaped;
+    index += 1;
+  }
+  return result;
+}
+
+const SINGLE_QUOTED_KEY_ESCAPES = new Map<string, string>([
+  ["'", "'"],
+  ['"', '"'],
+  ["\\", "\\"],
+  ["/", "/"],
+  ["b", "\b"],
+  ["f", "\f"],
+  ["n", "\n"],
+  ["r", "\r"],
+  ["t", "\t"],
+]);
+
+function parseUnquotedObjectKey(text: string, keyStart: number): {
+  key: string;
+  end: number;
+} | null {
+  if (!isUnquotedRjsonKeyStart(text.charAt(keyStart))) {
+    return null;
+  }
+  let index = keyStart + 1;
+  while (index < text.length && isUnquotedRjsonKeyChar(text.charAt(index))) {
+    index += 1;
+  }
+  return { key: text.slice(keyStart, index), end: index - 1 };
+}
+
+function previousSignificantChar(text: string, index: number): string {
+  let cursor = index - 1;
+  while (cursor >= 0) {
+    while (cursor >= 0 && /\s/.test(text.charAt(cursor))) {
+      cursor -= 1;
+    }
+    if (cursor < 0) {
+      return "";
+    }
+    if (text.charAt(cursor) === "/" && text.charAt(cursor - 1) === "*") {
+      const commentStart = text.lastIndexOf("/*", cursor - 2);
+      if (commentStart === -1) {
+        return "/";
+      }
+      cursor = commentStart - 1;
+      continue;
+    }
+    const lineStart = text.lastIndexOf("\n", cursor) + 1;
+    const lineCommentStart = text.lastIndexOf("//", cursor);
+    if (lineCommentStart >= lineStart) {
+      cursor = lineCommentStart - 1;
+      continue;
+    }
+    return text.charAt(cursor);
+  }
+  return "";
+}
+
+function skipJsonComment(text: string, index: number): number | null {
+  if (text.charAt(index) !== "/") {
+    return null;
+  }
+  const next = text.charAt(index + 1);
+  if (next === "/") {
+    const lf = text.indexOf("\n", index + 2);
+    const cr = text.indexOf("\r", index + 2);
+    const end = lf === -1 ? cr : cr === -1 ? lf : Math.min(lf, cr);
+    return end === -1 ? text.length - 1 : end - 1;
+  }
+  if (next === "*") {
+    const end = text.indexOf("*/", index + 2);
+    return end === -1 ? text.length - 1 : end + 1;
+  }
+  return null;
+}
+
+function collectObjectKeys(
+  text: string,
+  objectStart: number,
+  includeNested: boolean
+): string[] | null {
+  if (text.charAt(objectStart) !== "{") {
+    return null;
+  }
+
+  const keys: string[] = [];
+  let depth = 0;
+  let quoteChar: string | null = null;
+  let escaping = false;
+
+  for (let index = objectStart; index < text.length; index += 1) {
+    const char = text.charAt(index);
+
+    if (quoteChar) {
+      if (escaping) {
+        escaping = false;
+      } else if (char === "\\") {
+        escaping = true;
+      } else if (char === quoteChar) {
+        quoteChar = null;
+      }
+      continue;
+    }
+
+    const commentEnd = skipJsonComment(text, index);
+    if (commentEnd !== null) {
+      index = commentEnd;
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return keys;
+      }
+      continue;
+    }
+    if (depth !== 1 && !includeNested) {
+      if (char === '"' || char === "'") {
+        quoteChar = char;
+      }
+      continue;
+    }
+    if (depth < 1) {
+      continue;
+    }
+
+    if (char !== '"' && char !== "'") {
+      if (!isUnquotedRjsonKeyStart(char)) {
+        continue;
+      }
+      const previous = previousSignificantChar(text, index);
+      if (previous === "{" || previous === ",") {
+        const parsedKey = parseUnquotedObjectKey(text, index);
+        if (!parsedKey) {
+          return null;
+        }
+        const valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
+        if (text.charAt(valueCursor) === ":") {
+          keys.push(parsedKey.key);
+          index = valueCursor;
+        }
+      }
+      continue;
+    }
+
+    const parsedKey = parseQuotedObjectKey(text, index);
+    if (!parsedKey) {
+      return null;
+    }
+    const valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
+    if (text.charAt(valueCursor) === ":") {
+      keys.push(parsedKey.key);
+      index = valueCursor;
+      continue;
+    }
+    index = parsedKey.end;
+  }
+
+  return null;
+}
+
+function applyToolArgumentKeyPolicy(
+  toolName: string,
+  args: unknown,
+  tools: LanguageModelV3FunctionTool[]
+): { args: unknown } | null {
+  const keyPolicy = extractArgumentKeyPolicy(tools, toolName);
+  if (keyPolicy?.rejectAll) {
+    return null;
+  }
+  if (!isRecord(args)) {
+    if (keyPolicy?.rejectNonRecordArguments) {
+      return null;
+    }
+    return { args };
+  }
+  const policyArgs = applyArgumentKeyPolicy(args, keyPolicy);
+  return policyArgs === null ? null : { args: policyArgs };
 }
 
 /** Maximum size (in UTF-16 code units) for the arguments body before bailing out of repair. */
@@ -522,29 +1071,21 @@ const FIRST_KEY_RE = /^\s*"([^"]+)"\s*:\s*/;
 const KV_PATTERN_RE = /,\s*"([^"]+)"\s*:\s*/g;
 const TRAILING_COMMA_RE = /,\s*$/;
 
-/**
- * Returns true if `position` in `argsBody` is at nesting depth 0
- * (not inside a nested `{}` or `[]`).
- */
-function isAtTopLevel(argsBody: string, position: number): boolean {
+function getTopLevelPositionMap(argsBody: string): Uint8Array {
+  const topLevelAtPosition = new Uint8Array(argsBody.length + 1);
   let depth = 0;
   let inStr = false;
   let esc = false;
-  for (let i = 0; i < position; i++) {
+  topLevelAtPosition[0] = 1;
+  for (let i = 0; i < argsBody.length; i++) {
     const ch = argsBody[i];
     if (esc) {
       esc = false;
-      continue;
-    }
-    if (ch === "\\" && inStr) {
+    } else if (ch === "\\" && inStr) {
       esc = true;
-      continue;
-    }
-    if (ch === '"') {
+    } else if (ch === '"') {
       inStr = !inStr;
-      continue;
-    }
-    if (!inStr) {
+    } else if (!inStr) {
       if (ch === "{" || ch === "[") {
         depth++;
       }
@@ -552,8 +1093,56 @@ function isAtTopLevel(argsBody: string, position: number): boolean {
         depth--;
       }
     }
+    topLevelAtPosition[i + 1] = depth === 0 ? 1 : 0;
   }
-  return depth === 0;
+  return topLevelAtPosition;
+}
+
+function hasTrailingTopLevelFieldAfterArgumentsObject(argsBody: string): boolean {
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  const hasCommaAfterWhitespace = (fromIndex: number): boolean => {
+    let cursor = fromIndex;
+    while (cursor < argsBody.length && WHITESPACE_RE.test(argsBody[cursor])) {
+      cursor += 1;
+    }
+    return argsBody.charAt(cursor) === ",";
+  };
+  for (let index = 0; index < argsBody.length; index += 1) {
+    const char = argsBody.charAt(index);
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (inStr) {
+      if (char === "\\") {
+        esc = true;
+      } else if (char === '"') {
+        inStr = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inStr = true;
+      continue;
+    }
+    if (char === "{" || char === "[") {
+      depth += 1;
+      continue;
+    }
+    if (char !== "}" && char !== "]") {
+      continue;
+    }
+    if (depth > 0) {
+      depth -= 1;
+      continue;
+    }
+    if (hasCommaAfterWhitespace(index + 1)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -570,11 +1159,10 @@ function isAtTopLevel(argsBody: string, position: number): boolean {
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: JSON repair requires manual character-level scanning with multiple heuristic passes.
 function repairToolCallJson(
   raw: string,
-  knownArgKeys?: string[]
+  toolName: string,
+  keyPolicy?: ArgumentKeyPolicy
 ): { name: string; arguments: Record<string, unknown> } | null {
-  // 1. Extract tool name (depth-aware to avoid matching nested "name" keys)
-  const toolName = extractTopLevelStringProperty(raw, "name");
-  if (!toolName) {
+  if (hasPrototypeSensitiveKeyInJsonLikeObject(raw)) {
     return null;
   }
 
@@ -622,12 +1210,20 @@ function repairToolCallJson(
   if (argsBody.length > REPAIR_MAX_ARGS_BODY_SIZE) {
     return null;
   }
+  if (hasTrailingTopLevelFieldAfterArgumentsObject(argsBody)) {
+    return null;
+  }
 
   // 4. Try standard parse first
   try {
+    const parsedArgs = JSON.parse(`{${argsBody}}`) as Record<string, unknown>;
+    const policyArgs = applyArgumentKeyPolicy(parsedArgs, keyPolicy);
+    if (!policyArgs) {
+      return null;
+    }
     return {
       name: toolName,
-      arguments: JSON.parse(`{${argsBody}}`) as Record<string, unknown>,
+      arguments: policyArgs,
     };
   } catch {
     /* fall through to repair */
@@ -663,27 +1259,26 @@ function repairToolCallJson(
   //     value slices, because their ,"extra":... text gets merged into
   //     the previous value. Schema filtering is applied later when
   //     assigning parsed values into args (step 8 below).
-  const knownKeySet =
-    knownArgKeys && knownArgKeys.length > 0 ? new Set(knownArgKeys) : null;
+  const topLevelAtPosition = getTopLevelPositionMap(argsBody);
   allKeys = allKeys.filter(
     (entry) =>
-      entry.matchStart === 0 || isAtTopLevel(argsBody, entry.matchStart)
+      entry.matchStart === 0 || topLevelAtPosition[entry.matchStart] === 1
   );
 
   // 7. Handle duplicate key names with scoring heuristic
-  const firstByKey: Record<string, number> = {};
-  const lastByKey: Record<string, number> = {};
+  const firstByKey = new Map<string, number>();
+  const lastByKey = new Map<string, number>();
   for (let idx = 0; idx < allKeys.length; idx++) {
-    if (!(allKeys[idx].key in firstByKey)) {
-      firstByKey[allKeys[idx].key] = idx;
+    if (!firstByKey.has(allKeys[idx].key)) {
+      firstByKey.set(allKeys[idx].key, idx);
     }
-    lastByKey[allKeys[idx].key] = idx;
+    lastByKey.set(allKeys[idx].key, idx);
   }
   const firstPositions = allKeys.filter(
-    (_, i) => firstByKey[allKeys[i].key] === i
+    (_, i) => firstByKey.get(allKeys[i].key) === i
   );
   const lastPositions = allKeys.filter(
-    (_, i) => lastByKey[allKeys[i].key] === i
+    (_, i) => lastByKey.get(allKeys[i].key) === i
   );
 
   let keyPositions: typeof allKeys;
@@ -761,15 +1356,9 @@ function repairToolCallJson(
     return null;
   }
 
-  // 8. Repair each value by escaping unescaped quotes.
-  //    Schema-unknown keys are skipped here (their slice was still needed
-  //    for correct boundary detection in step 5b).
-  const args: Record<string, unknown> = {};
+  const args = Object.create(null) as Record<string, unknown>;
   for (let i = 0; i < allKeys.length; i++) {
     const kp = allKeys[i];
-    if (knownKeySet && !knownKeySet.has(kp.key)) {
-      continue;
-    }
     const vs = kp.valueStart;
     const ve =
       i + 1 < allKeys.length ? allKeys[i + 1].matchStart : argsBody.length;
@@ -819,13 +1408,26 @@ function repairToolCallJson(
       return null;
     }
   }
-  // Guard: if the schema filter skipped every parsed key, we have nothing
-  // meaningful to emit. Returning {arguments: {}} here would trigger a
-  // tool invocation with empty args — worse than reporting parse failure.
-  if (knownKeySet && Object.keys(args).length === 0) {
+  if (Object.keys(args).length === 0) {
     return null;
   }
-  return { name: toolName, arguments: args };
+  const policyArgs = applyArgumentKeyPolicy(args, keyPolicy);
+  return policyArgs === null ? null : { name: toolName, arguments: policyArgs };
+}
+
+function repairToolCallJsonForTools(
+  raw: string,
+  tools: LanguageModelV3FunctionTool[]
+): { name: string; arguments: Record<string, unknown> } | null {
+  const toolName = extractTopLevelStringProperty(raw, "name");
+  if (!toolName) {
+    return null;
+  }
+  return repairToolCallJson(
+    raw,
+    toolName,
+    extractArgumentKeyPolicy(tools, toolName)
+  );
 }
 
 function processToolCallJson(
@@ -838,22 +1440,32 @@ function processToolCallJson(
   try {
     const parsedToolCall = parseRJSON(
       normalizeJsonStringCtrl(toolCallJson)
-    ) as {
-      name: string;
-      arguments: unknown;
-    };
+    );
+    if (!isParsedToolCallRecord(parsedToolCall)) {
+      throw new Error("Tool call object is missing own name or arguments");
+    }
+    if (
+      hasPrototypeSensitiveKeyInJsonLikeObject(toolCallJson)
+    ) {
+      throw new Error("Tool call arguments contain prototype-sensitive keys");
+    }
+    const policyArguments = applyToolArgumentKeyPolicy(
+      parsedToolCall.name,
+      parsedToolCall.arguments,
+      tools
+    );
+    if (policyArguments === null) {
+      throw new Error("Tool call arguments contain schema-unknown keys");
+    }
     processedElements.push({
       type: "tool-call",
       toolCallId: generateToolCallId(),
       toolName: parsedToolCall.name,
-      input: canonicalizeToolInput(parsedToolCall.arguments),
+      input: canonicalizeToolInput(policyArguments.args),
     });
   } catch (error) {
     // Attempt repair for unescaped quotes
-    const repaired = repairToolCallJson(
-      toolCallJson,
-      extractKnownArgKeys(tools, toolCallJson)
-    );
+    const repaired = repairToolCallJsonForTools(toolCallJson, tools);
     if (repaired) {
       processedElements.push({
         type: "tool-call",
@@ -897,6 +1509,11 @@ interface StreamState {
   currentToolCallJson: string;
   hasEmittedTextStart: boolean;
   isInsideToolCall: boolean;
+  pendingToolInputProgressVersion: number;
+  speculativeToolCall: {
+    input: string;
+    toolName: string;
+  } | null;
 }
 
 type StreamController =
@@ -932,13 +1549,13 @@ function findTopLevelPropertyValueStart(
   }
 
   let depth = 0;
-  let inString = false;
+  let quoteChar: string | null = null;
   let escaping = false;
 
   for (let index = objectStart; index < text.length; index += 1) {
     const char = text.charAt(index);
 
-    if (inString) {
+    if (quoteChar) {
       if (escaping) {
         escaping = false;
         continue;
@@ -947,9 +1564,15 @@ function findTopLevelPropertyValueStart(
         escaping = true;
         continue;
       }
-      if (char === '"') {
-        inString = false;
+      if (char === quoteChar) {
+        quoteChar = null;
       }
+      continue;
+    }
+
+    const commentEnd = skipJsonComment(text, index);
+    if (commentEnd !== null) {
+      index = commentEnd;
       continue;
     }
 
@@ -962,43 +1585,39 @@ function findTopLevelPropertyValueStart(
       continue;
     }
 
-    if (char !== '"') {
-      continue;
-    }
-
     if (depth !== 1) {
-      inString = true;
+      if (char === '"' || char === "'") {
+        quoteChar = char;
+      }
       continue;
     }
 
-    const keyStart = index + 1;
-    let keyEnd = keyStart;
-    let keyEscaped = false;
-    while (keyEnd < text.length) {
-      const keyChar = text.charAt(keyEnd);
-      if (keyEscaped) {
-        keyEscaped = false;
-      } else if (keyChar === "\\") {
-        keyEscaped = true;
-      } else if (keyChar === '"') {
-        break;
+    let parsedKey: { key: string; end: number } | null = null;
+    if (char === '"' || char === "'") {
+      parsedKey = parseQuotedObjectKey(text, index);
+    } else {
+      if (!isUnquotedRjsonKeyStart(char)) {
+        continue;
       }
-      keyEnd += 1;
+      const previous = previousSignificantChar(text, index);
+      if (previous !== "{" && previous !== ",") {
+        continue;
+      }
+      parsedKey = parseUnquotedObjectKey(text, index);
     }
 
-    if (keyEnd >= text.length || text.charAt(keyEnd) !== '"') {
+    if (!parsedKey) {
       return null;
     }
 
-    const key = text.slice(keyStart, keyEnd);
-    let valueCursor = skipJsonWhitespace(text, keyEnd + 1);
+    let valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
     if (valueCursor >= text.length || text.charAt(valueCursor) !== ":") {
-      index = keyEnd;
+      index = parsedKey.end;
       continue;
     }
 
     valueCursor = skipJsonWhitespace(text, valueCursor + 1);
-    if (key === property) {
+    if (parsedKey.key === property) {
       return valueCursor < text.length ? valueCursor : null;
     }
 
@@ -1199,6 +1818,77 @@ function emitToolInputDelta(
   });
 }
 
+function emitStreamingToolInputProgress(options: {
+  state: StreamState;
+  controller: StreamController;
+  toolCallJson: string;
+  tools: LanguageModelV3FunctionTool[];
+}): boolean {
+  const { state, controller, toolCallJson, tools } = options;
+  const progress = extractStreamingToolCallProgress(toolCallJson);
+  if (!progress.toolName || !progress.argumentsComplete) {
+    return false;
+  }
+  try {
+    const parsedToolCall = parseRJSON(normalizeJsonStringCtrl(toolCallJson));
+    if (!isParsedToolCallRecord(parsedToolCall)) {
+      return false;
+    }
+    if (hasPrototypeSensitiveKeyInJsonLikeObject(toolCallJson)) {
+      return false;
+    }
+    const policyArguments = applyToolArgumentKeyPolicy(
+      parsedToolCall.name,
+      parsedToolCall.arguments,
+      tools
+    );
+    if (policyArguments === null) {
+      return false;
+    }
+    const input = stringifyToolInputWithSchema({
+      toolName: parsedToolCall.name,
+      args: policyArguments.args,
+      tools,
+      fallback: canonicalizeToolInput,
+    });
+    ensureToolInputStart(state, controller, parsedToolCall.name);
+    emitToolInputDelta(state, controller, input);
+    state.speculativeToolCall = {
+      input,
+      toolName: parsedToolCall.name,
+    };
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function scheduleStreamingToolInputProgress(options: {
+  state: StreamState;
+  controller: StreamController;
+  toolCallJson: string;
+  tools: LanguageModelV3FunctionTool[];
+}) {
+  const { state, controller, toolCallJson, tools } = options;
+  state.pendingToolInputProgressVersion += 1;
+  const version = state.pendingToolInputProgressVersion;
+  setTimeout(() => {
+    if (
+      !state.isInsideToolCall ||
+      state.pendingToolInputProgressVersion !== version ||
+      state.currentToolCallJson !== toolCallJson
+    ) {
+      return;
+    }
+    emitStreamingToolInputProgress({
+      state,
+      controller,
+      toolCallJson,
+      tools,
+    });
+  });
+}
+
 function closeToolInput(state: StreamState, controller: StreamController) {
   if (!state.activeToolInput) {
     return;
@@ -1231,64 +1921,13 @@ function emitToolCallFromParsed(
   emitToolInputDelta(state, controller, input);
   const toolCallId = state.activeToolInput?.id ?? generateToolCallId();
   closeToolInput(state, controller);
+  state.speculativeToolCall = null;
   controller.enqueue({
     type: "tool-call",
     toolCallId,
     toolName,
     input,
   } as LanguageModelV3StreamPart);
-}
-
-function canonicalizeArgumentsProgressInput(
-  progress: {
-    argumentsText: string | undefined;
-    argumentsComplete: boolean;
-  },
-  toolName: string,
-  tools: LanguageModelV3FunctionTool[]
-): string | undefined {
-  if (progress.argumentsText === undefined || !progress.argumentsComplete) {
-    return undefined;
-  }
-
-  try {
-    const parsedArguments = parseRJSON(
-      normalizeJsonStringCtrl(progress.argumentsText)
-    );
-    return stringifyToolInputWithSchema({
-      toolName,
-      args: parsedArguments,
-      tools,
-      fallback: canonicalizeToolInput,
-    });
-  } catch {
-    return undefined;
-  }
-}
-
-function emitToolInputProgress(
-  state: StreamState,
-  controller: StreamController,
-  tools: LanguageModelV3FunctionTool[]
-) {
-  if (!(state.isInsideToolCall && state.currentToolCallJson)) {
-    return;
-  }
-
-  const progress = extractStreamingToolCallProgress(state.currentToolCallJson);
-  if (!progress.toolName) {
-    return;
-  }
-
-  ensureToolInputStart(state, controller, progress.toolName);
-  const canonicalProgressInput = canonicalizeArgumentsProgressInput(
-    progress,
-    progress.toolName,
-    tools
-  );
-  if (canonicalProgressInput !== undefined) {
-    emitToolInputDelta(state, controller, canonicalProgressInput);
-  }
 }
 
 function flushBuffer(
@@ -1349,11 +1988,29 @@ function emitIncompleteToolCall(
     try {
       const parsedToolCall = parseRJSON(
         normalizeJsonStringCtrl(state.currentToolCallJson)
-      ) as {
-        name: string;
-        arguments: unknown;
-      };
-      emitToolCallFromParsed(state, controller, parsedToolCall, tools);
+      );
+      if (!isParsedToolCallRecord(parsedToolCall)) {
+        throw new Error("Tool call object is missing own name or arguments");
+      }
+      if (
+        hasPrototypeSensitiveKeyInJsonLikeObject(state.currentToolCallJson)
+      ) {
+        throw new Error("Tool call arguments contain prototype-sensitive keys");
+      }
+      const policyArguments = applyToolArgumentKeyPolicy(
+        parsedToolCall.name,
+        parsedToolCall.arguments,
+        tools
+      );
+      if (policyArguments === null) {
+        throw new Error("Tool call arguments contain schema-unknown keys");
+      }
+      emitToolCallFromParsed(
+        state,
+        controller,
+        { ...parsedToolCall, arguments: policyArguments.args },
+        tools
+      );
       state.currentToolCallJson = "";
       state.isInsideToolCall = false;
       return;
@@ -1450,13 +2107,11 @@ function handleFinishChunk(
 function publishText(
   text: string,
   state: StreamState,
-  controller: StreamController,
-  tools: LanguageModelV3FunctionTool[]
+  controller: StreamController
 ) {
   if (state.isInsideToolCall) {
     closeTextBlock(state, controller);
     state.currentToolCallJson += text;
-    emitToolInputProgress(state, controller, tools);
   } else if (text.length > 0) {
     if (!state.currentTextId) {
       state.currentTextId = generateId();
@@ -1480,28 +2135,45 @@ function emitToolCall(context: TagProcessingContext) {
   try {
     const parsedToolCall = parseRJSON(
       normalizeJsonStringCtrl(state.currentToolCallJson)
-    ) as {
-      name: string;
-      arguments: unknown;
-    };
-    emitToolCallFromParsed(state, controller, parsedToolCall, tools);
+    );
+    if (!isParsedToolCallRecord(parsedToolCall)) {
+      throw new Error("Tool call object is missing own name or arguments");
+    }
+    if (
+      hasPrototypeSensitiveKeyInJsonLikeObject(state.currentToolCallJson)
+    ) {
+      throw new Error("Tool call arguments contain prototype-sensitive keys");
+    }
+    const policyArguments = applyToolArgumentKeyPolicy(
+      parsedToolCall.name,
+      parsedToolCall.arguments,
+      tools
+    );
+    if (policyArguments === null) {
+      throw new Error("Tool call arguments contain schema-unknown keys");
+    }
+    emitToolCallFromParsed(
+      state,
+      controller,
+      { ...parsedToolCall, arguments: policyArguments.args },
+      tools
+    );
   } catch (error) {
     // Attempt repair for unescaped quotes
-    const repaired = repairToolCallJson(
-      state.currentToolCallJson,
-      extractKnownArgKeys(tools, state.currentToolCallJson)
-    );
+    const repaired = repairToolCallJsonForTools(state.currentToolCallJson, tools);
     if (repaired) {
       emitToolCallFromParsed(state, controller, repaired, tools);
       return;
     }
+    const activeToolCallId = state.activeToolInput?.id;
+    const activeToolName = state.activeToolInput?.toolName;
+    state.speculativeToolCall = null;
 
     const errorContent = `${toolCallStart}${state.currentToolCallJson}${toolCallEnd}`;
     const shouldEmitRawFallback = shouldEmitRawToolCallTextOnError(options);
-    const streamingToolCallId =
-      state.activeToolInput?.id ?? generateToolCallId();
+    const streamingToolCallId = activeToolCallId ?? generateToolCallId();
     const streamingToolName =
-      state.activeToolInput?.toolName ??
+      activeToolName ??
       extractStreamingToolCallProgress(state.currentToolCallJson).toolName;
 
     logParseFailure({
@@ -1624,7 +2296,7 @@ function recoverNestedStreamingToolCall(options: {
 }
 
 function processInsideToolCallBoundary(context: TagProcessingContext): boolean {
-  const { state, controller, toolCallStart, toolCallEnd, tools } = context;
+  const { state, controller, toolCallStart, toolCallEnd } = context;
   const currentLength = state.currentToolCallJson.length;
   const combined = state.currentToolCallJson + state.buffer;
   const boundary = findToolCallBoundaryOutsideRjsonSyntax(
@@ -1656,8 +2328,7 @@ function processInsideToolCallBoundary(context: TagProcessingContext): boolean {
   publishText(
     state.buffer.slice(0, relativeEndIndex),
     state,
-    controller,
-    tools
+    controller
   );
   state.buffer = state.buffer.slice(relativeEndIndex + toolCallEnd.length);
   processTagMatch(context);
@@ -1665,7 +2336,7 @@ function processInsideToolCallBoundary(context: TagProcessingContext): boolean {
 }
 
 function processBufferTags(context: TagProcessingContext) {
-  const { state, controller, toolCallStart, tools } = context;
+  const { state, controller, toolCallStart } = context;
 
   while (state.isInsideToolCall) {
     if (!processInsideToolCallBoundary(context)) {
@@ -1680,7 +2351,7 @@ function processBufferTags(context: TagProcessingContext) {
       break;
     }
 
-    publishText(state.buffer.slice(0, startIndex), state, controller, tools);
+    publishText(state.buffer.slice(0, startIndex), state, controller);
     state.buffer = state.buffer.slice(startIndex + toolCallStart.length);
     processTagMatch(context);
 
@@ -1710,12 +2381,23 @@ function handlePartialTag(
       publishText(
         state.buffer.slice(0, potentialEndIndex),
         state,
-        controller,
-        tools
+        controller
       );
+      scheduleStreamingToolInputProgress({
+        state,
+        controller,
+        toolCallJson: state.currentToolCallJson,
+        tools,
+      });
       state.buffer = state.buffer.slice(potentialEndIndex);
     } else {
-      publishText(state.buffer, state, controller, tools);
+      publishText(state.buffer, state, controller);
+      scheduleStreamingToolInputProgress({
+        state,
+        controller,
+        toolCallJson: state.currentToolCallJson,
+        tools,
+      });
       state.buffer = "";
     }
     return;
@@ -1729,12 +2411,11 @@ function handlePartialTag(
     publishText(
       state.buffer.slice(0, potentialIndex),
       state,
-      controller,
-      tools
+      controller
     );
     state.buffer = state.buffer.slice(potentialIndex);
   } else {
-    publishText(state.buffer, state, controller, tools);
+    publishText(state.buffer, state, controller);
     state.buffer = "";
   }
 }
@@ -1852,6 +2533,8 @@ export const hermesProtocol = ({
       currentTextId: null,
       hasEmittedTextStart: false,
       activeToolInput: null,
+      pendingToolInputProgressVersion: 0,
+      speculativeToolCall: null,
     };
 
     return new TransformStream<

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -560,6 +560,12 @@ function isAtTopLevel(argsBody: string, position: number): boolean {
  * Attempt to repair a malformed tool-call JSON string where the model
  * failed to escape double-quotes inside string values.  Returns the
  * parsed result or null when repair is not possible.
+ *
+ * Scope: this path assumes strict JSON structure (double-quoted keys and
+ * string values, per-value `JSON.parse`). Relaxed-JSON malformation
+ * (unquoted keys, single-quoted strings, comments) is out of scope — such
+ * input returns null and the caller falls through to the text segment path,
+ * matching pre-repair behavior.
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: JSON repair requires manual character-level scanning with multiple heuristic passes.
 function repairToolCallJson(

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -985,7 +985,229 @@ function skipJsonComment(text: string, index: number): number | null {
   return null;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: RJSON object-key scanning is a compact state machine.
+interface QuotedScanState {
+  escaping: boolean;
+  quoteChar: string | null;
+}
+
+interface JsonDepthScanState {
+  depth: number;
+  escaping: boolean;
+  inString: boolean;
+}
+
+interface ObjectKeyCandidate {
+  key?: string;
+  nextIndex: number;
+}
+
+interface StrictJsonPropertyCandidate {
+  key?: string;
+  nextIndex: number;
+  valueStart?: number;
+}
+
+function consumeQuotedScanChar(state: QuotedScanState, char: string): boolean {
+  if (!state.quoteChar) {
+    return false;
+  }
+  if (state.escaping) {
+    state.escaping = false;
+  } else if (char === "\\") {
+    state.escaping = true;
+  } else if (char === state.quoteChar) {
+    state.quoteChar = null;
+  }
+  return true;
+}
+
+function objectKeyDepthTransition(
+  state: { depth: number },
+  char: string
+): "closed" | "changed" | "none" {
+  if (char === "{") {
+    state.depth += 1;
+    return "changed";
+  }
+  if (char === "}") {
+    state.depth -= 1;
+    return state.depth === 0 ? "closed" : "changed";
+  }
+  return "none";
+}
+
+function shouldCollectObjectKey(
+  depth: number,
+  includeNested: boolean
+): boolean {
+  return depth >= 1 && (includeNested || depth === 1);
+}
+
+function readUnquotedObjectKeyCandidate(
+  text: string,
+  index: number,
+  char: string
+): ObjectKeyCandidate | null | undefined {
+  if (!isUnquotedRjsonKeyStart(char)) {
+    return;
+  }
+  const previous = previousSignificantChar(text, index);
+  if (!(previous === "{" || previous === ",")) {
+    return;
+  }
+  const parsedKey = parseUnquotedObjectKey(text, index);
+  if (!parsedKey) {
+    return null;
+  }
+  const valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
+  return text.charAt(valueCursor) === ":"
+    ? { key: parsedKey.key, nextIndex: valueCursor }
+    : undefined;
+}
+
+function readQuotedObjectKeyCandidate(
+  text: string,
+  index: number
+): ObjectKeyCandidate | null {
+  const parsedKey = parseQuotedObjectKey(text, index);
+  if (!parsedKey) {
+    return null;
+  }
+  const valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
+  return text.charAt(valueCursor) === ":"
+    ? { key: parsedKey.key, nextIndex: valueCursor }
+    : { nextIndex: parsedKey.end };
+}
+
+function readStrictJsonPropertyCandidate(
+  text: string,
+  index: number
+): StrictJsonPropertyCandidate | null {
+  const parsedKey = parseQuotedObjectKey(text, index);
+  if (!parsedKey) {
+    return null;
+  }
+  let valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
+  if (valueCursor >= text.length || text.charAt(valueCursor) !== ":") {
+    return { nextIndex: parsedKey.end };
+  }
+  valueCursor = skipJsonWhitespace(text, valueCursor + 1);
+  return {
+    key: parsedKey.key,
+    nextIndex: valueCursor - 1,
+    valueStart: valueCursor,
+  };
+}
+
+function readObjectKeyCandidate(
+  text: string,
+  index: number,
+  char: string
+): ObjectKeyCandidate | null | undefined {
+  return char === '"' || char === "'"
+    ? readQuotedObjectKeyCandidate(text, index)
+    : readUnquotedObjectKeyCandidate(text, index, char);
+}
+
+function appendObjectKeyCandidate(
+  keys: string[],
+  text: string,
+  index: number,
+  char: string
+): { invalid: boolean; nextIndex: number } {
+  const candidate = readObjectKeyCandidate(text, index, char);
+  if (candidate === null) {
+    return { invalid: true, nextIndex: index };
+  }
+  if (candidate?.key) {
+    keys.push(candidate.key);
+  }
+  return {
+    invalid: false,
+    nextIndex: candidate?.nextIndex ?? index,
+  };
+}
+
+function consumeJsonStringScanChar(
+  state: JsonDepthScanState,
+  char: string
+): boolean {
+  if (state.escaping) {
+    state.escaping = false;
+    return true;
+  }
+  if (state.inString) {
+    if (char === "\\") {
+      state.escaping = true;
+    } else if (char === '"') {
+      state.inString = false;
+    }
+    return true;
+  }
+  if (char === '"') {
+    state.inString = true;
+    return true;
+  }
+  return false;
+}
+
+function consumeJsonDepthOpen(
+  state: JsonDepthScanState,
+  char: string
+): boolean {
+  if (!(char === "{" || char === "[")) {
+    return false;
+  }
+  state.depth += 1;
+  return true;
+}
+
+function consumeJsonDepthClose(
+  state: JsonDepthScanState,
+  char: string
+): "top-level-close" | "nested-close" | "none" {
+  if (!(char === "}" || char === "]")) {
+    return "none";
+  }
+  if (state.depth > 0) {
+    state.depth -= 1;
+    return "nested-close";
+  }
+  return "top-level-close";
+}
+
+function consumeExistingJsonString(
+  state: JsonDepthScanState,
+  char: string
+): boolean {
+  if (!state.inString) {
+    return false;
+  }
+  if (state.escaping) {
+    state.escaping = false;
+  } else if (char === "\\") {
+    state.escaping = true;
+  } else if (char === '"') {
+    state.inString = false;
+  }
+  return true;
+}
+
+function consumeJsonObjectDepth(
+  state: JsonDepthScanState,
+  char: string
+): boolean {
+  if (char === "{") {
+    state.depth += 1;
+    return true;
+  }
+  if (char === "}") {
+    state.depth = Math.max(0, state.depth - 1);
+    return true;
+  }
+  return false;
+}
+
 function collectObjectKeys(
   text: string,
   objectStart: number,
@@ -996,21 +1218,13 @@ function collectObjectKeys(
   }
 
   const keys: string[] = [];
-  let depth = 0;
-  let quoteChar: string | null = null;
-  let escaping = false;
+  const quoteState: QuotedScanState = { escaping: false, quoteChar: null };
+  const depthState = { depth: 0 };
 
   for (let index = objectStart; index < text.length; index += 1) {
     const char = text.charAt(index);
 
-    if (quoteChar) {
-      if (escaping) {
-        escaping = false;
-      } else if (char === "\\") {
-        escaping = true;
-      } else if (char === quoteChar) {
-        quoteChar = null;
-      }
+    if (consumeQuotedScanChar(quoteState, char)) {
       continue;
     }
 
@@ -1020,57 +1234,25 @@ function collectObjectKeys(
       continue;
     }
 
-    if (char === "{") {
-      depth += 1;
+    const depthTransition = objectKeyDepthTransition(depthState, char);
+    if (depthTransition === "closed") {
+      return keys;
+    }
+    if (depthTransition === "changed") {
       continue;
     }
-    if (char === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return keys;
-      }
-      continue;
-    }
-    if (depth !== 1 && !includeNested) {
+    if (!shouldCollectObjectKey(depthState.depth, includeNested)) {
       if (char === '"' || char === "'") {
-        quoteChar = char;
-      }
-      continue;
-    }
-    if (depth < 1) {
-      continue;
-    }
-
-    if (char !== '"' && char !== "'") {
-      if (!isUnquotedRjsonKeyStart(char)) {
-        continue;
-      }
-      const previous = previousSignificantChar(text, index);
-      if (previous === "{" || previous === ",") {
-        const parsedKey = parseUnquotedObjectKey(text, index);
-        if (!parsedKey) {
-          return null;
-        }
-        const valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
-        if (text.charAt(valueCursor) === ":") {
-          keys.push(parsedKey.key);
-          index = valueCursor;
-        }
+        quoteState.quoteChar = char;
       }
       continue;
     }
 
-    const parsedKey = parseQuotedObjectKey(text, index);
-    if (!parsedKey) {
+    const candidate = appendObjectKeyCandidate(keys, text, index, char);
+    if (candidate.invalid) {
       return null;
     }
-    const valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
-    if (text.charAt(valueCursor) === ":") {
-      keys.push(parsedKey.key);
-      index = valueCursor;
-      continue;
-    }
-    index = parsedKey.end;
+    index = candidate.nextIndex;
   }
 
   return null;
@@ -1087,6 +1269,11 @@ function applyToolArgumentKeyPolicy(
   }
   const normalizedArgs = args === undefined ? {} : args;
   if (!isRecord(normalizedArgs)) {
+    if (normalizedArgs === null) {
+      return topLevelNullArgumentMatchesToolSchema(toolName, tools)
+        ? { args: normalizedArgs }
+        : null;
+    }
     if (
       keyPolicy &&
       argumentValueMatchesSchemaKeyShape(
@@ -1107,6 +1294,22 @@ function applyToolArgumentKeyPolicy(
   return policyArgs === null ? null : { args: policyArgs };
 }
 
+function topLevelNullArgumentMatchesToolSchema(
+  toolName: string,
+  tools: LanguageModelV3FunctionTool[]
+): boolean {
+  const tool = tools.find((candidate) => candidate.name === toolName);
+  if (!tool || tool.inputSchema === undefined) {
+    return false;
+  }
+  return argumentValueMatchesSchemaKeyShape(
+    null,
+    tool.inputSchema,
+    new Set(),
+    true
+  );
+}
+
 /** Maximum size (in UTF-16 code units) for the arguments body before bailing out of repair. */
 const REPAIR_MAX_ARGS_BODY_SIZE = 102_400;
 
@@ -1114,6 +1317,12 @@ const WHITESPACE_RE = /\s/;
 const FIRST_KEY_RE = /^\s*"([^"]+)"\s*:\s*/;
 const KV_PATTERN_RE = /,\s*"([^"]+)"\s*:\s*/g;
 const TRAILING_COMMA_RE = /,\s*$/;
+
+interface JsonRepairKeyPosition {
+  key: string;
+  matchStart: number;
+  valueStart: number;
+}
 
 function getTopLevelPositionMap(argsBody: string): Uint8Array {
   const topLevelAtPosition = new Uint8Array(argsBody.length + 1);
@@ -1142,78 +1351,42 @@ function getTopLevelPositionMap(argsBody: string): Uint8Array {
   return topLevelAtPosition;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Top-level argument scanning is a compact state machine.
+function hasCommaAfterWhitespace(text: string, fromIndex: number): boolean {
+  let cursor = fromIndex;
+  while (cursor < text.length && WHITESPACE_RE.test(text[cursor])) {
+    cursor += 1;
+  }
+  return text.charAt(cursor) === ",";
+}
+
 function hasTrailingTopLevelFieldAfterArgumentsObject(
   argsBody: string
 ): boolean {
-  let depth = 0;
-  let inStr = false;
-  let esc = false;
-  const hasCommaAfterWhitespace = (fromIndex: number): boolean => {
-    let cursor = fromIndex;
-    while (cursor < argsBody.length && WHITESPACE_RE.test(argsBody[cursor])) {
-      cursor += 1;
-    }
-    return argsBody.charAt(cursor) === ",";
+  const state: JsonDepthScanState = {
+    depth: 0,
+    escaping: false,
+    inString: false,
   };
   for (let index = 0; index < argsBody.length; index += 1) {
     const char = argsBody.charAt(index);
-    if (esc) {
-      esc = false;
+    if (consumeJsonStringScanChar(state, char)) {
       continue;
     }
-    if (inStr) {
-      if (char === "\\") {
-        esc = true;
-      } else if (char === '"') {
-        inStr = false;
-      }
+    if (consumeJsonDepthOpen(state, char)) {
       continue;
     }
-    if (char === '"') {
-      inStr = true;
+    const close = consumeJsonDepthClose(state, char);
+    if (close === "none" || close === "nested-close") {
       continue;
     }
-    if (char === "{" || char === "[") {
-      depth += 1;
-      continue;
-    }
-    if (char !== "}" && char !== "]") {
-      continue;
-    }
-    if (depth > 0) {
-      depth -= 1;
-      continue;
-    }
-    if (hasCommaAfterWhitespace(index + 1)) {
+    if (hasCommaAfterWhitespace(argsBody, index + 1)) {
       return true;
     }
   }
   return false;
 }
 
-/**
- * Attempt to repair a malformed tool-call JSON string where the model
- * failed to escape double-quotes inside string values.  Returns the
- * parsed result or null when repair is not possible.
- *
- * Scope: this path assumes strict JSON structure (double-quoted keys and
- * string values, per-value `JSON.parse`). Relaxed-JSON malformation
- * (unquoted keys, single-quoted strings, comments) is out of scope — such
- * input returns null and the caller falls through to the text segment path,
- * matching pre-repair behavior.
- */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: JSON repair requires manual character-level scanning with multiple heuristic passes.
-function repairToolCallJson(
-  raw: string,
-  toolName: string,
-  keyPolicy?: ArgumentKeyPolicy
-): { name: string; arguments: Record<string, unknown> } | null {
-  if (hasPrototypeSensitiveKeyInJsonLikeObject(raw)) {
-    return null;
-  }
-
-  // 2. Find arguments object boundaries (top-level aware, like name extraction)
+function findRepairArgumentsBody(raw: string): string | null {
   const argsValueStart = findStrictTopLevelJsonPropertyValueStart(
     raw,
     "arguments"
@@ -1222,10 +1395,6 @@ function repairToolCallJson(
     return null;
   }
   const argsStart = argsValueStart + 1;
-
-  // 3. Find closing braces from end (arguments + outer object).
-  //    Uses backwards scan because forward brace-balance is unreliable
-  //    when quotes are broken (which is the premise of this repair path).
   let outerClose = -1;
   for (let i = raw.length - 1; i >= argsStart; i--) {
     if (raw.charAt(i) === "}") {
@@ -1250,13 +1419,227 @@ function repairToolCallJson(
       break;
     }
   }
-  if (argsClose === -1) {
+  return argsClose === -1 ? null : raw.slice(argsStart, argsClose);
+}
+
+function parseArgsBodyWithoutRepair(
+  argsBody: string,
+  keyPolicy?: ArgumentKeyPolicy
+): Record<string, unknown> | null {
+  try {
+    const parsedArgs = JSON.parse(`{${argsBody}}`) as Record<string, unknown>;
+    return applyArgumentKeyPolicy(parsedArgs, keyPolicy);
+  } catch {
+    return null;
+  }
+}
+
+function collectRepairKeyPositions(
+  argsBody: string
+): JsonRepairKeyPosition[] | null {
+  const firstKeyMatch = argsBody.match(FIRST_KEY_RE);
+  if (!firstKeyMatch) {
+    return null;
+  }
+  const positions: JsonRepairKeyPosition[] = [
+    {
+      key: firstKeyMatch[1],
+      matchStart: 0,
+      valueStart: firstKeyMatch[0].length,
+    },
+  ];
+  for (const match of argsBody.matchAll(KV_PATTERN_RE)) {
+    positions.push({
+      key: match[1],
+      matchStart: match.index,
+      valueStart: match.index + match[0].length,
+    });
+  }
+
+  const topLevelAtPosition = getTopLevelPositionMap(argsBody);
+  return positions.filter(
+    (entry) =>
+      entry.matchStart === 0 || topLevelAtPosition[entry.matchStart] === 1
+  );
+}
+
+function uniqueRepairKeyPositions(
+  positions: JsonRepairKeyPosition[],
+  keepLast: boolean
+): JsonRepairKeyPosition[] {
+  const selectedByKey = new Map<string, number>();
+  for (let index = 0; index < positions.length; index += 1) {
+    if (keepLast || !selectedByKey.has(positions[index].key)) {
+      selectedByKey.set(positions[index].key, index);
+    }
+  }
+  return positions.filter(
+    (_, index) => selectedByKey.get(positions[index].key) === index
+  );
+}
+
+function sameRepairPositions(
+  left: JsonRepairKeyPosition[],
+  right: JsonRepairKeyPosition[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((entry, index) => entry.matchStart === right[index].matchStart)
+  );
+}
+
+function escapeMalformedStringInner(inner: string): string {
+  let escaped = "";
+  let backslashes = 0;
+  for (const char of inner) {
+    if (char === "\\") {
+      backslashes += 1;
+      escaped += char;
+    } else if (char === '"' && backslashes % 2 === 0) {
+      backslashes = 0;
+      escaped += '\\"';
+    } else {
+      backslashes = 0;
+      escaped += char;
+    }
+  }
+  return escaped
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+}
+
+function lastQuoteIndex(value: string): number {
+  let cursor = value.length - 1;
+  while (cursor > 0 && value.charAt(cursor) !== '"') {
+    cursor -= 1;
+  }
+  return cursor;
+}
+
+function parsePossiblyMalformedJsonString(value: string): unknown | undefined {
+  if (value.charAt(0) !== '"') {
+    return;
+  }
+  const quoteEnd = lastQuoteIndex(value);
+  if (quoteEnd <= 0) {
+    return;
+  }
+  const escaped = escapeMalformedStringInner(value.slice(1, quoteEnd));
+  try {
+    return JSON.parse(`"${escaped}"`);
+  } catch {
+    return;
+  }
+}
+
+function scoreRepairValue(value: string): [number, number] {
+  try {
+    JSON.parse(value);
+    return [1, 0];
+  } catch {
+    return parsePossiblyMalformedJsonString(value) === undefined
+      ? [0, 0]
+      : [0, 1];
+  }
+}
+
+function scoreRepairKeyPositions(
+  argsBody: string,
+  positions: JsonRepairKeyPosition[]
+): [number, number] {
+  let rawOk = 0;
+  let repaired = 0;
+  for (let index = 0; index < positions.length; index += 1) {
+    const valueEnd =
+      index + 1 < positions.length
+        ? positions[index + 1].matchStart
+        : argsBody.length;
+    const value = argsBody
+      .slice(positions[index].valueStart, valueEnd)
+      .replace(TRAILING_COMMA_RE, "");
+    const [rawScore, repairScore] = scoreRepairValue(value);
+    rawOk += rawScore;
+    repaired += repairScore;
+  }
+  return [rawOk, repaired];
+}
+
+function chooseRepairKeyPositions(
+  argsBody: string,
+  positions: JsonRepairKeyPosition[]
+): JsonRepairKeyPosition[] {
+  const firstPositions = uniqueRepairKeyPositions(positions, false);
+  const lastPositions = uniqueRepairKeyPositions(positions, true);
+  if (sameRepairPositions(firstPositions, lastPositions)) {
+    return firstPositions;
+  }
+  const firstScore = scoreRepairKeyPositions(argsBody, firstPositions);
+  const lastScore = scoreRepairKeyPositions(argsBody, lastPositions);
+  return lastScore[0] > firstScore[0] ||
+    (lastScore[0] === firstScore[0] && lastScore[1] > firstScore[1])
+    ? lastPositions
+    : firstPositions;
+}
+
+function parseRepairValue(value: string): unknown | undefined {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return parsePossiblyMalformedJsonString(value);
+  }
+}
+
+function parseRepairArguments(
+  argsBody: string,
+  positions: JsonRepairKeyPosition[],
+  keyPolicy?: ArgumentKeyPolicy
+): Record<string, unknown> | null {
+  const args = Object.create(null) as Record<string, unknown>;
+  for (let index = 0; index < positions.length; index += 1) {
+    const valueEnd =
+      index + 1 < positions.length
+        ? positions[index + 1].matchStart
+        : argsBody.length;
+    const rawValue = argsBody
+      .slice(positions[index].valueStart, valueEnd)
+      .replace(TRAILING_COMMA_RE, "");
+    const parsedValue = parseRepairValue(rawValue);
+    if (parsedValue === undefined) {
+      return null;
+    }
+    args[positions[index].key] = parsedValue;
+  }
+  if (Object.keys(args).length === 0) {
+    return null;
+  }
+  return applyArgumentKeyPolicy(args, keyPolicy);
+}
+
+/**
+ * Attempt to repair a malformed tool-call JSON string where the model
+ * failed to escape double-quotes inside string values.  Returns the
+ * parsed result or null when repair is not possible.
+ *
+ * Scope: this path assumes strict JSON structure (double-quoted keys and
+ * string values, per-value `JSON.parse`). Relaxed-JSON malformation
+ * (unquoted keys, single-quoted strings, comments) is out of scope — such
+ * input returns null and the caller falls through to the text segment path,
+ * matching pre-repair behavior.
+ */
+function repairToolCallJson(
+  raw: string,
+  toolName: string,
+  keyPolicy?: ArgumentKeyPolicy
+): { name: string; arguments: Record<string, unknown> } | null {
+  if (hasPrototypeSensitiveKeyInJsonLikeObject(raw)) {
     return null;
   }
 
-  const argsBody = raw.slice(argsStart, argsClose);
-
-  // Size guard: bail out on unreasonably large argument bodies
+  const argsBody = findRepairArgumentsBody(raw);
+  if (argsBody === null) {
+    return null;
+  }
   if (argsBody.length > REPAIR_MAX_ARGS_BODY_SIZE) {
     return null;
   }
@@ -1264,205 +1647,22 @@ function repairToolCallJson(
     return null;
   }
 
-  // 4. Try standard parse first
-  try {
-    const parsedArgs = JSON.parse(`{${argsBody}}`) as Record<string, unknown>;
-    const policyArgs = applyArgumentKeyPolicy(parsedArgs, keyPolicy);
-    if (!policyArgs) {
-      return null;
-    }
-    return {
-      name: toolName,
-      arguments: policyArgs,
-    };
-  } catch {
-    /* fall through to repair */
+  const parsedArgs = parseArgsBodyWithoutRepair(argsBody, keyPolicy);
+  if (parsedArgs) {
+    return { name: toolName, arguments: parsedArgs };
   }
 
-  // 5. Collect key positions
-  const firstKeyMatch = argsBody.match(FIRST_KEY_RE);
-  if (!firstKeyMatch) {
-    return null;
-  }
-  let allKeys: Array<{
-    key: string;
-    matchStart: number;
-    valueStart: number;
-  }> = [
-    {
-      key: firstKeyMatch[1],
-      matchStart: 0,
-      valueStart: firstKeyMatch[0].length,
-    },
-  ];
-  for (const m of argsBody.matchAll(KV_PATTERN_RE)) {
-    allKeys.push({
-      key: m[1],
-      matchStart: m.index,
-      valueStart: m.index + m[0].length,
-    });
-  }
-
-  // 5b. Filter candidates to prevent false boundary splits.
-  //     Boundary detection always uses top-level position — dropping
-  //     schema-unknown keys from the candidate list corrupts neighbouring
-  //     value slices, because their ,"extra":... text gets merged into
-  //     the previous value. Schema filtering is applied later when
-  //     assigning parsed values into args (step 8 below).
-  const topLevelAtPosition = getTopLevelPositionMap(argsBody);
-  allKeys = allKeys.filter(
-    (entry) =>
-      entry.matchStart === 0 || topLevelAtPosition[entry.matchStart] === 1
-  );
-
-  // 7. Handle duplicate key names with scoring heuristic
-  const firstByKey = new Map<string, number>();
-  const lastByKey = new Map<string, number>();
-  for (let idx = 0; idx < allKeys.length; idx++) {
-    if (!firstByKey.has(allKeys[idx].key)) {
-      firstByKey.set(allKeys[idx].key, idx);
-    }
-    lastByKey.set(allKeys[idx].key, idx);
-  }
-  const firstPositions = allKeys.filter(
-    (_, i) => firstByKey.get(allKeys[i].key) === i
-  );
-  const lastPositions = allKeys.filter(
-    (_, i) => lastByKey.get(allKeys[i].key) === i
-  );
-
-  let keyPositions: typeof allKeys;
-  if (
-    firstPositions.length === lastPositions.length &&
-    firstPositions.every(
-      (fp, i) => fp.matchStart === lastPositions[i].matchStart
-    )
-  ) {
-    keyPositions = firstPositions;
-  } else {
-    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Scoring heuristic requires multi-stage fallback parsing.
-    function scorePositions(positions: typeof allKeys): [number, number] {
-      let rawOk = 0;
-      let repaired = 0;
-      for (let si = 0; si < positions.length; si++) {
-        const svs = positions[si].valueStart;
-        const sve =
-          si + 1 < positions.length
-            ? positions[si + 1].matchStart
-            : argsBody.length;
-        const srv = argsBody.slice(svs, sve).replace(TRAILING_COMMA_RE, "");
-        try {
-          JSON.parse(srv);
-          rawOk++;
-          continue;
-        } catch {
-          /* skip */
-        }
-        if (srv.charAt(0) === '"') {
-          let seq = srv.length - 1;
-          while (seq > 0 && srv.charAt(seq) !== '"') {
-            seq--;
-          }
-          if (seq > 0) {
-            const sinner = srv.slice(1, seq);
-            let sesc = "";
-            let sbs = 0;
-            for (const sch of sinner) {
-              if (sch === "\\") {
-                sbs++;
-                sesc += sch;
-              } else if (sch === '"' && sbs % 2 === 0) {
-                sbs = 0;
-                sesc += '\\"';
-              } else {
-                sbs = 0;
-                sesc += sch;
-              }
-            }
-            sesc = sesc
-              .replace(/\n/g, "\\n")
-              .replace(/\r/g, "\\r")
-              .replace(/\t/g, "\\t");
-            try {
-              JSON.parse(`"${sesc}"`);
-              repaired++;
-            } catch {
-              /* skip */
-            }
-          }
-        }
-      }
-      return [rawOk, repaired];
-    }
-    const fs = scorePositions(firstPositions);
-    const ls = scorePositions(lastPositions);
-    keyPositions =
-      ls[0] > fs[0] || (ls[0] === fs[0] && ls[1] > fs[1])
-        ? lastPositions
-        : firstPositions;
-  }
-  allKeys = keyPositions;
-  if (allKeys.length === 0) {
+  const collectedKeys = collectRepairKeyPositions(argsBody);
+  if (!collectedKeys || collectedKeys.length === 0) {
     return null;
   }
 
-  const args = Object.create(null) as Record<string, unknown>;
-  for (let i = 0; i < allKeys.length; i++) {
-    const kp = allKeys[i];
-    const vs = kp.valueStart;
-    const ve =
-      i + 1 < allKeys.length ? allKeys[i + 1].matchStart : argsBody.length;
-    const rv = argsBody.slice(vs, ve).replace(TRAILING_COMMA_RE, "");
-    try {
-      args[kp.key] = JSON.parse(rv);
-      continue;
-    } catch {
-      /* needs repair */
-    }
-    if (rv.charAt(0) === '"') {
-      let eq = rv.length - 1;
-      while (eq > 0 && rv.charAt(eq) !== '"') {
-        eq--;
-      }
-      if (eq <= 0) {
-        // String literal with no closing quote — repair cannot handle this
-        return null;
-      }
-      const inner = rv.slice(1, eq);
-      let esc = "";
-      let bs = 0;
-      for (const ch of inner) {
-        if (ch === "\\") {
-          bs++;
-          esc += ch;
-        } else if (ch === '"' && bs % 2 === 0) {
-          bs = 0;
-          esc += '\\"';
-        } else {
-          bs = 0;
-          esc += ch;
-        }
-      }
-      esc = esc
-        .replace(/\n/g, "\\n")
-        .replace(/\r/g, "\\r")
-        .replace(/\t/g, "\\t");
-      try {
-        args[kp.key] = JSON.parse(`"${esc}"`);
-      } catch {
-        // Repaired string still invalid — bail out
-        return null;
-      }
-    } else {
-      // Non-string value that failed JSON.parse — repair cannot handle this
-      return null;
-    }
-  }
-  if (Object.keys(args).length === 0) {
-    return null;
-  }
-  const policyArgs = applyArgumentKeyPolicy(args, keyPolicy);
-  return policyArgs === null ? null : { name: toolName, arguments: policyArgs };
+  const args = parseRepairArguments(
+    argsBody,
+    chooseRepairKeyPositions(argsBody, collectedKeys),
+    keyPolicy
+  );
+  return args === null ? null : { name: toolName, arguments: args };
 }
 
 function repairToolCallJsonForTools(
@@ -1686,7 +1886,6 @@ function findTopLevelPropertyValueStart(
   return null;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Strict repair needs a small JSON scanner that ignores relaxed RJSON keys.
 function findStrictTopLevelJsonPropertyValueStart(
   text: string,
   property: string
@@ -1696,61 +1895,40 @@ function findStrictTopLevelJsonPropertyValueStart(
     return null;
   }
 
-  let depth = 0;
-  let inString = false;
-  let escaping = false;
+  const state: JsonDepthScanState = {
+    depth: 0,
+    escaping: false,
+    inString: false,
+  };
 
   for (let index = objectStart; index < text.length; index += 1) {
     const char = text.charAt(index);
 
-    if (inString) {
-      if (escaping) {
-        escaping = false;
-        continue;
-      }
-      if (char === "\\") {
-        escaping = true;
-        continue;
-      }
-      if (char === '"') {
-        inString = false;
-      }
+    if (consumeExistingJsonString(state, char)) {
       continue;
     }
-
-    if (char === "{") {
-      depth += 1;
-      continue;
-    }
-    if (char === "}") {
-      depth = Math.max(0, depth - 1);
+    if (consumeJsonObjectDepth(state, char)) {
       continue;
     }
     if (char !== '"') {
       continue;
     }
-    if (depth !== 1) {
-      inString = true;
+    if (state.depth !== 1) {
+      state.inString = true;
       continue;
     }
 
-    const parsedKey = parseQuotedObjectKey(text, index);
-    if (!parsedKey) {
+    const candidate = readStrictJsonPropertyCandidate(text, index);
+    if (candidate === null) {
       return null;
     }
-
-    let valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
-    if (valueCursor >= text.length || text.charAt(valueCursor) !== ":") {
-      index = parsedKey.end;
-      continue;
+    if (candidate.key === property) {
+      return candidate.valueStart !== undefined &&
+        candidate.valueStart < text.length
+        ? candidate.valueStart
+        : null;
     }
-
-    valueCursor = skipJsonWhitespace(text, valueCursor + 1);
-    if (parsedKey.key === property) {
-      return valueCursor < text.length ? valueCursor : null;
-    }
-
-    index = valueCursor - 1;
+    index = candidate.nextIndex;
   }
 
   return null;

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -503,13 +503,37 @@ function extractKnownArgKeys(
   tools: LanguageModelV3FunctionTool[],
   toolCallJson: string
 ): string[] | undefined {
-  const nameMatch = toolCallJson.match(/"name"\s*:\s*"([^"]+)"/);
-  if (!nameMatch) return undefined;
-  const tool = tools.find((t) => t.name === nameMatch[1]);
+  const toolName = extractTopLevelStringProperty(toolCallJson, "name");
+  if (!toolName) return undefined;
+  const tool = tools.find((t) => t.name === toolName);
   if (!tool?.inputSchema?.properties) return undefined;
   return Object.keys(
     tool.inputSchema.properties as Record<string, unknown>
   );
+}
+
+/** Maximum size (in UTF-16 code units) for the arguments body before bailing out of repair. */
+const REPAIR_MAX_ARGS_BODY_SIZE = 102400;
+
+/**
+ * Returns true if `position` in `argsBody` is at nesting depth 0
+ * (not inside a nested `{}` or `[]`).
+ */
+function isAtTopLevel(argsBody: string, position: number): boolean {
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < position; i++) {
+    const ch = argsBody[i];
+    if (esc) { esc = false; continue; }
+    if (ch === '\\' && inStr) { esc = true; continue; }
+    if (ch === '"') { inStr = !inStr; continue; }
+    if (!inStr) {
+      if (ch === '{' || ch === '[') depth++;
+      if (ch === '}' || ch === ']') depth--;
+    }
+  }
+  return depth === 0;
 }
 
 /**
@@ -522,17 +546,18 @@ function repairToolCallJson(
   raw: string,
   knownArgKeys?: string[]
 ): { name: string; arguments: Record<string, unknown> } | null {
-  // 1. Extract tool name
-  const nameMatch = raw.match(/"name"\s*:\s*"([^"]+)"/);
-  if (!nameMatch) return null;
-  const toolName = nameMatch[1];
+  // 1. Extract tool name (depth-aware to avoid matching nested "name" keys)
+  const toolName = extractTopLevelStringProperty(raw, "name");
+  if (!toolName) return null;
 
-  // 2. Find arguments object boundaries
-  const argsMatch = raw.match(/"arguments"\s*:\s*\{/);
-  if (!argsMatch || argsMatch.index === undefined) return null;
-  const argsStart = argsMatch.index + argsMatch[0].length;
+  // 2. Find arguments object boundaries (top-level aware, like name extraction)
+  const argsValueStart = findTopLevelPropertyValueStart(raw, "arguments");
+  if (argsValueStart == null || raw.charAt(argsValueStart) !== "{") return null;
+  const argsStart = argsValueStart + 1;
 
-  // 3. Find closing braces from end (arguments + outer object)
+  // 3. Find closing braces from end (arguments + outer object).
+  //    Uses backwards scan because forward brace-balance is unreliable
+  //    when quotes are broken (which is the premise of this repair path).
   let outerClose = -1;
   for (let i = raw.length - 1; i >= argsStart; i--) {
     if (raw.charAt(i) === "}") {
@@ -554,6 +579,9 @@ function repairToolCallJson(
   if (argsClose === -1) return null;
 
   const argsBody = raw.substring(argsStart, argsClose);
+
+  // Size guard: bail out on unreasonably large argument bodies
+  if (argsBody.length > REPAIR_MAX_ARGS_BODY_SIZE) return null;
 
   // 4. Try standard parse first
   try {
@@ -589,10 +617,22 @@ function repairToolCallJson(
     });
   }
 
-  // 6. Filter by known keys if provided
-  if (knownArgKeys && knownArgKeys.length > 0) {
-    const known = new Set(knownArgKeys);
-    allKeys = allKeys.filter((entry) => known.has(entry.key));
+  // 5b. Filter candidates to prevent false boundary splits.
+  //     When knownArgKeys is available, only keep keys that match the schema.
+  //     This prevents ,"fake": patterns inside broken string values from
+  //     being treated as key boundaries.  Unknown extra keys are dropped —
+  //     acceptable for a best-effort repair path since the alternative
+  //     (keeping them) corrupts known values.
+  //     When no schema is available, use depth checking as a heuristic.
+  const knownKeySet = knownArgKeys && knownArgKeys.length > 0
+    ? new Set(knownArgKeys)
+    : null;
+  if (knownKeySet) {
+    allKeys = allKeys.filter((entry) => knownKeySet.has(entry.key));
+  } else {
+    allKeys = allKeys.filter((entry) =>
+      entry.matchStart === 0 || isAtTopLevel(argsBody, entry.matchStart)
+    );
   }
 
   // 7. Handle duplicate key names with scoring heuristic
@@ -702,8 +742,8 @@ function repairToolCallJson(
       let eq = rv.length - 1;
       while (eq > 0 && rv.charAt(eq) !== '"') eq--;
       if (eq <= 0) {
-        args[kp.key] = rv;
-        continue;
+        // String literal with no closing quote — repair cannot handle this
+        return null;
       }
       const inner = rv.substring(1, eq);
       let esc = "";
@@ -727,10 +767,12 @@ function repairToolCallJson(
       try {
         args[kp.key] = JSON.parse(`"${esc}"`);
       } catch {
-        args[kp.key] = inner;
+        // Repaired string still invalid — bail out
+        return null;
       }
     } else {
-      args[kp.key] = rv;
+      // Non-string value that failed JSON.parse — repair cannot handle this
+      return null;
     }
   }
   return { name: toolName, arguments: args };
@@ -1266,18 +1308,9 @@ function emitIncompleteToolCall(
       state.isInsideToolCall = false;
       return;
     } catch {
-      // Attempt repair for unescaped quotes
-      const repaired = repairToolCallJson(
-        state.currentToolCallJson,
-        extractKnownArgKeys(tools, state.currentToolCallJson)
-      );
-      if (repaired) {
-        emitToolCallFromParsed(state, controller, repaired, tools);
-        state.currentToolCallJson = "";
-        state.isInsideToolCall = false;
-        return;
-      }
-      // fall through to text fallback
+      // Incomplete tool calls (no closing </tool_call>) are not candidates
+      // for repair — the JSON may be genuinely truncated.
+      // Fall through to text/error fallback.
     }
   }
 

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -504,16 +504,23 @@ function extractKnownArgKeys(
   toolCallJson: string
 ): string[] | undefined {
   const toolName = extractTopLevelStringProperty(toolCallJson, "name");
-  if (!toolName) return undefined;
+  if (!toolName) {
+    return undefined;
+  }
   const tool = tools.find((t) => t.name === toolName);
-  if (!tool?.inputSchema?.properties) return undefined;
-  return Object.keys(
-    tool.inputSchema.properties as Record<string, unknown>
-  );
+  if (!tool?.inputSchema?.properties) {
+    return undefined;
+  }
+  return Object.keys(tool.inputSchema.properties as Record<string, unknown>);
 }
 
 /** Maximum size (in UTF-16 code units) for the arguments body before bailing out of repair. */
-const REPAIR_MAX_ARGS_BODY_SIZE = 102400;
+const REPAIR_MAX_ARGS_BODY_SIZE = 102_400;
+
+const WHITESPACE_RE = /\s/;
+const FIRST_KEY_RE = /^\s*"([^"]+)"\s*:\s*/;
+const KV_PATTERN_RE = /,\s*"([^"]+)"\s*:\s*/g;
+const TRAILING_COMMA_RE = /,\s*$/;
 
 /**
  * Returns true if `position` in `argsBody` is at nesting depth 0
@@ -525,12 +532,25 @@ function isAtTopLevel(argsBody: string, position: number): boolean {
   let esc = false;
   for (let i = 0; i < position; i++) {
     const ch = argsBody[i];
-    if (esc) { esc = false; continue; }
-    if (ch === '\\' && inStr) { esc = true; continue; }
-    if (ch === '"') { inStr = !inStr; continue; }
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (ch === "\\" && inStr) {
+      esc = true;
+      continue;
+    }
+    if (ch === '"') {
+      inStr = !inStr;
+      continue;
+    }
     if (!inStr) {
-      if (ch === '{' || ch === '[') depth++;
-      if (ch === '}' || ch === ']') depth--;
+      if (ch === "{" || ch === "[") {
+        depth++;
+      }
+      if (ch === "}" || ch === "]") {
+        depth--;
+      }
     }
   }
   return depth === 0;
@@ -548,11 +568,15 @@ function repairToolCallJson(
 ): { name: string; arguments: Record<string, unknown> } | null {
   // 1. Extract tool name (depth-aware to avoid matching nested "name" keys)
   const toolName = extractTopLevelStringProperty(raw, "name");
-  if (!toolName) return null;
+  if (!toolName) {
+    return null;
+  }
 
   // 2. Find arguments object boundaries (top-level aware, like name extraction)
   const argsValueStart = findTopLevelPropertyValueStart(raw, "arguments");
-  if (argsValueStart == null || raw.charAt(argsValueStart) !== "{") return null;
+  if (argsValueStart == null || raw.charAt(argsValueStart) !== "{") {
+    return null;
+  }
   const argsStart = argsValueStart + 1;
 
   // 3. Find closing braces from end (arguments + outer object).
@@ -564,9 +588,13 @@ function repairToolCallJson(
       outerClose = i;
       break;
     }
-    if (!/\s/.test(raw.charAt(i))) break;
+    if (!WHITESPACE_RE.test(raw.charAt(i))) {
+      break;
+    }
   }
-  if (outerClose === -1) return null;
+  if (outerClose === -1) {
+    return null;
+  }
 
   let argsClose = -1;
   for (let j = outerClose - 1; j >= argsStart; j--) {
@@ -574,14 +602,20 @@ function repairToolCallJson(
       argsClose = j;
       break;
     }
-    if (!/\s/.test(raw.charAt(j))) break;
+    if (!WHITESPACE_RE.test(raw.charAt(j))) {
+      break;
+    }
   }
-  if (argsClose === -1) return null;
+  if (argsClose === -1) {
+    return null;
+  }
 
-  const argsBody = raw.substring(argsStart, argsClose);
+  const argsBody = raw.slice(argsStart, argsClose);
 
   // Size guard: bail out on unreasonably large argument bodies
-  if (argsBody.length > REPAIR_MAX_ARGS_BODY_SIZE) return null;
+  if (argsBody.length > REPAIR_MAX_ARGS_BODY_SIZE) {
+    return null;
+  }
 
   // 4. Try standard parse first
   try {
@@ -594,8 +628,10 @@ function repairToolCallJson(
   }
 
   // 5. Collect key positions
-  const firstKeyMatch = argsBody.match(/^\s*"([^"]+)"\s*:\s*/);
-  if (!firstKeyMatch) return null;
+  const firstKeyMatch = argsBody.match(FIRST_KEY_RE);
+  if (!firstKeyMatch) {
+    return null;
+  }
   let allKeys: Array<{
     key: string;
     matchStart: number;
@@ -607,9 +643,7 @@ function repairToolCallJson(
       valueStart: firstKeyMatch[0].length,
     },
   ];
-  const kvPattern = /,\s*"([^"]+)"\s*:\s*/g;
-  let m: RegExpExecArray | null;
-  while ((m = kvPattern.exec(argsBody)) !== null) {
+  for (const m of argsBody.matchAll(KV_PATTERN_RE)) {
     allKeys.push({
       key: m[1],
       matchStart: m.index,
@@ -623,19 +657,20 @@ function repairToolCallJson(
   //     value slices, because their ,"extra":... text gets merged into
   //     the previous value. Schema filtering is applied later when
   //     assigning parsed values into args (step 8 below).
-  const knownKeySet = knownArgKeys && knownArgKeys.length > 0
-    ? new Set(knownArgKeys)
-    : null;
-  allKeys = allKeys.filter((entry) =>
-    entry.matchStart === 0 || isAtTopLevel(argsBody, entry.matchStart)
+  const knownKeySet =
+    knownArgKeys && knownArgKeys.length > 0 ? new Set(knownArgKeys) : null;
+  allKeys = allKeys.filter(
+    (entry) =>
+      entry.matchStart === 0 || isAtTopLevel(argsBody, entry.matchStart)
   );
 
   // 7. Handle duplicate key names with scoring heuristic
   const firstByKey: Record<string, number> = {};
   const lastByKey: Record<string, number> = {};
   for (let idx = 0; idx < allKeys.length; idx++) {
-    if (!(allKeys[idx].key in firstByKey))
+    if (!(allKeys[idx].key in firstByKey)) {
       firstByKey[allKeys[idx].key] = idx;
+    }
     lastByKey[allKeys[idx].key] = idx;
   }
   const firstPositions = allKeys.filter(
@@ -654,9 +689,8 @@ function repairToolCallJson(
   ) {
     keyPositions = firstPositions;
   } else {
-    function scorePositions(
-      positions: typeof allKeys
-    ): [number, number] {
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Scoring heuristic requires multi-stage fallback parsing.
+    function scorePositions(positions: typeof allKeys): [number, number] {
       let rawOk = 0;
       let repaired = 0;
       for (let si = 0; si < positions.length; si++) {
@@ -665,7 +699,7 @@ function repairToolCallJson(
           si + 1 < positions.length
             ? positions[si + 1].matchStart
             : argsBody.length;
-        const srv = argsBody.substring(svs, sve).replace(/,\s*$/, "");
+        const srv = argsBody.slice(svs, sve).replace(TRAILING_COMMA_RE, "");
         try {
           JSON.parse(srv);
           rawOk++;
@@ -675,9 +709,11 @@ function repairToolCallJson(
         }
         if (srv.charAt(0) === '"') {
           let seq = srv.length - 1;
-          while (seq > 0 && srv.charAt(seq) !== '"') seq--;
+          while (seq > 0 && srv.charAt(seq) !== '"') {
+            seq--;
+          }
           if (seq > 0) {
-            const sinner = srv.substring(1, seq);
+            const sinner = srv.slice(1, seq);
             let sesc = "";
             let sbs = 0;
             for (const sch of sinner) {
@@ -715,7 +751,9 @@ function repairToolCallJson(
         : firstPositions;
   }
   allKeys = keyPositions;
-  if (allKeys.length === 0) return null;
+  if (allKeys.length === 0) {
+    return null;
+  }
 
   // 8. Repair each value by escaping unescaped quotes.
   //    Schema-unknown keys are skipped here (their slice was still needed
@@ -723,13 +761,13 @@ function repairToolCallJson(
   const args: Record<string, unknown> = {};
   for (let i = 0; i < allKeys.length; i++) {
     const kp = allKeys[i];
-    if (knownKeySet && !knownKeySet.has(kp.key)) continue;
+    if (knownKeySet && !knownKeySet.has(kp.key)) {
+      continue;
+    }
     const vs = kp.valueStart;
     const ve =
-      i + 1 < allKeys.length
-        ? allKeys[i + 1].matchStart
-        : argsBody.length;
-    let rv = argsBody.substring(vs, ve).replace(/,\s*$/, "");
+      i + 1 < allKeys.length ? allKeys[i + 1].matchStart : argsBody.length;
+    const rv = argsBody.slice(vs, ve).replace(TRAILING_COMMA_RE, "");
     try {
       args[kp.key] = JSON.parse(rv);
       continue;
@@ -738,12 +776,14 @@ function repairToolCallJson(
     }
     if (rv.charAt(0) === '"') {
       let eq = rv.length - 1;
-      while (eq > 0 && rv.charAt(eq) !== '"') eq--;
+      while (eq > 0 && rv.charAt(eq) !== '"') {
+        eq--;
+      }
       if (eq <= 0) {
         // String literal with no closing quote — repair cannot handle this
         return null;
       }
-      const inner = rv.substring(1, eq);
+      const inner = rv.slice(1, eq);
       let esc = "";
       let bs = 0;
       for (const ch of inner) {
@@ -776,7 +816,9 @@ function repairToolCallJson(
   // Guard: if the schema filter skipped every parsed key, we have nothing
   // meaningful to emit. Returning {arguments: {}} here would trigger a
   // tool invocation with empty args — worse than reporting parse failure.
-  if (knownKeySet && Object.keys(args).length === 0) return null;
+  if (knownKeySet && Object.keys(args).length === 0) {
+    return null;
+  }
   return { name: toolName, arguments: args };
 }
 

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -9,6 +9,7 @@ import {
   coerceBySchema,
   compileSafePatternPropertyRegex,
   getSchemaType,
+  schemaIsUnconstrained,
   unwrapJsonSchema,
 } from "../../schema-coerce";
 import { logParseFailure } from "../utils/debug";
@@ -307,18 +308,27 @@ function canonicalizeToolInput(argumentsValue: unknown): string {
   return JSON.stringify(argumentsValue ?? {});
 }
 
+function stringifyParsedToolInput(
+  toolName: string,
+  args: unknown,
+  tools: LanguageModelV3FunctionTool[]
+): string {
+  return stringifyToolInputWithSchema({
+    toolName,
+    args,
+    tools,
+    fallback: canonicalizeToolInput,
+  });
+}
+
 function isParsedToolCallRecord(
   value: unknown
-): value is { name: string; arguments: unknown } {
+): value is { name: string; arguments?: unknown } {
   if (typeof value !== "object" || value === null) {
     return false;
   }
   const record = value as Record<string, unknown>;
-  return (
-    Object.hasOwn(record, "name") &&
-    Object.hasOwn(record, "arguments") &&
-    typeof record.name === "string"
-  );
+  return Object.hasOwn(record, "name") && typeof record.name === "string";
 }
 
 const CHAR_CODE_BACKSLASH = 0x5c;
@@ -631,7 +641,10 @@ function extractArgumentKeyPolicy(
     }
     if (regex) {
       keyPatterns.push(regex);
-    } else if (patternSchema !== true) {
+    } else if (
+      patternSchema === false ||
+      !schemaIsUnconstrained(patternSchema)
+    ) {
       unsafeDeniedPatterns.push(pattern);
     }
   }
@@ -758,31 +771,38 @@ const PROTOTYPE_SENSITIVE_ARGUMENT_KEYS = new Set([
   "prototype",
 ]);
 
-function containsPrototypeSensitiveArgumentKey(
-  value: unknown,
-  seen = new Set<object>()
-): boolean {
-  if (Array.isArray(value)) {
-    if (seen.has(value)) {
-      return false;
+function containsPrototypeSensitiveArgumentKey(value: unknown): boolean {
+  const seen = new Set<object>();
+  const stack: unknown[] = [value];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (Array.isArray(current)) {
+      if (seen.has(current)) {
+        continue;
+      }
+      seen.add(current);
+      for (const item of current) {
+        stack.push(item);
+      }
+      continue;
     }
-    seen.add(value);
-    return value.some((item) =>
-      containsPrototypeSensitiveArgumentKey(item, seen)
-    );
+    if (!isRecord(current)) {
+      continue;
+    }
+    if (seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    for (const key of Object.keys(current)) {
+      if (PROTOTYPE_SENSITIVE_ARGUMENT_KEYS.has(key)) {
+        return true;
+      }
+      stack.push(current[key]);
+    }
   }
-  if (!isRecord(value)) {
-    return false;
-  }
-  if (seen.has(value)) {
-    return false;
-  }
-  seen.add(value);
-  return Object.keys(value).some(
-    (key) =>
-      PROTOTYPE_SENSITIVE_ARGUMENT_KEYS.has(key) ||
-      containsPrototypeSensitiveArgumentKey(value[key], seen)
-  );
+
+  return false;
 }
 
 function hasPrototypeSensitiveKeyInJsonLikeObject(text: string): boolean {
@@ -1065,13 +1085,25 @@ function applyToolArgumentKeyPolicy(
   if (keyPolicy?.rejectAll) {
     return null;
   }
-  if (!isRecord(args)) {
+  const normalizedArgs = args === undefined ? {} : args;
+  if (!isRecord(normalizedArgs)) {
+    if (
+      keyPolicy &&
+      argumentValueMatchesSchemaKeyShape(
+        normalizedArgs,
+        keyPolicy.schema,
+        new Set(),
+        true
+      )
+    ) {
+      return { args: normalizedArgs };
+    }
     if (keyPolicy?.rejectNonRecordArguments) {
       return null;
     }
-    return { args };
+    return { args: normalizedArgs };
   }
-  const policyArgs = applyArgumentKeyPolicy(args, keyPolicy);
+  const policyArgs = applyArgumentKeyPolicy(normalizedArgs, keyPolicy);
   return policyArgs === null ? null : { args: policyArgs };
 }
 
@@ -1182,7 +1214,10 @@ function repairToolCallJson(
   }
 
   // 2. Find arguments object boundaries (top-level aware, like name extraction)
-  const argsValueStart = findTopLevelPropertyValueStart(raw, "arguments");
+  const argsValueStart = findStrictTopLevelJsonPropertyValueStart(
+    raw,
+    "arguments"
+  );
   if (argsValueStart == null || raw.charAt(argsValueStart) !== "{") {
     return null;
   }
@@ -1434,7 +1469,7 @@ function repairToolCallJsonForTools(
   raw: string,
   tools: LanguageModelV3FunctionTool[]
 ): { name: string; arguments: Record<string, unknown> } | null {
-  const toolName = extractTopLevelStringProperty(raw, "name");
+  const toolName = extractStrictTopLevelStringProperty(raw, "name");
   if (!toolName) {
     return null;
   }
@@ -1472,19 +1507,32 @@ function processToolCallJson(
       type: "tool-call",
       toolCallId: generateToolCallId(),
       toolName: parsedToolCall.name,
-      input: canonicalizeToolInput(policyArguments.args),
+      input: stringifyParsedToolInput(
+        parsedToolCall.name,
+        policyArguments.args,
+        tools
+      ),
     });
   } catch (error) {
+    let finalError: unknown = error;
     // Attempt repair for unescaped quotes
     const repaired = repairToolCallJsonForTools(toolCallJson, tools);
     if (repaired) {
-      processedElements.push({
-        type: "tool-call",
-        toolCallId: generateToolCallId(),
-        toolName: repaired.name,
-        input: canonicalizeToolInput(repaired.arguments),
-      });
-      return;
+      try {
+        processedElements.push({
+          type: "tool-call",
+          toolCallId: generateToolCallId(),
+          toolName: repaired.name,
+          input: stringifyParsedToolInput(
+            repaired.name,
+            repaired.arguments,
+            tools
+          ),
+        });
+        return;
+      } catch (repairError) {
+        finalError = repairError;
+      }
     }
     const salvagedToolName =
       extractStreamingToolCallProgress(toolCallJson).toolName;
@@ -1493,13 +1541,13 @@ function processToolCallJson(
       phase: "generated-text",
       reason: "Failed to parse tool call JSON segment",
       snippet: fullMatch,
-      error,
+      error: finalError,
     });
     options?.onError?.(
       "Could not process JSON tool call, keeping original text.",
       {
         toolCall: fullMatch,
-        error,
+        error: finalError,
         toolName: salvagedToolName,
         toolCallId: salvagedToolCallId,
         dropReason: "malformed-tool-call-body",
@@ -1638,11 +1686,110 @@ function findTopLevelPropertyValueStart(
   return null;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Strict repair needs a small JSON scanner that ignores relaxed RJSON keys.
+function findStrictTopLevelJsonPropertyValueStart(
+  text: string,
+  property: string
+): number | null {
+  const objectStart = skipJsonWhitespace(text, 0);
+  if (objectStart >= text.length || text.charAt(objectStart) !== "{") {
+    return null;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaping = false;
+
+  for (let index = objectStart; index < text.length; index += 1) {
+    const char = text.charAt(index);
+
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaping = true;
+        continue;
+      }
+      if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char === "}") {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (char !== '"') {
+      continue;
+    }
+    if (depth !== 1) {
+      inString = true;
+      continue;
+    }
+
+    const parsedKey = parseQuotedObjectKey(text, index);
+    if (!parsedKey) {
+      return null;
+    }
+
+    let valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
+    if (valueCursor >= text.length || text.charAt(valueCursor) !== ":") {
+      index = parsedKey.end;
+      continue;
+    }
+
+    valueCursor = skipJsonWhitespace(text, valueCursor + 1);
+    if (parsedKey.key === property) {
+      return valueCursor < text.length ? valueCursor : null;
+    }
+
+    index = valueCursor - 1;
+  }
+
+  return null;
+}
+
 function extractTopLevelStringProperty(
   text: string,
   property: string
 ): string | undefined {
   const valueStart = findTopLevelPropertyValueStart(text, property);
+  if (valueStart == null || valueStart >= text.length) {
+    return;
+  }
+  if (text.charAt(valueStart) !== '"') {
+    return;
+  }
+
+  let valueEnd = valueStart + 1;
+  let escaped = false;
+  while (valueEnd < text.length) {
+    const char = text.charAt(valueEnd);
+    if (escaped) {
+      escaped = false;
+    } else if (char === "\\") {
+      escaped = true;
+    } else if (char === '"') {
+      return text.slice(valueStart + 1, valueEnd);
+    }
+    valueEnd += 1;
+  }
+
+  return;
+}
+
+function extractStrictTopLevelStringProperty(
+  text: string,
+  property: string
+): string | undefined {
+  const valueStart = findStrictTopLevelJsonPropertyValueStart(text, property);
   if (valueStart == null || valueStart >= text.length) {
     return;
   }
@@ -2165,14 +2312,19 @@ function emitToolCall(context: TagProcessingContext) {
       tools
     );
   } catch (error) {
+    let finalError: unknown = error;
     // Attempt repair for unescaped quotes
     const repaired = repairToolCallJsonForTools(
       state.currentToolCallJson,
       tools
     );
     if (repaired) {
-      emitToolCallFromParsed(state, controller, repaired, tools);
-      return;
+      try {
+        emitToolCallFromParsed(state, controller, repaired, tools);
+        return;
+      } catch (repairError) {
+        finalError = repairError;
+      }
     }
     const activeToolCallId = state.activeToolInput?.id;
     const activeToolName = state.activeToolInput?.toolName;
@@ -2189,7 +2341,7 @@ function emitToolCall(context: TagProcessingContext) {
       phase: "stream",
       reason: "Failed to parse streaming tool call JSON segment",
       snippet: errorContent,
-      error,
+      error: finalError,
     });
     if (shouldEmitRawFallback) {
       const errorId = generateId();
@@ -2214,7 +2366,7 @@ function emitToolCall(context: TagProcessingContext) {
         : "Could not process streaming JSON tool call.",
       {
         toolCall: errorContent,
-        error,
+        error: finalError,
         toolCallId: streamingToolCallId,
         toolName: streamingToolName,
         dropReason: "malformed-tool-call-body",

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -618,22 +618,17 @@ function repairToolCallJson(
   }
 
   // 5b. Filter candidates to prevent false boundary splits.
-  //     When knownArgKeys is available, only keep keys that match the schema.
-  //     This prevents ,"fake": patterns inside broken string values from
-  //     being treated as key boundaries.  Unknown extra keys are dropped —
-  //     acceptable for a best-effort repair path since the alternative
-  //     (keeping them) corrupts known values.
-  //     When no schema is available, use depth checking as a heuristic.
+  //     Boundary detection always uses top-level position — dropping
+  //     schema-unknown keys from the candidate list corrupts neighbouring
+  //     value slices, because their ,"extra":... text gets merged into
+  //     the previous value. Schema filtering is applied later when
+  //     assigning parsed values into args (step 8 below).
   const knownKeySet = knownArgKeys && knownArgKeys.length > 0
     ? new Set(knownArgKeys)
     : null;
-  if (knownKeySet) {
-    allKeys = allKeys.filter((entry) => knownKeySet.has(entry.key));
-  } else {
-    allKeys = allKeys.filter((entry) =>
-      entry.matchStart === 0 || isAtTopLevel(argsBody, entry.matchStart)
-    );
-  }
+  allKeys = allKeys.filter((entry) =>
+    entry.matchStart === 0 || isAtTopLevel(argsBody, entry.matchStart)
+  );
 
   // 7. Handle duplicate key names with scoring heuristic
   const firstByKey: Record<string, number> = {};
@@ -722,10 +717,13 @@ function repairToolCallJson(
   allKeys = keyPositions;
   if (allKeys.length === 0) return null;
 
-  // 8. Repair each value by escaping unescaped quotes
+  // 8. Repair each value by escaping unescaped quotes.
+  //    Schema-unknown keys are skipped here (their slice was still needed
+  //    for correct boundary detection in step 5b).
   const args: Record<string, unknown> = {};
   for (let i = 0; i < allKeys.length; i++) {
     const kp = allKeys[i];
+    if (knownKeySet && !knownKeySet.has(kp.key)) continue;
     const vs = kp.valueStart;
     const ve =
       i + 1 < allKeys.length

--- a/src/core/protocols/hermes-unsafe-pattern.ts
+++ b/src/core/protocols/hermes-unsafe-pattern.ts
@@ -35,6 +35,14 @@ function pushLiteralRun(hints: PatternCharacterHints, run: string): string {
   return "";
 }
 
+function addLiteralHint(hints: PatternCharacterHints, char: string): boolean {
+  if (!isComparableKeyChar(char)) {
+    return false;
+  }
+  hints.literals.add(char);
+  return true;
+}
+
 function readCharacterClassRangeEnd(
   pattern: string,
   index: number
@@ -85,7 +93,56 @@ function readEscapedLiteral(
   return null;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Regex character-class scanning is a compact state machine.
+function consumeEscapedClassHint(
+  pattern: string,
+  index: number,
+  hints: PatternCharacterHints,
+  previous: string | undefined
+): { nextIndex: number; previous: string | undefined } {
+  const literal = readEscapedLiteral(pattern, index);
+  if (literal) {
+    return {
+      nextIndex: literal.nextIndex,
+      previous: addLiteralHint(hints, literal.char) ? literal.char : previous,
+    };
+  }
+  const char = pattern.charAt(index);
+  if ("dDsSwWpP".includes(char)) {
+    hints.hasUnknownMatcher = true;
+    return { nextIndex: index, previous };
+  }
+  return {
+    nextIndex: index,
+    previous: addLiteralHint(hints, char) ? char : previous,
+  };
+}
+
+function consumeClassRangeHint(
+  pattern: string,
+  index: number,
+  previous: string | undefined,
+  hints: PatternCharacterHints
+): { handled: boolean; nextIndex: number } {
+  if (
+    pattern.charAt(index) !== "-" ||
+    previous === undefined ||
+    index + 1 >= pattern.length ||
+    pattern.charAt(index + 1) === "]"
+  ) {
+    return { handled: false, nextIndex: index };
+  }
+  const end = readCharacterClassRangeEnd(pattern, index + 1);
+  if (end?.unknown) {
+    hints.hasUnknownMatcher = true;
+    return { handled: true, nextIndex: end.nextIndex };
+  }
+  if (end && isComparableKeyChar(end.char)) {
+    pushCharacterClassRange(hints.ranges, previous, end.char);
+    return { handled: true, nextIndex: end.nextIndex };
+  }
+  return { handled: false, nextIndex: index };
+}
+
 function addCharacterClassHints(
   pattern: string,
   classStart: number,
@@ -96,19 +153,9 @@ function addCharacterClassHints(
   for (let index = classStart + 1; index < pattern.length; index += 1) {
     const char = pattern.charAt(index);
     if (escaped) {
-      const literal = readEscapedLiteral(pattern, index);
-      if (literal) {
-        if (isComparableKeyChar(literal.char)) {
-          hints.literals.add(literal.char);
-          previous = literal.char;
-        }
-        index = literal.nextIndex;
-      } else if ("dDsSwWpP".includes(char)) {
-        hints.hasUnknownMatcher = true;
-      } else if (isComparableKeyChar(char)) {
-        hints.literals.add(char);
-        previous = char;
-      }
+      const result = consumeEscapedClassHint(pattern, index, hints, previous);
+      previous = result.previous;
+      index = result.nextIndex;
       escaped = false;
       continue;
     }
@@ -124,28 +171,13 @@ function addCharacterClassHints(
       previous = undefined;
       continue;
     }
-    if (
-      char === "-" &&
-      previous !== undefined &&
-      index + 1 < pattern.length &&
-      pattern.charAt(index + 1) !== "]"
-    ) {
-      const end = readCharacterClassRangeEnd(pattern, index + 1);
-      if (end?.unknown) {
-        hints.hasUnknownMatcher = true;
-        index = end.nextIndex;
-        previous = undefined;
-        continue;
-      }
-      if (end && isComparableKeyChar(end.char)) {
-        pushCharacterClassRange(hints.ranges, previous, end.char);
-        index = end.nextIndex;
-        previous = undefined;
-        continue;
-      }
+    const range = consumeClassRangeHint(pattern, index, previous, hints);
+    if (range.handled) {
+      index = range.nextIndex;
+      previous = undefined;
+      continue;
     }
-    if (isComparableKeyChar(char)) {
-      hints.literals.add(char);
+    if (addLiteralHint(hints, char)) {
       previous = char;
     } else {
       previous = undefined;
@@ -155,7 +187,34 @@ function addCharacterClassHints(
   return pattern.length;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Regex hint collection is a compact state machine.
+function consumeEscapedPatternHint(
+  pattern: string,
+  index: number,
+  hints: PatternCharacterHints,
+  literalRun: string
+): { literalRun: string; nextIndex: number } {
+  const literal = readEscapedLiteral(pattern, index);
+  if (literal) {
+    return addLiteralHint(hints, literal.char)
+      ? {
+          literalRun: literalRun + literal.char,
+          nextIndex: literal.nextIndex,
+        }
+      : {
+          literalRun: pushLiteralRun(hints, literalRun),
+          nextIndex: literal.nextIndex,
+        };
+  }
+  const char = pattern.charAt(index);
+  if ("dDsSwWpP".includes(char)) {
+    hints.hasUnknownMatcher = true;
+    return { literalRun: pushLiteralRun(hints, literalRun), nextIndex: index };
+  }
+  return addLiteralHint(hints, char)
+    ? { literalRun: literalRun + char, nextIndex: index }
+    : { literalRun: pushLiteralRun(hints, literalRun), nextIndex: index };
+}
+
 function collectPatternCharacterHints(pattern: string): PatternCharacterHints {
   const hints: PatternCharacterHints = {
     hasUnknownMatcher: false,
@@ -168,24 +227,14 @@ function collectPatternCharacterHints(pattern: string): PatternCharacterHints {
   for (let index = 0; index < pattern.length; index += 1) {
     const char = pattern.charAt(index);
     if (escaped) {
-      const literal = readEscapedLiteral(pattern, index);
-      if (literal) {
-        if (isComparableKeyChar(literal.char)) {
-          hints.literals.add(literal.char);
-          literalRun += literal.char;
-        } else {
-          literalRun = pushLiteralRun(hints, literalRun);
-        }
-        index = literal.nextIndex;
-      } else if ("dDsSwWpP".includes(char)) {
-        literalRun = pushLiteralRun(hints, literalRun);
-        hints.hasUnknownMatcher = true;
-      } else if (isComparableKeyChar(char)) {
-        hints.literals.add(char);
-        literalRun += char;
-      } else {
-        literalRun = pushLiteralRun(hints, literalRun);
-      }
+      const result = consumeEscapedPatternHint(
+        pattern,
+        index,
+        hints,
+        literalRun
+      );
+      literalRun = result.literalRun;
+      index = result.nextIndex;
       escaped = false;
       continue;
     }
@@ -203,8 +252,7 @@ function collectPatternCharacterHints(pattern: string): PatternCharacterHints {
       hints.hasUnknownMatcher = true;
       continue;
     }
-    if (isComparableKeyChar(char)) {
-      hints.literals.add(char);
+    if (addLiteralHint(hints, char)) {
       literalRun += char;
     } else {
       literalRun = pushLiteralRun(hints, literalRun);

--- a/src/core/protocols/hermes-unsafe-pattern.ts
+++ b/src/core/protocols/hermes-unsafe-pattern.ts
@@ -1,0 +1,274 @@
+interface CharacterClassRange {
+  end: string;
+  start: string;
+}
+
+interface PatternCharacterHints {
+  hasUnknownMatcher: boolean;
+  literalRuns: string[];
+  literals: Set<string>;
+  ranges: CharacterClassRange[];
+}
+
+function isComparableKeyChar(char: string): boolean {
+  return /^[A-Za-z0-9_-]$/.test(char);
+}
+
+function pushCharacterClassRange(
+  ranges: CharacterClassRange[],
+  start: string,
+  end: string
+) {
+  if (start.length === 1 && end.length === 1) {
+    ranges.push({ start, end });
+  }
+}
+
+function pushLiteralRun(hints: PatternCharacterHints, run: string): string {
+  if (run.length > 0) {
+    hints.literalRuns.push(run);
+  }
+  return "";
+}
+
+function readCharacterClassRangeEnd(
+  pattern: string,
+  index: number
+): { char: string; nextIndex: number; unknown: boolean } | null {
+  const char = pattern.charAt(index);
+  if (char !== "\\") {
+    return { char, nextIndex: index, unknown: false };
+  }
+
+  const escaped = pattern.charAt(index + 1);
+  const literal = readEscapedLiteral(pattern, index + 1);
+  if (literal) {
+    return { char: literal.char, nextIndex: literal.nextIndex, unknown: false };
+  }
+  if ("dDsSwWpP".includes(escaped)) {
+    return { char: "", nextIndex: index + 1, unknown: true };
+  }
+  return { char: escaped, nextIndex: index + 1, unknown: false };
+}
+
+function readEscapedLiteral(
+  pattern: string,
+  index: number
+): { char: string; nextIndex: number } | null {
+  const escape = pattern.charAt(index);
+  if (escape === "x" && /^[\da-fA-F]{2}$/.test(pattern.slice(index + 1, index + 3))) {
+    return {
+      char: String.fromCharCode(
+        Number.parseInt(pattern.slice(index + 1, index + 3), 16)
+      ),
+      nextIndex: index + 2,
+    };
+  }
+  if (escape === "u" && /^[\da-fA-F]{4}$/.test(pattern.slice(index + 1, index + 5))) {
+    return {
+      char: String.fromCharCode(
+        Number.parseInt(pattern.slice(index + 1, index + 5), 16)
+      ),
+      nextIndex: index + 4,
+    };
+  }
+  return null;
+}
+
+function addCharacterClassHints(
+  pattern: string,
+  classStart: number,
+  hints: PatternCharacterHints
+): number {
+  let previous: string | undefined;
+  let escaped = false;
+  for (let index = classStart + 1; index < pattern.length; index += 1) {
+    const char = pattern.charAt(index);
+    if (escaped) {
+      const literal = readEscapedLiteral(pattern, index);
+      if (literal) {
+        if (isComparableKeyChar(literal.char)) {
+          hints.literals.add(literal.char);
+          previous = literal.char;
+        }
+        index = literal.nextIndex;
+      } else if ("dDsSwWpP".includes(char)) {
+        hints.hasUnknownMatcher = true;
+      } else if (isComparableKeyChar(char)) {
+        hints.literals.add(char);
+        previous = char;
+      }
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === "]") {
+      return index;
+    }
+    if (char === "^" && index === classStart + 1) {
+      hints.hasUnknownMatcher = true;
+      previous = undefined;
+      continue;
+    }
+    if (
+      char === "-" &&
+      previous !== undefined &&
+      index + 1 < pattern.length &&
+      pattern.charAt(index + 1) !== "]"
+    ) {
+      const end = readCharacterClassRangeEnd(pattern, index + 1);
+      if (end?.unknown) {
+        hints.hasUnknownMatcher = true;
+        index = end.nextIndex;
+        previous = undefined;
+        continue;
+      }
+      if (end && isComparableKeyChar(end.char)) {
+        pushCharacterClassRange(hints.ranges, previous, end.char);
+        index = end.nextIndex;
+        previous = undefined;
+        continue;
+      }
+    }
+    if (isComparableKeyChar(char)) {
+      hints.literals.add(char);
+      previous = char;
+    } else {
+      previous = undefined;
+    }
+  }
+  hints.hasUnknownMatcher = true;
+  return pattern.length;
+}
+
+function collectPatternCharacterHints(pattern: string): PatternCharacterHints {
+  const hints: PatternCharacterHints = {
+    hasUnknownMatcher: false,
+    literalRuns: [],
+    literals: new Set<string>(),
+    ranges: [],
+  };
+  let escaped = false;
+  let literalRun = "";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern.charAt(index);
+    if (escaped) {
+      const literal = readEscapedLiteral(pattern, index);
+      if (literal) {
+        if (isComparableKeyChar(literal.char)) {
+          hints.literals.add(literal.char);
+          literalRun += literal.char;
+        } else {
+          literalRun = pushLiteralRun(hints, literalRun);
+        }
+        index = literal.nextIndex;
+      } else if ("dDsSwWpP".includes(char)) {
+        literalRun = pushLiteralRun(hints, literalRun);
+        hints.hasUnknownMatcher = true;
+      } else if (isComparableKeyChar(char)) {
+        hints.literals.add(char);
+        literalRun += char;
+      } else {
+        literalRun = pushLiteralRun(hints, literalRun);
+      }
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === "[") {
+      literalRun = pushLiteralRun(hints, literalRun);
+      index = addCharacterClassHints(pattern, index, hints);
+      continue;
+    }
+    if (char === ".") {
+      literalRun = pushLiteralRun(hints, literalRun);
+      hints.hasUnknownMatcher = true;
+      continue;
+    }
+    if (isComparableKeyChar(char)) {
+      hints.literals.add(char);
+      literalRun += char;
+    } else {
+      literalRun = pushLiteralRun(hints, literalRun);
+    }
+  }
+  pushLiteralRun(hints, literalRun);
+  return hints;
+}
+
+function charInRange(char: string, range: CharacterClassRange): boolean {
+  return char >= range.start && char <= range.end;
+}
+
+function characterMayBeMatched(
+  char: string,
+  hints: PatternCharacterHints
+): boolean {
+  return (
+    hints.literals.has(char) ||
+    hints.ranges.some((range) => charInRange(char, range))
+  );
+}
+
+export function unsafeDeniedPatternMayMatchKey(
+  pattern: string,
+  key: string
+): boolean {
+  const hints = collectPatternCharacterHints(pattern);
+  if (hints.literals.size === 0 && hints.ranges.length === 0) {
+    return true;
+  }
+
+  let comparable = 0;
+  let matching = 0;
+  let firstComparableMatches = false;
+  let lastComparableMatches = false;
+  for (const char of key) {
+    if (!isComparableKeyChar(char)) {
+      continue;
+    }
+    comparable += 1;
+    const matches = characterMayBeMatched(char, hints);
+    if (comparable === 1) {
+      firstComparableMatches = matches;
+    }
+    lastComparableMatches = matches;
+    if (matches) {
+      matching += 1;
+    }
+  }
+
+  if (comparable === 0) {
+    return true;
+  }
+  if (hints.hasUnknownMatcher) {
+    return true;
+  }
+  if (matching === 0) {
+    return false;
+  }
+  if (hints.literalRuns.some((run) => run.length >= 2 && key.includes(run))) {
+    return true;
+  }
+  const startsAtBoundary = pattern.trimStart().startsWith("^");
+  const endsAtBoundary = pattern.trimEnd().endsWith("$");
+  if (!(startsAtBoundary || endsAtBoundary)) {
+    return true;
+  }
+  if (!startsAtBoundary) {
+    return lastComparableMatches;
+  }
+  if (!endsAtBoundary) {
+    return firstComparableMatches;
+  }
+  return (
+    matching === comparable ||
+    (key.length >= 16 && matching / comparable >= 0.75)
+  );
+}

--- a/src/core/utils/tool-call-coercion.ts
+++ b/src/core/utils/tool-call-coercion.ts
@@ -3,12 +3,52 @@ import type {
   LanguageModelV3FunctionTool,
   LanguageModelV3StreamPart,
 } from "@ai-sdk/provider";
-import { coerceBySchema } from "../../schema-coerce";
+import { coerceBySchema, unwrapJsonSchema } from "../../schema-coerce";
 
 type ToolCallLike = Extract<
   LanguageModelV3Content | LanguageModelV3StreamPart,
   { type: "tool-call" }
 >;
+
+function schemaAllowsNull(schema: unknown, seen = new Set<object>()): boolean {
+  const unwrapped = unwrapJsonSchema(schema);
+  if (unwrapped === true) {
+    return true;
+  }
+  if (unwrapped === false || !unwrapped || typeof unwrapped !== "object") {
+    return false;
+  }
+  if (Array.isArray(unwrapped)) {
+    return false;
+  }
+  if (seen.has(unwrapped)) {
+    return false;
+  }
+  seen.add(unwrapped);
+
+  const record = unwrapped as Record<string, unknown>;
+  const schemaType = record.type;
+  if (schemaType === "null") {
+    return true;
+  }
+  if (Array.isArray(schemaType) && schemaType.includes("null")) {
+    return true;
+  }
+
+  const allOf = Array.isArray(record.allOf) ? record.allOf : undefined;
+  if (
+    allOf?.length &&
+    allOf.every((item) => schemaAllowsNull(item, new Set(seen)))
+  ) {
+    return true;
+  }
+  const anyOf = Array.isArray(record.anyOf) ? record.anyOf : undefined;
+  if (anyOf?.some((item) => schemaAllowsNull(item, new Set(seen)))) {
+    return true;
+  }
+  const oneOf = Array.isArray(record.oneOf) ? record.oneOf : undefined;
+  return oneOf?.some((item) => schemaAllowsNull(item, new Set(seen))) === true;
+}
 
 export function coerceToolCallInput(
   toolName: string,
@@ -22,6 +62,8 @@ export function coerceToolCallInput(
     } catch {
       return;
     }
+  } else if (input === null) {
+    args = null;
   } else if (input && typeof input === "object") {
     args = input;
   } else {
@@ -30,6 +72,9 @@ export function coerceToolCallInput(
 
   const schema = tools.find((t) => t.name === toolName)?.inputSchema;
   const coerced = coerceBySchema(args, schema);
+  if (coerced === null && schemaAllowsNull(schema)) {
+    return "null";
+  }
   return JSON.stringify(coerced ?? {});
 }
 

--- a/src/core/utils/tool-call-coercion.ts
+++ b/src/core/utils/tool-call-coercion.ts
@@ -71,9 +71,12 @@ export function coerceToolCallInput(
   }
 
   const schema = tools.find((t) => t.name === toolName)?.inputSchema;
+  if (args === null) {
+    return schemaAllowsNull(schema) ? "null" : undefined;
+  }
   const coerced = coerceBySchema(args, schema);
-  if (coerced === null && schemaAllowsNull(schema)) {
-    return "null";
+  if (coerced === null) {
+    return schemaAllowsNull(schema) ? "null" : undefined;
   }
   return JSON.stringify(coerced ?? {});
 }

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -251,7 +251,7 @@ function schemaHasProperty(schema: unknown, key: string, depth = 0): boolean {
   return schemaAllowsPropertyViaCombinators(s, key, depth);
 }
 
-function schemaIsUnconstrained(schema: unknown): boolean {
+export function schemaIsUnconstrained(schema: unknown): boolean {
   const unwrapped = unwrapJsonSchema(schema);
   if (unwrapped == null || unwrapped === true) {
     return true;

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -267,6 +267,18 @@ interface RegexGroupState {
   hasQuantifier: boolean;
 }
 
+interface RegexRiskScanState {
+  escaped: boolean;
+  groups: RegexGroupState[];
+  inCharClass: boolean;
+}
+
+interface RegexAtomRead {
+  atom: string | null;
+  end: number;
+  resetPrevious: boolean;
+}
+
 const REGEX_ATOM_CHAR_RE = /^[A-Za-z0-9_$-]$/;
 
 function regexQuantifierEnd(pattern: string, index: number): number | null {
@@ -310,67 +322,106 @@ function regexGroupPrefixEnd(
   return nameEnd === -1 ? null : nameEnd;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Regex quantifier scanning is a compact state machine.
+function consumeRegexEscapeOrClassState(
+  state: RegexRiskScanState,
+  char: string
+): boolean {
+  if (state.escaped) {
+    state.escaped = false;
+    return true;
+  }
+  if (char === "\\") {
+    state.escaped = true;
+    return true;
+  }
+  if (char === "[" && !state.inCharClass) {
+    state.inCharClass = true;
+    return true;
+  }
+  if (char === "]" && state.inCharClass) {
+    state.inCharClass = false;
+    return true;
+  }
+  return state.inCharClass;
+}
+
+function openRegexGroup(
+  pattern: string,
+  index: number,
+  groups: RegexGroupState[]
+): number {
+  groups.push({ hasAlternation: false, hasQuantifier: false });
+  return regexGroupPrefixEnd(pattern, index) ?? index;
+}
+
+function markParentGroupQuantified(groups: RegexGroupState[]) {
+  const parentGroup = groups.at(-1);
+  if (parentGroup) {
+    parentGroup.hasQuantifier = true;
+  }
+}
+
+function closeRegexGroup(
+  pattern: string,
+  index: number,
+  groups: RegexGroupState[]
+): { nextIndex: number; risk: boolean } {
+  const group = groups.pop();
+  const quantifierEnd = regexQuantifierEnd(pattern, index + 1);
+  if (!(group && quantifierEnd != null)) {
+    return { nextIndex: index, risk: false };
+  }
+  if (group.hasAlternation || group.hasQuantifier) {
+    return { nextIndex: index, risk: true };
+  }
+  markParentGroupQuantified(groups);
+  return { nextIndex: quantifierEnd, risk: false };
+}
+
+function markRegexQuantifier(
+  pattern: string,
+  index: number,
+  groups: RegexGroupState[]
+): number | null {
+  const quantifierEnd = regexQuantifierEnd(pattern, index);
+  if (quantifierEnd == null) {
+    return null;
+  }
+  markParentGroupQuantified(groups);
+  return quantifierEnd;
+}
+
 function hasNestedQuantifierRisk(pattern: string): boolean {
-  let escaped = false;
-  let inCharClass = false;
-  const groups: RegexGroupState[] = [];
+  const state: RegexRiskScanState = {
+    escaped: false,
+    groups: [],
+    inCharClass: false,
+  };
 
   for (let index = 0; index < pattern.length; index += 1) {
     const ch = pattern.charAt(index);
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (ch === "\\") {
-      escaped = true;
-      continue;
-    }
-    if (ch === "[" && !inCharClass) {
-      inCharClass = true;
-      continue;
-    }
-    if (ch === "]" && inCharClass) {
-      inCharClass = false;
-      continue;
-    }
-    if (inCharClass) {
+    if (consumeRegexEscapeOrClassState(state, ch)) {
       continue;
     }
     if (ch === "(") {
-      groups.push({ hasAlternation: false, hasQuantifier: false });
-      const prefixEnd = regexGroupPrefixEnd(pattern, index);
-      if (prefixEnd != null) {
-        index = prefixEnd;
-      }
+      index = openRegexGroup(pattern, index, state.groups);
       continue;
     }
-    if (ch === ")" && groups.length > 0) {
-      const group = groups.pop();
-      const quantifierEnd = regexQuantifierEnd(pattern, index + 1);
-      if (group && quantifierEnd != null) {
-        if (group.hasAlternation || group.hasQuantifier) {
-          return true;
-        }
-        const parentGroup = groups.at(-1);
-        if (parentGroup) {
-          parentGroup.hasQuantifier = true;
-        }
-        index = quantifierEnd;
+    if (ch === ")" && state.groups.length > 0) {
+      const closed = closeRegexGroup(pattern, index, state.groups);
+      if (closed.risk) {
+        return true;
       }
+      index = closed.nextIndex;
       continue;
     }
-    const currentGroup = groups.at(-1);
+    const currentGroup = state.groups.at(-1);
     if (ch === "|" && currentGroup) {
       currentGroup.hasAlternation = true;
       continue;
     }
-    const quantifierEnd = regexQuantifierEnd(pattern, index);
+    const quantifierEnd = markRegexQuantifier(pattern, index, state.groups);
     if (quantifierEnd != null) {
-      const quantifiedGroup = groups.at(-1);
-      if (quantifiedGroup) {
-        quantifiedGroup.hasQuantifier = true;
-      }
       index = quantifierEnd;
     }
   }
@@ -435,53 +486,67 @@ function findGroupEnd(pattern: string, start: number): number | null {
   return null;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Regex atom scanning is a compact state machine.
+function readRegexAtom(pattern: string, index: number): RegexAtomRead | null {
+  const char = pattern.charAt(index);
+  if (char === "\\") {
+    return {
+      atom: pattern.slice(index, Math.min(index + 2, pattern.length)),
+      end: index + 1,
+      resetPrevious: false,
+    };
+  }
+  if (char === "[") {
+    const classEnd = findCharClassEnd(pattern, index);
+    return classEnd == null
+      ? null
+      : {
+          atom: pattern.slice(index, classEnd + 1),
+          end: classEnd,
+          resetPrevious: false,
+        };
+  }
+  if (char === "(") {
+    const groupEnd = findGroupEnd(pattern, index);
+    if (groupEnd == null) {
+      return null;
+    }
+    return {
+      atom: null,
+      end: regexQuantifierEnd(pattern, groupEnd + 1) ?? groupEnd,
+      resetPrevious: true,
+    };
+  }
+  return char === "." || REGEX_ATOM_CHAR_RE.test(char)
+    ? { atom: char, end: index, resetPrevious: false }
+    : { atom: null, end: index, resetPrevious: true };
+}
+
 function hasAdjacentRepeatedQuantifiedAtoms(pattern: string): boolean {
   let previousQuantifiedAtom: string | null = null;
 
   for (let index = 0; index < pattern.length; index += 1) {
-    const ch = pattern.charAt(index);
-    let atom: string | null = null;
-    let atomEnd = index;
-
-    if (ch === "\\") {
-      atom = pattern.slice(index, Math.min(index + 2, pattern.length));
-      atomEnd = index + 1;
-    } else if (ch === "[") {
-      const classEnd = findCharClassEnd(pattern, index);
-      if (classEnd == null) {
-        return false;
-      }
-      atom = pattern.slice(index, classEnd + 1);
-      atomEnd = classEnd;
-    } else if (ch === "(") {
-      const groupEnd = findGroupEnd(pattern, index);
-      if (groupEnd == null) {
-        return false;
-      }
-      const quantifierEnd = regexQuantifierEnd(pattern, groupEnd + 1);
-      index = quantifierEnd ?? groupEnd;
+    const read = readRegexAtom(pattern, index);
+    if (read === null) {
+      return false;
+    }
+    if (read.resetPrevious) {
       previousQuantifiedAtom = null;
-      continue;
-    } else if (ch === "." || REGEX_ATOM_CHAR_RE.test(ch)) {
-      atom = ch;
-    } else {
-      previousQuantifiedAtom = null;
+      index = read.end;
       continue;
     }
 
-    const quantifierEnd = regexQuantifierEnd(pattern, atomEnd + 1);
-    if (atom && quantifierEnd != null) {
-      if (previousQuantifiedAtom === atom) {
+    const quantifierEnd = regexQuantifierEnd(pattern, read.end + 1);
+    if (read.atom && quantifierEnd != null) {
+      if (previousQuantifiedAtom === read.atom) {
         return true;
       }
-      previousQuantifiedAtom = atom;
+      previousQuantifiedAtom = read.atom;
       index = quantifierEnd;
       continue;
     }
 
     previousQuantifiedAtom = null;
-    index = atomEnd;
+    index = read.end;
   }
 
   return false;

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -11,13 +11,15 @@ const DOUBLE_QUOTE = '"';
 const SNAKE_SEGMENT_REGEX = /_([a-zA-Z0-9])/g;
 const CAMEL_BOUNDARY_REGEX = /([a-z0-9])([A-Z])/g;
 const LEADING_UNDERSCORES_REGEX = /^_+/;
+const REGEX_BACKREFERENCE_REGEX = /\\(?:[1-9]|k<)/;
+const MAX_PATTERN_PROPERTY_REGEX_LENGTH = 128;
 
 export function unwrapJsonSchema(schema: unknown): unknown {
   if (!schema || typeof schema !== "object") {
     return schema;
   }
   const s = schema as Record<string, unknown>;
-  if (s.jsonSchema && typeof s.jsonSchema === "object") {
+  if ("jsonSchema" in s) {
     return unwrapJsonSchema(s.jsonSchema);
   }
   return schema;
@@ -260,6 +262,239 @@ function schemaIsUnconstrained(schema: unknown): boolean {
   return Object.keys(unwrapped).length === 0;
 }
 
+interface RegexGroupState {
+  hasAlternation: boolean;
+  hasQuantifier: boolean;
+}
+
+function regexQuantifierEnd(pattern: string, index: number): number | null {
+  const char = pattern.charAt(index);
+  if (char === "*" || char === "+" || char === "?") {
+    return index;
+  }
+  if (char !== "{") {
+    return null;
+  }
+  let cursor = index + 1;
+  while (cursor < pattern.length && pattern.charAt(cursor) !== "}") {
+    const part = pattern.charAt(cursor);
+    if (!(part === "," || (part >= "0" && part <= "9"))) {
+      return null;
+    }
+    cursor += 1;
+  }
+  return cursor < pattern.length ? cursor : null;
+}
+
+function regexGroupPrefixEnd(pattern: string, groupStart: number): number | null {
+  if (pattern.charAt(groupStart + 1) !== "?") {
+    return null;
+  }
+  const prefix = pattern.charAt(groupStart + 2);
+  if (prefix === ":" || prefix === "=" || prefix === "!") {
+    return groupStart + 2;
+  }
+  if (prefix !== "<") {
+    return null;
+  }
+  const lookbehindPrefix = pattern.charAt(groupStart + 3);
+  if (lookbehindPrefix === "=" || lookbehindPrefix === "!") {
+    return groupStart + 3;
+  }
+  const nameEnd = pattern.indexOf(">", groupStart + 3);
+  return nameEnd === -1 ? null : nameEnd;
+}
+
+function hasNestedQuantifierRisk(pattern: string): boolean {
+  let escaped = false;
+  let inCharClass = false;
+  const groups: RegexGroupState[] = [];
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const ch = pattern.charAt(index);
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === "[" && !inCharClass) {
+      inCharClass = true;
+      continue;
+    }
+    if (ch === "]" && inCharClass) {
+      inCharClass = false;
+      continue;
+    }
+    if (inCharClass) {
+      continue;
+    }
+    if (ch === "(") {
+      groups.push({ hasAlternation: false, hasQuantifier: false });
+      const prefixEnd = regexGroupPrefixEnd(pattern, index);
+      if (prefixEnd != null) {
+        index = prefixEnd;
+      }
+      continue;
+    }
+    if (ch === ")" && groups.length > 0) {
+      const group = groups.pop();
+      const quantifierEnd = regexQuantifierEnd(pattern, index + 1);
+      if (group && quantifierEnd != null) {
+        if (group.hasAlternation || group.hasQuantifier) {
+          return true;
+        }
+        if (groups.length > 0) {
+          groups[groups.length - 1].hasQuantifier = true;
+        }
+        index = quantifierEnd;
+      }
+      continue;
+    }
+    if (ch === "|" && groups.length > 0) {
+      groups[groups.length - 1].hasAlternation = true;
+      continue;
+    }
+    const quantifierEnd = regexQuantifierEnd(pattern, index);
+    if (quantifierEnd != null) {
+      if (groups.length > 0) {
+        groups[groups.length - 1].hasQuantifier = true;
+      }
+      index = quantifierEnd;
+    }
+  }
+  return false;
+}
+
+function findCharClassEnd(pattern: string, start: number): number | null {
+  let escaped = false;
+  for (let index = start + 1; index < pattern.length; index += 1) {
+    const ch = pattern.charAt(index);
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === "]") {
+      return index;
+    }
+  }
+  return null;
+}
+
+function findGroupEnd(pattern: string, start: number): number | null {
+  let escaped = false;
+  let inCharClass = false;
+  let depth = 0;
+  for (let index = start; index < pattern.length; index += 1) {
+    const ch = pattern.charAt(index);
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === "[" && !inCharClass) {
+      inCharClass = true;
+      continue;
+    }
+    if (ch === "]" && inCharClass) {
+      inCharClass = false;
+      continue;
+    }
+    if (inCharClass) {
+      continue;
+    }
+    if (ch === "(") {
+      depth += 1;
+      continue;
+    }
+    if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return null;
+}
+
+function hasAdjacentRepeatedQuantifiedAtoms(pattern: string): boolean {
+  let previousQuantifiedAtom: string | null = null;
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const ch = pattern.charAt(index);
+    let atom: string | null = null;
+    let atomEnd = index;
+
+    if (ch === "\\") {
+      atom = pattern.slice(index, Math.min(index + 2, pattern.length));
+      atomEnd = index + 1;
+    } else if (ch === "[") {
+      const classEnd = findCharClassEnd(pattern, index);
+      if (classEnd == null) {
+        return false;
+      }
+      atom = pattern.slice(index, classEnd + 1);
+      atomEnd = classEnd;
+    } else if (ch === "(") {
+      const groupEnd = findGroupEnd(pattern, index);
+      if (groupEnd == null) {
+        return false;
+      }
+      const quantifierEnd = regexQuantifierEnd(pattern, groupEnd + 1);
+      index = quantifierEnd ?? groupEnd;
+      previousQuantifiedAtom = null;
+      continue;
+    } else if (ch === "." || /^[A-Za-z0-9_$-]$/.test(ch)) {
+      atom = ch;
+    } else {
+      previousQuantifiedAtom = null;
+      continue;
+    }
+
+    const quantifierEnd = regexQuantifierEnd(pattern, atomEnd + 1);
+    if (atom && quantifierEnd != null) {
+      if (previousQuantifiedAtom === atom) {
+        return true;
+      }
+      previousQuantifiedAtom = atom;
+      index = quantifierEnd;
+      continue;
+    }
+
+    previousQuantifiedAtom = null;
+    index = atomEnd;
+  }
+
+  return false;
+}
+
+export function compileSafePatternPropertyRegex(
+  pattern: string
+): RegExp | null {
+  if (
+    pattern.length > MAX_PATTERN_PROPERTY_REGEX_LENGTH ||
+    REGEX_BACKREFERENCE_REGEX.test(pattern) ||
+    hasNestedQuantifierRisk(pattern) ||
+    hasAdjacentRepeatedQuantifiedAtoms(pattern)
+  ) {
+    return null;
+  }
+  try {
+    return new RegExp(pattern);
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Gets all schemas from patternProperties that match the given key.
  *
@@ -289,13 +524,9 @@ function getPatternSchemasForKey(
   for (const [pattern, schema] of Object.entries(
     patternProperties as Record<string, unknown>
   )) {
-    try {
-      const regex = new RegExp(pattern);
-      if (regex.test(key)) {
-        schemas.push(schema);
-      }
-    } catch {
-      // Ignore invalid regex patterns.
+    const regex = compileSafePatternPropertyRegex(pattern);
+    if (regex?.test(key)) {
+      schemas.push(schema);
     }
   }
   return schemas;
@@ -1147,6 +1378,28 @@ function coerceArrayValue(
   return [value];
 }
 
+function coerceByStrictAllOfObjectSchemas(
+  value: unknown,
+  allOf: unknown
+): unknown {
+  if (!Array.isArray(allOf)) {
+    return value;
+  }
+  let output = value;
+  for (const subSchema of allOf) {
+    const unwrapped = unwrapJsonSchema(subSchema);
+    if (
+      unwrapped &&
+      typeof unwrapped === "object" &&
+      !Array.isArray(unwrapped) &&
+      getStrictObjectSchemaInfo(unwrapped as Record<string, unknown>)
+    ) {
+      output = coerceBySchema(output, subSchema);
+    }
+  }
+  return output;
+}
+
 export function coerceBySchema(value: unknown, schema?: unknown): unknown {
   const unwrapped = unwrapJsonSchema(schema);
   if (!unwrapped || typeof unwrapped !== "object") {
@@ -1158,14 +1411,22 @@ export function coerceBySchema(value: unknown, schema?: unknown): unknown {
 
   const schemaType = getSchemaType(unwrapped);
   const u = unwrapped as Record<string, unknown>;
+  const valueAfterAllOf = coerceByStrictAllOfObjectSchemas(value, u.allOf);
+  if (
+    valueAfterAllOf === null &&
+    Array.isArray(u.type) &&
+    u.type.includes("null")
+  ) {
+    return valueAfterAllOf;
+  }
 
   // Handle string values
-  if (typeof value === "string") {
-    return coerceStringValue(value, schemaType, u);
+  if (typeof valueAfterAllOf === "string") {
+    return coerceStringValue(valueAfterAllOf, schemaType, u);
   }
 
   // Coerce primitive scalars to string when schema explicitly expects a string.
-  const primitiveString = coercePrimitiveToString(value, schemaType);
+  const primitiveString = coercePrimitiveToString(valueAfterAllOf, schemaType);
   if (primitiveString !== null) {
     return primitiveString;
   }
@@ -1173,22 +1434,22 @@ export function coerceBySchema(value: unknown, schema?: unknown): unknown {
   // Handle object to object coercion
   if (
     schemaType === "object" &&
-    value &&
-    typeof value === "object" &&
-    !Array.isArray(value)
+    valueAfterAllOf &&
+    typeof valueAfterAllOf === "object" &&
+    !Array.isArray(valueAfterAllOf)
   ) {
-    return coerceObjectToObject(value as Record<string, unknown>, u);
+    return coerceObjectToObject(valueAfterAllOf as Record<string, unknown>, u);
   }
 
   // Handle object wrappers when schema expects a primitive value.
   if (
-    value &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
+    valueAfterAllOf &&
+    typeof valueAfterAllOf === "object" &&
+    !Array.isArray(valueAfterAllOf) &&
     isPrimitiveSchemaType(schemaType)
   ) {
     const primitiveResult = coerceObjectToPrimitive(
-      value as Record<string, unknown>,
+      valueAfterAllOf as Record<string, unknown>,
       schemaType,
       u
     );
@@ -1204,8 +1465,8 @@ export function coerceBySchema(value: unknown, schema?: unknown): unknown {
       : undefined;
     const itemsSchema = u.items as unknown;
 
-    return coerceArrayValue(value, prefixItems, itemsSchema);
+    return coerceArrayValue(valueAfterAllOf, prefixItems, itemsSchema);
   }
 
-  return value;
+  return valueAfterAllOf;
 }


### PR DESCRIPTION
## Summary

When models fail to escape double quotes inside JSON string values, the tool call is rejected entirely. This adds a `repairToolCallJson` fallback that attempts to recover the tool call by:

1. Extracting the tool name via `extractTopLevelStringProperty` (depth-aware)
2. Locating the `arguments` object via `findTopLevelPropertyValueStart` (top-level aware)
3. Splitting by key positions with optional schema-aware filtering (`knownArgKeys` from tool definitions)
4. Repairing each string value by escaping unescaped quotes

The repair is best-effort — returns `null` when repair is not possible, falling through to the existing `onError` path. Also threads the `tools` parameter through `processToolCallJson` / `processMatchedToolCall` / `ParseContext` to enable schema-aware key filtering.

**Known limitations:**
- `arguments` must be the last top-level property (backwards `}}` scan)
- Unknown extra keys are dropped when schema filtering is active
- Non-string values that fail `JSON.parse` cause the repair to bail out (no type coercion)

Closes #298

## Test plan

- 15 new test cases (13 non-streaming, 2 streaming)
- Unescaped quotes in single and multiple arguments
- Schema-aware key filtering (false-positive `,"fake":` patterns)
- Valid JSON passthrough (no regression)
- Completely broken JSON falls through to `onError`
- Numeric, boolean, null values alongside broken strings
- Nested objects and arrays without false key splits
- Nested `"name"` inside arguments not confused with tool name
- Non-string parse failure returns `null` (type coercion prevention)
- Arguments-not-last-property graceful failure
- 100KB size guard
- Streaming repair on complete tool calls

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds best‑effort repair for malformed tool call JSON when models don’t escape quotes in string arguments, so valid tool calls aren’t dropped. Enforces strict schema semantics during repair in `hermes-protocol` across parse and streaming; strict‑JSON only, with hardened edge cases, bounded recursion to prevent stack overflows, and safe full‑text fallback when repair isn’t possible.

- **Bug Fixes**
  - Schema: honor wrapped schemas; enforce nested shapes and `patternProperties`; reject unknown/invalid keys under strict policy; distinguish `oneOf` branches; validate key–value shape matches; fail‑closed on unsafe deny classes; bound recursive validation (max depth 256) to avoid stack overflow; reject null arguments when disallowed and preserve `null` when allowed.
  - Key detection: depth‑ and top‑level aware detection of "name"/"arguments"; keep all top‑level key boundaries; score duplicate keys; require own top‑level fields.
  - Filtering: apply schema checks only at assignment; drop schema‑unknown keys; bail if all parsed keys are unknown; compile safe pattern regexes; deny unsafe/backreference patterns.
  - Repair: escape unescaped quotes in string values; catch‑all around repair to return `null` on unexpected errors; bail on non‑string parse failures, ambiguous `,"unknown":` inside broken strings, or arguments body >100KB.
  - Streaming: emit progress safely (including before delayed closing tags); preserve full original text on bailout; block unsafe progress paths.

<sup>Written for commit f030717350bb6469a150e0748965e9dac2c76953. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

