### PR TITLE
fix: preserve schema semantics in Hermes JSON repair

### DIFF
--- a/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
+++ b/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
@@ -1,6 +1,8 @@
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
 import { describe, expect, it } from "vitest";
 import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
 import { toolInputStreamFixtures } from "../../../fixtures/tool-input-stream-fixtures";
+import { stopFinishReason, zeroUsage } from "../../../test-helpers";
 import {
   assertCanonicalAiSdkEventOrder,
   assertCoreAiSdkEventCoverage,
@@ -47,6 +49,64 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
 
     assertCanonicalAiSdkEventOrder(out);
     assertCoreAiSdkEventCoverage(out);
+  });
+
+  it("json protocol emits progress before a delayed closing tag", async () => {
+    const input = new TransformStream<
+      LanguageModelV3StreamPart,
+      LanguageModelV3StreamPart
+    >();
+    const out: LanguageModelV3StreamPart[] = [];
+    const done = input.readable
+      .pipeThrough(protocol.createStreamParser({ tools: fixture.tools }))
+      .pipeTo(
+        new WritableStream<LanguageModelV3StreamPart>({
+          write(part) {
+            out.push(part);
+          },
+        })
+      );
+    const writer = input.writable.getWriter();
+
+    await writer.write({
+      type: "text-delta",
+      id: "1",
+      delta:
+        '<tool_call>{"name":"get_weather","arguments":{"location":"Seoul","unit":"celsius"}}',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const beforeClose = extractToolInputTimeline(out);
+    expect(beforeClose.starts).toHaveLength(1);
+    expect(beforeClose.deltas.map((delta) => delta.delta).join("")).toBe(
+      '{"location":"Seoul","unit":"celsius"}'
+    );
+    expect(beforeClose.ends).toHaveLength(0);
+    expect(out.some((part) => part.type === "tool-call")).toBe(false);
+
+    await writer.write({
+      type: "text-delta",
+      id: "1",
+      delta: "</tool_call>",
+    });
+    await writer.write({
+      type: "finish",
+      finishReason: stopFinishReason,
+      usage: zeroUsage,
+    });
+    await writer.close();
+    await done;
+
+    const { starts, ends } = extractToolInputTimeline(out);
+    const toolCall = out.find((part) => part.type === "tool-call") as {
+      type: "tool-call";
+      toolCallId: string;
+      input: string;
+    };
+    expect(starts).toHaveLength(1);
+    expect(ends).toHaveLength(1);
+    expect(toolCall.toolCallId).toBe(starts[0].id);
+    expect(toolCall.input).toBe('{"location":"Seoul","unit":"celsius"}');
   });
 
   it("json protocol force-completes tool input at finish when closing tag is missing", async () => {

--- a/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
+++ b/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
@@ -51,7 +51,7 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
     assertCoreAiSdkEventCoverage(out);
   });
 
-  it("json protocol emits progress before a delayed closing tag", async () => {
+  it("json protocol waits for a delayed closing tag before emitting progress", async () => {
     const input = new TransformStream<
       LanguageModelV3StreamPart,
       LanguageModelV3StreamPart
@@ -77,10 +77,8 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     const beforeClose = extractToolInputTimeline(out);
-    expect(beforeClose.starts).toHaveLength(1);
-    expect(beforeClose.deltas.map((delta) => delta.delta).join("")).toBe(
-      '{"location":"Seoul","unit":"celsius"}'
-    );
+    expect(beforeClose.starts).toHaveLength(0);
+    expect(beforeClose.deltas).toHaveLength(0);
     expect(beforeClose.ends).toHaveLength(0);
     expect(out.some((part) => part.type === "tool-call")).toBe(false);
 

--- a/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
+++ b/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
@@ -161,7 +161,7 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
     expect(deltas.map((delta) => delta.delta).join("")).toBe(toolCall.input);
   });
 
-  it("json protocol emits tool-input deltas for parseable arguments even when outer JSON is incomplete", async () => {
+  it("json protocol does not emit tool-input deltas for incomplete outer JSON", async () => {
     const out = await runHermesJsonStream([
       '<tool_call>{"meta":{"msg":"{"},"name":"get_weather","arguments":{"location":"Seoul","unit":"celsius"}',
     ]);
@@ -172,11 +172,9 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
       .map((part) => (part as { delta: string }).delta)
       .join("");
 
-    expect(starts).toHaveLength(1);
-    expect(ends).toHaveLength(1);
-    expect(deltas.map((delta) => delta.delta).join("")).toBe(
-      '{"location":"Seoul","unit":"celsius"}'
-    );
+    expect(starts).toHaveLength(0);
+    expect(ends).toHaveLength(0);
+    expect(deltas).toHaveLength(0);
     expect(out.some((part) => part.type === "tool-call")).toBe(false);
     expect(leakedText).not.toContain("<tool_call>");
   });

--- a/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
+++ b/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
@@ -1,5 +1,5 @@
 import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
 import { toolInputStreamFixtures } from "../../../fixtures/tool-input-stream-fixtures";
 import { stopFinishReason, zeroUsage } from "../../../test-helpers";
@@ -157,46 +157,38 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
     expect(leakedText).not.toContain("</tool_");
   });
 
-  it("json protocol normalizes streamed arguments:null progress to match final tool-call input", async () => {
-    const out = await runHermesJsonStream([
-      '<tool_call>{"name":"get_weather","arguments":null',
-      "}</tool_call>",
-    ]);
+  it("json protocol rejects streamed arguments:null for object schemas", async () => {
+    const onError = vi.fn();
+    const out = await runProtocolTextDeltaStream({
+      protocol,
+      tools: fixture.tools,
+      chunks: ['<tool_call>{"name":"get_weather","arguments":null', "}</tool_call>"],
+      options: { onError },
+    });
 
     const { starts, deltas, ends } = extractToolInputTimeline(out);
-    const toolCall = out.find((part) => part.type === "tool-call") as {
-      type: "tool-call";
-      toolCallId: string;
-      toolName: string;
-      input: string;
-    };
-
-    expect(starts).toHaveLength(1);
-    expect(ends).toHaveLength(1);
-    expect(toolCall.toolCallId).toBe(starts[0].id);
-    expect(toolCall.input).toBe("{}");
-    expect(deltas.map((delta) => delta.delta)).toEqual(["{}"]);
-    expect(deltas.map((delta) => delta.delta).join("")).toBe(toolCall.input);
+    expect(starts).toHaveLength(0);
+    expect(deltas).toHaveLength(0);
+    expect(ends).toHaveLength(0);
+    expect(out.find((part) => part.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 
-  it("json protocol does not emit non-canonical partial literal prefixes for split null arguments", async () => {
-    const out = await runHermesJsonStream([
-      '<tool_call>{"name":"get_weather","arguments":n',
-      "ull}</tool_call>",
-    ]);
+  it("json protocol rejects split null arguments for object schemas", async () => {
+    const onError = vi.fn();
+    const out = await runProtocolTextDeltaStream({
+      protocol,
+      tools: fixture.tools,
+      chunks: ['<tool_call>{"name":"get_weather","arguments":n', "ull}</tool_call>"],
+      options: { onError },
+    });
 
     const { starts, deltas, ends } = extractToolInputTimeline(out);
-    const toolCall = out.find((part) => part.type === "tool-call") as {
-      type: "tool-call";
-      toolCallId: string;
-      input: string;
-    };
-
-    expect(starts).toHaveLength(1);
-    expect(ends).toHaveLength(1);
-    expect(toolCall.input).toBe("{}");
-    expect(deltas.map((delta) => delta.delta)).toEqual(["{}"]);
-    expect(deltas.map((delta) => delta.delta).join("")).toBe(toolCall.input);
+    expect(starts).toHaveLength(0);
+    expect(deltas).toHaveLength(0);
+    expect(ends).toHaveLength(0);
+    expect(out.find((part) => part.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 
   it("json protocol canonicalizes pretty-printed arguments progress before emitting deltas", async () => {

--- a/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
+++ b/src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts
@@ -51,7 +51,7 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
     assertCoreAiSdkEventCoverage(out);
   });
 
-  it("json protocol waits for a delayed closing tag before emitting progress", async () => {
+  it("json protocol emits progress before a delayed closing tag", async () => {
     const input = new TransformStream<
       LanguageModelV3StreamPart,
       LanguageModelV3StreamPart
@@ -77,8 +77,10 @@ describe("cross-protocol tool-input streaming events: hermes json", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     const beforeClose = extractToolInputTimeline(out);
-    expect(beforeClose.starts).toHaveLength(0);
-    expect(beforeClose.deltas).toHaveLength(0);
+    expect(beforeClose.starts).toHaveLength(1);
+    expect(beforeClose.deltas.map((delta) => delta.delta).join("")).toBe(
+      '{"location":"Seoul","unit":"celsius"}'
+    );
     expect(beforeClose.ends).toHaveLength(0);
     expect(out.some((part) => part.type === "tool-call")).toBe(false);
 

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -385,6 +385,54 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("accepts coercible keys before strict schema validation", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"translate","arguments":{"text":"Ship","target_language":"fr","formality":"casual"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("translate", {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+          targetLanguage: { type: "string" },
+          formality: { type: "string" },
+        },
+        required: ["text", "targetLanguage", "formality"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool).toBeTruthy();
+    if (tool?.type !== "tool-call") {
+      throw new Error("expected tool call");
+    }
+    expect(JSON.parse(tool.input)).toEqual({
+      text: "Ship",
+      targetLanguage: "fr",
+      formality: "casual",
+    });
+  });
+
+  it("rejects __proto__ keys in strict repair bookkeeping", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"__proto__":{"content":"bypass"},"content":"He said "hi" there"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts patternProperties keys for strict schemas", () => {
     const p = hermesProtocol();
     const text =
@@ -407,6 +455,30 @@ describe("parseGeneratedText JSON repair", () => {
     expect(tool).toBeTruthy();
     const args = JSON.parse(tool.input);
     expect(args["x-debug"]).toBe("kept");
+  });
+
+  it("fails closed for unsafe patternProperties without regex backtracking", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const slowKey = `${"a".repeat(24)}!`;
+    const text = `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const started = performance.now();
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 
   it("falls back to text instead of truncating content at schema-unknown key-like text", () => {

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -1212,6 +1212,44 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("accepts oneOf object branches distinguished by nested primitive value types", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"value":"abc"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "number" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: { value: "abc" },
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("does not let primitive oneOf branches bypass object key constraints", () => {
     const onError = vi.fn();
     const p = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -1,4 +1,7 @@
-import type { LanguageModelV3FunctionTool } from "@ai-sdk/provider";
+import type {
+  LanguageModelV3Content,
+  LanguageModelV3FunctionTool,
+} from "@ai-sdk/provider";
 import { describe, expect, it, vi } from "vitest";
 import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
 
@@ -25,14 +28,32 @@ function makeSchemaTool(
   return { type: "function", name, inputSchema };
 }
 
+type ToolCallContent = Extract<LanguageModelV3Content, { type: "tool-call" }>;
+
+function expectToolCall(
+  output: LanguageModelV3Content[]
+): ToolCallContent {
+  const tool = output.find(
+    (part): part is ToolCallContent => part.type === "tool-call"
+  );
+  expect(tool?.type).toBe("tool-call");
+  if (!tool) {
+    throw new Error("Expected tool call");
+  }
+  return tool;
+}
+
 describe("parseGeneratedText JSON repair", () => {
   it("repairs unescaped quotes in a string value", () => {
     const p = hermesProtocol();
     const text =
       '<tool_call>{"name":"edit","arguments":{"content":"He said "hello" to me"}}</tool_call>';
     const out = p.parseGeneratedText({ text, tools: [] });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    if (tool?.type !== "tool-call") {
+      throw new Error("Expected tool call");
+    }
     expect(tool.toolName).toBe("edit");
     const args = JSON.parse(tool.input);
     expect(args.content).toBe('He said "hello" to me');
@@ -63,8 +84,11 @@ describe("parseGeneratedText JSON repair", () => {
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    if (tool?.type !== "tool-call") {
+      throw new Error("Expected tool call");
+    }
     expect(tool.toolName).toBe("write");
     const args = JSON.parse(tool.input);
     expect(args.path).toBe("/tmp/a.txt");
@@ -88,7 +112,9 @@ describe("parseGeneratedText JSON repair", () => {
       '<tool_call>{"name":"edit","arguments":{"content":"value with ,"fake": inside"}}</tool_call>';
     const tools = [makeTool("edit", { content: { type: "string" } })];
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
-    const tool = out.find((x) => x.type === "tool-call") as any;
+    const tool = out.find(
+      (x): x is ToolCallContent => x.type === "tool-call"
+    );
     if (tool) {
       const args = JSON.parse(tool.input);
       expect(typeof args.content).toBe("string");
@@ -102,8 +128,7 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"read","arguments":{"path":"/tmp/file.txt"}}</tool_call>';
     const out = p.parseGeneratedText({ text, tools: [] });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("read");
     expect(JSON.parse(tool.input)).toEqual({ path: "/tmp/file.txt" });
   });
@@ -126,7 +151,7 @@ describe("parseGeneratedText JSON repair", () => {
     const out = p.parseGeneratedText({ text, tools: [], options: { onError } });
     expect(onError).toHaveBeenCalled();
     const rejoined = out
-      .map((x) => (x.type === "text" ? (x as any).text : ""))
+      .map((x) => (x.type === "text" ? x.text : ""))
       .join("");
     expect(rejoined).toContain("{totally broken}");
   });
@@ -143,8 +168,7 @@ describe("parseGeneratedText JSON repair", () => {
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("update");
     const args = JSON.parse(tool.input);
     expect(args.content).toBe('He said "hi" there');
@@ -159,8 +183,7 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"x","arguments":{"opts":{"a":1,"b":2},"content":"say \\"hi\\""}}</tool_call>';
     const out = p.parseGeneratedText({ text, tools: [] });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("x");
     const args = JSON.parse(tool.input);
     expect(args.opts).toEqual({ a: 1, b: 2 });
@@ -172,8 +195,7 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"x","arguments":{"items":[1,2,3],"text":"a \\"b\\" c"}}</tool_call>';
     const out = p.parseGeneratedText({ text, tools: [] });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("x");
     const args = JSON.parse(tool.input);
     expect(args.items).toEqual([1, 2, 3]);
@@ -204,8 +226,7 @@ describe("parseGeneratedText JSON repair", () => {
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("x");
     const args = JSON.parse(tool.input);
     expect(args.opts).toEqual({ a: 1, b: 2 });
@@ -225,8 +246,7 @@ describe("parseGeneratedText JSON repair", () => {
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("edit");
     const args = JSON.parse(tool.input);
     expect(args.name).toBe("inner_value");
@@ -249,8 +269,7 @@ describe("parseGeneratedText JSON repair", () => {
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     expect(tool.toolName).toBe("update");
     const args = JSON.parse(tool.input);
     expect(args.count).toBe(42);
@@ -291,8 +310,7 @@ describe("parseGeneratedText JSON repair", () => {
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     const args = JSON.parse(tool.input);
     expect(args.content).toBe('He said "hi" there');
     expect(args.path).toBe("/tmp/a");
@@ -873,8 +891,7 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"x","arguments":{"a":1,"b":{"c":2}}}</tool_call>';
     const out = p.parseGeneratedText({ text, tools: [] });
-    const tool = out.find((x) => x.type === "tool-call") as any;
-    expect(tool).toBeTruthy();
+    const tool = expectToolCall(out);
     const args = JSON.parse(tool.input);
     expect(args.a).toBe(1);
     expect(args.b).toEqual({ c: 2 });
@@ -1244,6 +1261,37 @@ describe("parseGeneratedText JSON repair", () => {
     }
   });
 
+  it("coerces keys before validating allOf-wrapped strict object schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"translate","arguments":{"target_language":"ko"}}</tool_call>';
+    const out = p.parseGeneratedText({
+      text,
+      tools: [
+        makeSchemaTool("translate", {
+          allOf: [
+            {
+              type: "object",
+              properties: {
+                targetLanguage: { type: "string" },
+              },
+              required: ["targetLanguage"],
+              additionalProperties: false,
+            },
+          ],
+        }),
+      ],
+      options: { onError },
+    });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      targetLanguage: "ko",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("rejects strict primitive property values that cannot be coerced", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -1494,6 +1542,34 @@ describe("parseGeneratedText JSON repair", () => {
       payload: { value: "123" },
     });
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-finite numeric strings for number and integer schemas", () => {
+    const p = hermesProtocol();
+    const cases = [
+      { schemaType: "number", value: "1e999" },
+      { schemaType: "integer", value: "9".repeat(400) },
+    ];
+    for (const { schemaType, value } of cases) {
+      const onError = vi.fn();
+      const text = `<tool_call>{"name":"edit","arguments":{"value":${JSON.stringify(value)}}}</tool_call>`;
+      const out = p.parseGeneratedText({
+        text,
+        tools: [
+          makeSchemaTool("edit", {
+            type: "object",
+            properties: {
+              value: { type: schemaType },
+            },
+            required: ["value"],
+            additionalProperties: false,
+          }),
+        ],
+        options: { onError },
+      });
+      expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+      expect(onError).toHaveBeenCalled();
+    }
   });
 
   it("rejects decimal strings for integer oneOf branches", () => {

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -354,6 +354,26 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects schema-unknown keys for clean strict JSON", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts patternProperties keys for strict schemas", () => {
     const p = hermesProtocol();
     const text =

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -759,4 +759,43 @@ describe("parseGeneratedText JSON repair", () => {
       out.some((x) => x.type === "tool-call") || onError.mock.calls.length > 0;
     expect(hasToolOrError).toBe(true);
   });
+
+  it("rejects prototype-sensitive argument keys without a schema policy", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"constructor":"pollute"}}</tool_call>';
+    const out = p.parseGeneratedText({
+      text,
+      tools: [],
+      options: { onError },
+    });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested prototype-sensitive argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"prototype":"pollute"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -798,4 +798,76 @@ describe("parseGeneratedText JSON repair", () => {
     expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
   });
+
+  it("rejects missing required argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text = '<tool_call>{"name":"write","arguments":{}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested schema-unknown argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"payload":{"value":"ok","secret":"blocked"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            additionalProperties: false,
+          },
+        },
+        required: ["payload"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested argument keys disallowed by false schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"payload":{"value":"ok","secret":"blocked"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              secret: false,
+              value: { type: "string" },
+            },
+            additionalProperties: true,
+          },
+        },
+        required: ["payload"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -472,6 +472,17 @@ describe("parseGeneratedText JSON repair", () => {
     }
   });
 
+  it("rejects prototype-sensitive RJSON keys after leading comments", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const tools = [makeTool("write", { content: { type: "string" } }, true)];
+    const text =
+      '<tool_call>/*{}*/{name:"write",arguments:{__proto__:{polluted:true},content:"ok"}}</tool_call>';
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("rejects escaped single-quoted strict RJSON prototype-sensitive argument keys", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -1099,6 +1110,40 @@ describe("parseGeneratedText JSON repair", () => {
                   },
                   additionalProperties: false,
                 },
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects values that match multiple oneOf schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"payload":{"a":"ok"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: false,
               },
             ],
           },

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -1066,6 +1066,29 @@ describe("parseGeneratedText JSON repair", () => {
     }
   });
 
+  it("rejects non-object arguments for top-level boolean false input schemas", () => {
+    const p = hermesProtocol();
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      false,
+      { jsonSchema: false },
+    ];
+    const argumentBodies = ["[]", "null", '"x"'];
+
+    for (const inputSchema of schemas) {
+      for (const argumentBody of argumentBodies) {
+        const onError = vi.fn();
+        const text = `<tool_call>{"name":"deny","arguments":${argumentBody}}</tool_call>`;
+        const out = p.parseGeneratedText({
+          text,
+          tools: [makeSchemaTool("deny", inputSchema)],
+          options: { onError },
+        });
+        expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+        expect(onError).toHaveBeenCalled();
+      }
+    }
+  });
+
   it("rejects unknown keys through strict allOf schemas", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -1156,6 +1179,68 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("accepts values that match a primitive oneOf branch", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":"abc"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { content: { type: "string" } },
+                required: ["content"],
+                additionalProperties: false,
+              },
+              { type: "string" },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: "abc",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does not let primitive oneOf branches bypass object key constraints", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"content":"ok","extra":"bad"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { content: { type: "string" } },
+                required: ["content"],
+                additionalProperties: false,
+              },
+              { type: "string" },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("applies every matching property and pattern schema", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -1213,5 +1298,27 @@ describe("parseGeneratedText JSON repair", () => {
       note: "safe",
     });
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects keys that may match unsafe false patterns with escaped range endpoints", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","m":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          [String.raw`^([a-\x7a]+)+$`]: false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -680,6 +680,50 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("fails closed for unsafe false patternProperties with escaped literals", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","aaaa":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(\\x61+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties with unknown matchers", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","secret":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^([^\\n]+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("preserves allowed keys when an unsafe false pattern contains character classes", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -981,6 +1025,38 @@ describe("parseGeneratedText JSON repair", () => {
             additionalProperties: false,
           },
         ],
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested array item keys through allOf schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"payload":[{"value":"ok","secret":"leak"}]}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            allOf: [
+              {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    value: { type: "string" },
+                  },
+                  additionalProperties: false,
+                },
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
       }),
     ];
     const out = p.parseGeneratedText({ text, tools, options: { onError } });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -680,6 +680,33 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("preserves allowed keys when an unsafe false pattern contains character classes", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","note":"safe"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a|[0-9])+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool).toBeTruthy();
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      content: "ok",
+      note: "safe",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("falls back to text instead of truncating content at schema-unknown key-like text", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -709,6 +736,26 @@ describe("parseGeneratedText JSON repair", () => {
       '<tool_call>{"name":"edit","arguments":{"content":"He said "hello" to me"},"id":"123"}</tool_call>';
     const tools = [makeTool("edit", { content: { type: "string" } })];
     p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("falls back instead of repairing arguments across trailing top-level fields", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"path":"/tmp/a"},"debug":"drop"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
   });
 
@@ -910,6 +957,30 @@ describe("parseGeneratedText JSON repair", () => {
         },
         required: ["payload"],
         additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unknown keys through strict allOf schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"safe":"ok","secret":"leak"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        allOf: [
+          {
+            type: "object",
+            properties: {
+              safe: { type: "string" },
+            },
+            required: ["safe"],
+            additionalProperties: false,
+          },
+        ],
       }),
     ];
     const out = p.parseGeneratedText({ text, tools, options: { onError } });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -305,6 +305,26 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects schema-unknown keys in strict repair even when arguments parse cleanly", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("falls back to text instead of truncating content at schema-unknown key-like text", () => {
     const onError = vi.fn();
     const p = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -2,13 +2,10 @@ import type { LanguageModelV3FunctionTool } from "@ai-sdk/provider";
 import { describe, expect, it, vi } from "vitest";
 import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
 
-vi.mock("@ai-sdk/provider-utils", () => ({
-  generateId: vi.fn(() => "mock-id"),
-}));
-
 function makeTool(
   name: string,
-  properties: Record<string, { type: string }>
+  properties: Record<string, { type: string }>,
+  additionalProperties?: boolean
 ): LanguageModelV3FunctionTool {
   return {
     type: "function",
@@ -16,6 +13,7 @@ function makeTool(
     inputSchema: {
       type: "object",
       properties,
+      ...(additionalProperties === undefined ? {} : { additionalProperties }),
     },
   };
 }
@@ -247,13 +245,8 @@ describe("parseGeneratedText JSON repair", () => {
     expect(hasToolOrError).toBe(true);
   });
 
-  it("repairs with knownArgKeys and drops unknown extra keys", () => {
+  it("preserves schema-unknown keys when additionalProperties is implicit", () => {
     const p = hermesProtocol();
-    // Schema knows "content" and "path"; the model also emits a
-    // schema-unknown "extra" key between them. The unknown boundary is
-    // still used to slice correctly (so "content" does not absorb the
-    // ,"extra":"debug", prefix into a corrupted value), and the unknown
-    // key is dropped from the final args object.
     const text =
       '<tool_call>{"name":"write","arguments":{"content":"He said "hi" there","extra":"debug","path":"/tmp/a"}}</tool_call>';
     const tools = [
@@ -268,17 +261,75 @@ describe("parseGeneratedText JSON repair", () => {
     const args = JSON.parse(tool.input);
     expect(args.content).toBe('He said "hi" there');
     expect(args.path).toBe("/tmp/a");
-    // Schema-unknown key dropped from output
-    expect(args).not.toHaveProperty("extra");
+    expect(args.extra).toBe("debug");
+  });
+
+  it("preserves schema-unknown keys when additionalProperties is true", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"He said "hi" there","dynamic":"kept"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        true
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    const args = JSON.parse(tool.input);
+    expect(args.content).toBe('He said "hi" there');
+    expect(args.dynamic).toBe("kept");
+  });
+
+  it("calls onError for schema-unknown keys when additionalProperties is false", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"He said "hi" there","debug":"drop me","path":"/tmp/a"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("falls back to text instead of truncating content at schema-unknown key-like text", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"before "quoted" ,"debug":"inside after","path":"/tmp/a"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(
+      out.some((x) => x.type === "text" && x.text.includes("<tool_call>"))
+    ).toBe(true);
   });
 
   it("calls onError when arguments is not the last top-level property (backwards scan limitation)", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
-    // "id" comes after "arguments" — the backwards scan includes
-    // ,"id":"123" in argsBody, which corrupts the arguments object.
-    // This is a known limitation: repair only works when "arguments"
-    // is the last (or second-to-last) top-level property.
     const text =
       '<tool_call>{"name":"edit","arguments":{"content":"He said "hello" to me"},"id":"123"}</tool_call>';
     const tools = [makeTool("edit", { content: { type: "string" } })];
@@ -311,10 +362,14 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"write","arguments":{"foo":"He said "hi" there","bar":"b"}}</tool_call>';
     const tools = [
-      makeTool("write", {
-        content: { type: "string" },
-        path: { type: "string" },
-      }),
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        false
+      ),
     ];
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
     const tool = out.find((x) => x.type === "tool-call");

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -870,4 +870,31 @@ describe("parseGeneratedText JSON repair", () => {
     expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
   });
+
+  it("preserves allowed extra argument keys when a denied pattern is unsafe", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","note":"safe"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool).toBeTruthy();
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      content: "ok",
+      note: "safe",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -18,6 +18,13 @@ function makeTool(
   };
 }
 
+function makeSchemaTool(
+  name: string,
+  inputSchema: LanguageModelV3FunctionTool["inputSchema"]
+): LanguageModelV3FunctionTool {
+  return { type: "function", name, inputSchema };
+}
+
 describe("parseGeneratedText JSON repair", () => {
   it("repairs unescaped quotes in a string value", () => {
     const p = hermesProtocol();
@@ -323,6 +330,52 @@ describe("parseGeneratedText JSON repair", () => {
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
     expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects schema-unknown keys for jsonSchema-wrapped strict schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        jsonSchema: {
+          type: "object",
+          properties: {
+            content: { type: "string" },
+            path: { type: "string" },
+          },
+          additionalProperties: false,
+        },
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts patternProperties keys for strict schemas", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","x-debug":"kept","path":"/tmp/a"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+          path: { type: "string" },
+        },
+        patternProperties: {
+          "^x-": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    const args = JSON.parse(tool.input);
+    expect(args["x-debug"]).toBe("kept");
   });
 
   it("falls back to text instead of truncating content at schema-unknown key-like text", () => {

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -1173,6 +1173,48 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("accepts null for nullable object and array properties", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"payload":null,"rows":null}}</tool_call>';
+    const out = p.parseGeneratedText({
+      text,
+      tools: [
+        makeSchemaTool("write", {
+          type: "object",
+          properties: {
+            payload: {
+              type: ["object", "null"],
+              properties: { content: { type: "string" } },
+              required: ["content"],
+              additionalProperties: false,
+            },
+            rows: {
+              type: ["array", "null"],
+              items: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: ["payload", "rows"],
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: null,
+      rows: null,
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("rejects non-object arguments for allOf-wrapped strict object input schemas", () => {
     const p = hermesProtocol();
     const argumentBodies = ["[]", '"scalar"'];
@@ -1416,6 +1458,72 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("does not count numeric strings as numeric oneOf matches", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"value":"123"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "integer" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: { value: "123" },
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects decimal strings for integer oneOf branches", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"value":"1.5"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "integer" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts oneOf object branches distinguished by nested enum values", () => {
     const p = hermesProtocol();
     const tools = [
@@ -1453,6 +1561,91 @@ describe("parseGeneratedText JSON repair", () => {
       });
       expect(onError).not.toHaveBeenCalled();
     }
+  });
+
+  it("accepts oneOf object branches distinguished by nested const values", () => {
+    const p = hermesProtocol();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "text" },
+                  value: { type: "string" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "count" },
+                  value: { type: "integer" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    for (const [kind, value] of [
+      ["text", '"hello"'],
+      ["count", "3"],
+    ]) {
+      const onError = vi.fn();
+      const text = `<tool_call>{"name":"edit","arguments":{"payload":{"kind":"${kind}","value":${value}}}}</tool_call>`;
+      const out = p.parseGeneratedText({ text, tools, options: { onError } });
+      const tool = out.find((x) => x.type === "tool-call");
+      expect(tool?.type).toBe("tool-call");
+      expect(onError).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rejects oneOf object branches with mismatched const values", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"kind":"count","value":"hello"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "text" },
+                  value: { type: "string" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "count" },
+                  value: { type: "integer" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 
   it("does not let primitive oneOf branches bypass object key constraints", () => {
@@ -1543,6 +1736,25 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("rejects unsafe positive patternProperties that may match constrained keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"aaaa":123}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        patternProperties: {
+          "^(a+)+$": { type: "string", enum: ["allowed"] },
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("rejects unsafe false patternProperties that may match key substrings", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -1556,6 +1768,28 @@ describe("parseGeneratedText JSON repair", () => {
         },
         patternProperties: {
           "(secret+)+": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unsafe false patternProperties that may match unanchored suffixes", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","ba":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "(a+)+$": false,
         },
         additionalProperties: true,
       }),

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -799,6 +799,28 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects nested __proto__ argument keys parsed onto prototypes", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"__proto__":{"polluted":true}}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("rejects missing required argument keys", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -863,6 +885,38 @@ describe("parseGeneratedText JSON repair", () => {
           },
         },
         required: ["payload"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("applies every matching property and pattern schema", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"payload":{"other":"bad"}}}</tool_call>';
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+        patternProperties: {
+          "^payload$": {
+            type: "object",
+            properties: {
+              must: { type: "string" },
+            },
+            required: ["must"],
+            additionalProperties: false,
+          },
+        },
         additionalProperties: false,
       }),
     ];

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -580,6 +580,29 @@ describe("parseGeneratedText JSON repair", () => {
     expect(args["z-123"]).toBe("num");
   });
 
+  it("accepts non-capturing patternProperties groups for strict schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"x-":"ok"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        patternProperties: {
+          "^(?:x-)+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      "x-": "ok",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("rejects patternProperties false matches for strict schemas", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -1112,6 +1135,55 @@ describe("parseGeneratedText JSON repair", () => {
       expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
       expect(onError).toHaveBeenCalled();
     }
+  });
+
+  it("rejects non-object arguments for allOf-wrapped strict object input schemas", () => {
+    const p = hermesProtocol();
+    const argumentBodies = ["[]", '"scalar"'];
+    for (const argumentBody of argumentBodies) {
+      const onError = vi.fn();
+      const text = `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`;
+      const out = p.parseGeneratedText({
+        text,
+        tools: [
+          makeSchemaTool("write", {
+            allOf: [
+              {
+                type: "object",
+                properties: {
+                  content: { type: "string" },
+                },
+                required: ["content"],
+                additionalProperties: false,
+              },
+            ],
+          }),
+        ],
+        options: { onError },
+      });
+      expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
+  it("rejects strict primitive property values that cannot be coerced", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"count","arguments":{"count":"abc"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("count", {
+        type: "object",
+        properties: {
+          count: { type: "integer" },
+        },
+        required: ["count"],
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 
   it("rejects unknown keys through strict allOf schemas", () => {

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -38,6 +38,20 @@ describe("parseGeneratedText JSON repair", () => {
     expect(args.content).toBe('He said "hello" to me');
   });
 
+  it("repairs unescaped quotes before a right brace character in a string", () => {
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"edit","arguments":{"content":"He said "}" there"}}</tool_call>';
+    const tools = [makeTool("edit", { content: { type: "string" } }, false)];
+    const out = p.parseGeneratedText({ text, tools });
+    const tool = out.find((x) => x.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    if (tool?.type !== "tool-call") {
+      throw new Error("Expected repaired tool call");
+    }
+    expect(JSON.parse(tool.input)).toEqual({ content: 'He said "}" there' });
+  });
+
   it("repairs multiple arguments with one having unescaped quotes", () => {
     const p = hermesProtocol();
     const text =
@@ -443,6 +457,19 @@ describe("parseGeneratedText JSON repair", () => {
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
     expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unquoted prototype-sensitive RJSON keys after comments", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const tools = [makeTool("write", { content: { type: "string" } }, false)];
+    for (const prefix of ["/* comment */", "// comment\n"]) {
+      onError.mockClear();
+      const text = `<tool_call>{name:"write",arguments:{${prefix}__proto__:{polluted:true},content:"ok"}}</tool_call>`;
+      const out = p.parseGeneratedText({ text, tools, options: { onError } });
+      expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+      expect(onError).toHaveBeenCalled();
+    }
   });
 
   it("rejects escaped single-quoted strict RJSON prototype-sensitive argument keys", () => {
@@ -1006,6 +1033,26 @@ describe("parseGeneratedText JSON repair", () => {
     const out = p.parseGeneratedText({ text, tools, options: { onError } });
     expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects top-level boolean false input schemas", () => {
+    const p = hermesProtocol();
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      false,
+      { jsonSchema: false },
+    ];
+    for (const inputSchema of schemas) {
+      const onError = vi.fn();
+      const text =
+        '<tool_call>{"name":"deny","arguments":{"content":"ok"}}</tool_call>';
+      const out = p.parseGeneratedText({
+        text,
+        tools: [makeSchemaTool("deny", inputSchema)],
+        options: { onError },
+      });
+      expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+      expect(onError).toHaveBeenCalled();
+    }
   });
 
   it("rejects unknown keys through strict allOf schemas", () => {

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -94,6 +94,17 @@ describe("parseGeneratedText JSON repair", () => {
     expect(JSON.parse(tool.input)).toEqual({ path: "/tmp/file.txt" });
   });
 
+  it("rejects inherited tool call fields from __proto__ wrappers", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"__proto__":{"name":"write","arguments":{"content":"ok"}}}</tool_call>';
+    const tools = [makeTool("write", { content: { type: "string" } })];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("falls through to error for completely broken JSON (no name field)", () => {
     const onError = vi.fn();
     const p = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -1089,6 +1089,31 @@ describe("parseGeneratedText JSON repair", () => {
     }
   });
 
+  it("rejects non-object arguments for object input schemas", () => {
+    const p = hermesProtocol();
+    const argumentBodies = ["[]", "null", '"x"'];
+    for (const argumentBody of argumentBodies) {
+      const onError = vi.fn();
+      const text = `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`;
+      const out = p.parseGeneratedText({
+        text,
+        tools: [
+          makeSchemaTool("write", {
+            type: "object",
+            properties: {
+              content: { type: "string" },
+            },
+            required: ["content"],
+            additionalProperties: false,
+          }),
+        ],
+        options: { onError },
+      });
+      expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
   it("rejects unknown keys through strict allOf schemas", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -1137,6 +1162,39 @@ describe("parseGeneratedText JSON repair", () => {
             ],
           },
         },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested tuple item keys through draft-07 items arrays", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"rows":[{"value":"ok","secret":"leak"}]}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          rows: {
+            type: "array",
+            items: [
+              {
+                type: "object",
+                properties: {
+                  value: { type: "string" },
+                },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+            additionalItems: false,
+          },
+        },
+        required: ["rows"],
         additionalProperties: false,
       }),
     ];
@@ -1250,6 +1308,45 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("accepts oneOf object branches distinguished by nested enum values", () => {
+    const p = hermesProtocol();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string", enum: ["a"] } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "string", enum: ["b"] } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    for (const value of ["a", "b"]) {
+      const onError = vi.fn();
+      const text = `<tool_call>{"name":"edit","arguments":{"payload":{"value":"${value}"}}}</tool_call>`;
+      const out = p.parseGeneratedText({ text, tools, options: { onError } });
+      const tool = out.find((x) => x.type === "tool-call");
+      expect(tool?.type).toBe("tool-call");
+      expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+        payload: { value },
+      });
+      expect(onError).not.toHaveBeenCalled();
+    }
+  });
+
   it("does not let primitive oneOf branches bypass object key constraints", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -1336,6 +1433,28 @@ describe("parseGeneratedText JSON repair", () => {
       note: "safe",
     });
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe false patternProperties that may match key substrings", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","x-secret":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "(secret+)+": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 
   it("rejects keys that may match unsafe false patterns with escaped range endpoints", () => {

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -296,8 +296,11 @@ describe("parseGeneratedText JSON repair", () => {
       ),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
+    const tool = out.find((x) => x.type === "tool-call");
     expect(tool).toBeTruthy();
+    if (tool?.type !== "tool-call") {
+      throw new Error("expected tool call");
+    }
     const args = JSON.parse(tool.input);
     expect(args.content).toBe('He said "hi" there');
     expect(args.dynamic).toBe("kept");
@@ -404,11 +407,49 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects prototype-sensitive argument keys even when unknown keys are allowed", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","constructor":{"polluted":true}}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        true
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("rejects unquoted strict RJSON with prototype-sensitive argument keys", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
     const text =
       '<tool_call>{name:"write",arguments:{__proto__:{polluted:true},content:"ok"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects escaped single-quoted strict RJSON prototype-sensitive argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      "<tool_call>{name:\"write\",arguments:{'\\u005f\\u005fproto__':{polluted:true},content:\"ok\"}}</tool_call>";
     const tools = [
       makeTool(
         "write",
@@ -582,6 +623,30 @@ describe("parseGeneratedText JSON repair", () => {
           "^a+a+$": { type: "string" },
         },
         additionalProperties: false,
+      }),
+    ];
+    const started = performance.now();
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties when unknown keys are allowed", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const slowKey = `${"a".repeat(24)}!`;
+    const text = `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": false,
+        },
+        additionalProperties: true,
       }),
     ];
     const started = performance.now();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -385,6 +385,25 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects clean strict JSON with prototype-sensitive argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","__proto__":{"polluted":true}}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts coercible keys before strict schema validation", () => {
     const p = hermesProtocol();
     const text =
@@ -457,6 +476,28 @@ describe("parseGeneratedText JSON repair", () => {
     expect(args["x-debug"]).toBe("kept");
   });
 
+  it("rejects patternProperties false matches for strict schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","x-secret":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^x-": false,
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("fails closed for unsafe patternProperties without regex backtracking", () => {
     const onError = vi.fn();
     const p = hermesProtocol();
@@ -470,6 +511,30 @@ describe("parseGeneratedText JSON repair", () => {
         },
         patternProperties: {
           "^(a+)+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const started = performance.now();
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe repeated patternProperties without groups", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const slowKey = `${"a".repeat(24)}!`;
+    const text = `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^a+a+$": { type: "string" },
         },
         additionalProperties: false,
       }),

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -404,6 +404,25 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects unquoted strict RJSON with prototype-sensitive argument keys", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{name:"write",arguments:{__proto__:{polluted:true},content:"ok"}}</tool_call>';
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts coercible keys before strict schema validation", () => {
     const p = hermesProtocol();
     const text =
@@ -452,10 +471,10 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
-  it("accepts patternProperties keys for strict schemas", () => {
+  it("accepts common grouped and quantified patternProperties for strict schemas", () => {
     const p = hermesProtocol();
     const text =
-      '<tool_call>{"name":"write","arguments":{"content":"ok","x-debug":"kept","path":"/tmp/a"}}}</tool_call>';
+      '<tool_call>{"name":"write","arguments":{"content":"ok","x-debug":"kept","y-trace":"yes","z-123":"num","path":"/tmp/a"}}}</tool_call>';
     const tools = [
       makeSchemaTool("write", {
         type: "object",
@@ -464,16 +483,22 @@ describe("parseGeneratedText JSON repair", () => {
           path: { type: "string" },
         },
         patternProperties: {
-          "^x-": { type: "string" },
+          "^(x|y)-": { type: "string" },
+          "^z-[0-9]+$": { type: "string" },
         },
         additionalProperties: false,
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
-    const tool = out.find((x) => x.type === "tool-call") as any;
+    const tool = out.find((x) => x.type === "tool-call");
     expect(tool).toBeTruthy();
+    if (tool?.type !== "tool-call") {
+      throw new Error("expected tool call");
+    }
     const args = JSON.parse(tool.input);
     expect(args["x-debug"]).toBe("kept");
+    expect(args["y-trace"]).toBe("yes");
+    expect(args["z-123"]).toBe("num");
   });
 
   it("rejects patternProperties false matches for strict schemas", () => {
@@ -489,6 +514,26 @@ describe("parseGeneratedText JSON repair", () => {
         },
         patternProperties: {
           "^x-": false,
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects false property schemas for strict schemas", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","secret":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+          secret: false,
         },
         additionalProperties: false,
       }),

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -656,6 +656,30 @@ describe("parseGeneratedText JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("fails closed for unsafe false patternProperties with character classes", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":"ok","123":"blocked"}}</tool_call>';
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a|[0-9])+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const started = performance.now();
+    const out = p.parseGeneratedText({ text, tools, options: { onError } });
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("falls back to text instead of truncating content at schema-unknown key-like text", () => {
     const onError = vi.fn();
     const p = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts
@@ -238,11 +238,14 @@ describe("parseGeneratedText JSON repair", () => {
     const text =
       '<tool_call>{"name":"update","arguments":{"count":42,"flag":true,"label":null,"content":"He said "hi" there"}}</tool_call>';
     const tools = [
-      makeTool("update", {
-        count: { type: "number" },
-        flag: { type: "boolean" },
-        label: { type: "string" },
-        content: { type: "string" },
+      makeSchemaTool("update", {
+        type: "object",
+        properties: {
+          count: { type: "number" },
+          flag: { type: "boolean" },
+          label: { type: ["string", "null"] },
+          content: { type: "string" },
+        },
       }),
     ];
     const out = p.parseGeneratedText({ text, tools });
@@ -1115,26 +1118,59 @@ describe("parseGeneratedText JSON repair", () => {
   it("rejects non-object arguments for object input schemas", () => {
     const p = hermesProtocol();
     const argumentBodies = ["[]", "null", '"x"'];
-    for (const argumentBody of argumentBodies) {
-      const onError = vi.fn();
-      const text = `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`;
-      const out = p.parseGeneratedText({
-        text,
-        tools: [
-          makeSchemaTool("write", {
-            type: "object",
-            properties: {
-              content: { type: "string" },
-            },
-            required: ["content"],
-            additionalProperties: false,
-          }),
-        ],
-        options: { onError },
-      });
-      expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
-      expect(onError).toHaveBeenCalled();
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+      },
+      {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+        additionalProperties: false,
+      },
+    ];
+    for (const inputSchema of schemas) {
+      for (const argumentBody of argumentBodies) {
+        const onError = vi.fn();
+        const text = `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`;
+        const out = p.parseGeneratedText({
+          text,
+          tools: [makeSchemaTool("write", inputSchema)],
+          options: { onError },
+        });
+        expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+        expect(onError).toHaveBeenCalled();
+      }
     }
+  });
+
+  it("rejects null for non-nullable typed object properties", () => {
+    const onError = vi.fn();
+    const p = hermesProtocol();
+    const text =
+      '<tool_call>{"name":"write","arguments":{"content":null}}</tool_call>';
+    const out = p.parseGeneratedText({
+      text,
+      tools: [
+        makeSchemaTool("write", {
+          type: "object",
+          properties: {
+            content: { type: "string" },
+          },
+          required: ["content"],
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    expect(out.find((x) => x.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 
   it("rejects non-object arguments for allOf-wrapped strict object input schemas", () => {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -3,7 +3,7 @@ import type {
   LanguageModelV3StreamPart,
 } from "@ai-sdk/provider";
 import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
 import {
   pipeWithTransformer,
@@ -13,7 +13,8 @@ import {
 
 function makeTool(
   name: string,
-  properties: Record<string, { type: string }>
+  properties: Record<string, { type: string }>,
+  additionalProperties?: boolean
 ): LanguageModelV3FunctionTool {
   return {
     type: "function",
@@ -21,6 +22,7 @@ function makeTool(
     inputSchema: {
       type: "object",
       properties,
+      ...(additionalProperties === undefined ? {} : { additionalProperties }),
     },
   };
 }
@@ -110,5 +112,45 @@ describe("hermesProtocol streaming JSON repair", () => {
     const args = JSON.parse(tool.input);
     expect(args.path).toBe("/tmp/test.js");
     expect(args.content).toContain('"hello"');
+  });
+
+  it("calls onError for schema-unknown keys when additionalProperties is false", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          path: { type: "string" },
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"He said "hi" there","debug":"drop me","path":"/tmp/a"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -286,6 +286,52 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("accepts coercible keys before strict schema validation", async () => {
+    const tools = [
+      makeSchemaTool("translate", {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+          targetLanguage: { type: "string" },
+          formality: { type: "string" },
+        },
+        required: ["text", "targetLanguage", "formality"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"translate","arguments":{"text":"Ship","target_language":"fr","formality":"casual"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool).toBeTruthy();
+    if (tool?.type !== "tool-call") {
+      throw new Error("expected tool call");
+    }
+    expect(JSON.parse(tool.input)).toEqual({
+      text: "Ship",
+      targetLanguage: "fr",
+      formality: "casual",
+    });
+  });
+
   it("rejects inherited tool call fields from __proto__ wrappers", async () => {
     const onError = vi.fn();
     const tools = [makeTool("write", { content: { type: "string" } })];
@@ -301,6 +347,48 @@ describe("hermesProtocol streaming JSON repair", () => {
           id: "1",
           delta:
             '<tool_call>{"__proto__":{"name":"write","arguments":{"content":"ok"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects __proto__ keys in strict repair bookkeeping", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"__proto__":{"content":"bypass"},"content":"He said "hi" there"}}</tool_call>',
         });
         ctrl.enqueue({
           type: "finish",
@@ -359,5 +447,52 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(tool).toBeTruthy();
     const args = JSON.parse(tool.input);
     expect(args["x-debug"]).toBe("kept");
+  });
+
+  it("fails closed for unsafe patternProperties without leaking tool-input events", async () => {
+    const onError = vi.fn();
+    const slowKey = `${"a".repeat(24)}!`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`,
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const started = performance.now();
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -852,6 +852,53 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("preserves allowed keys when an unsafe false pattern contains character classes", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a|[0-9])+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","note":"safe"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool).toBeTruthy();
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      content: "ok",
+      note: "safe",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("fails closed for unsafe repeated patternProperties without groups", async () => {
     const onError = vi.fn();
     const slowKey = `${"a".repeat(24)}!`;
@@ -1166,6 +1213,53 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects unknown keys through strict allOf schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        allOf: [
+          {
+            type: "object",
+            properties: {
+              safe: { type: "string" },
+            },
+            required: ["safe"],
+            additionalProperties: false,
+          },
+        ],
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"safe":"ok","secret":"leak"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("applies every matching property and pattern schema", async () => {
     const onError = vi.fn();
     const tools = [
@@ -1278,29 +1372,39 @@ describe("hermesProtocol streaming JSON repair", () => {
       tools: [],
       options: { onError },
     });
-    const rs = new ReadableStream<LanguageModelV3StreamPart>({
-      start(ctrl) {
-        ctrl.enqueue({
-          type: "text-delta",
-          id: "1",
-          delta: '<tool_call>{"name":"edit","arguments":{"content":"ok"}}',
-        });
-        ctrl.enqueue({
-          type: "text-delta",
-          id: "1",
-          delta: ',"dangling":</tool_call>',
-        });
-        ctrl.enqueue({
-          type: "finish",
-          finishReason: stopFinishReason,
-          usage: zeroUsage,
-        });
-        ctrl.close();
-      },
-    });
-    const out = await convertReadableStreamToArray(
-      pipeWithTransformer(rs, transformer)
+    const input = new TransformStream<
+      LanguageModelV3StreamPart,
+      LanguageModelV3StreamPart
+    >();
+    const out: LanguageModelV3StreamPart[] = [];
+    const done = input.readable.pipeThrough(transformer).pipeTo(
+      new WritableStream<LanguageModelV3StreamPart>({
+        write(part) {
+          out.push(part);
+        },
+      })
     );
+    const writer = input.writable.getWriter();
+
+    await writer.write({
+      type: "text-delta",
+      id: "1",
+      delta: '<tool_call>{"name":"edit","arguments":{"content":"ok"}}',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await writer.write({
+      type: "text-delta",
+      id: "1",
+      delta: ',"dangling":</tool_call>',
+    });
+    await writer.write({
+      type: "finish",
+      finishReason: stopFinishReason,
+      usage: zeroUsage,
+    });
+    await writer.close();
+    await done;
+
     expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
     expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -851,4 +851,122 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
     expect(onError).toHaveBeenCalled();
   });
+
+  it("rejects prototype-sensitive argument keys without a schema policy", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"constructor":"pollute"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested prototype-sensitive argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"prototype":"pollute"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("does not leak tool-input events when a later chunk invalidates a complete arguments object", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"edit","arguments":{"content":"ok"}}',
+        });
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: ',"dangling":</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -243,6 +243,49 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects clean strict JSON without leaking tool-input lifecycle events", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          path: { type: "string" },
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts patternProperties keys for strict schemas", async () => {
     const tools = [
       makeSchemaTool("write", {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -933,6 +933,51 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects nested __proto__ argument keys parsed onto prototypes", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"__proto__":{"polluted":true}}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("rejects missing required argument keys", async () => {
     const onError = vi.fn();
     const tools = [
@@ -1055,6 +1100,61 @@ describe("hermesProtocol streaming JSON repair", () => {
           id: "1",
           delta:
             '<tool_call>{"name":"write","arguments":{"payload":{"value":"ok","secret":"blocked"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("applies every matching property and pattern schema", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+        patternProperties: {
+          "^payload$": {
+            type: "object",
+            properties: {
+              must: { type: "string" },
+            },
+            required: ["must"],
+            additionalProperties: false,
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"other":"bad"}}}</tool_call>',
         });
         ctrl.enqueue({
           type: "finish",

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -1920,7 +1920,7 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
-  it("does not promote a speculative tool-call when a later chunk invalidates a complete arguments object", async () => {
+  it("uses matching ids when a later chunk invalidates a speculative tool-call", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({
@@ -1961,7 +1961,13 @@ describe("hermesProtocol streaming JSON repair", () => {
     await done;
 
     const tool = out.find((c) => c.type === "tool-call");
-    expect(tool).toBeUndefined();
+    expect(tool).toBeTruthy();
+    if (tool?.type !== "tool-call") {
+      throw new Error("Expected speculative tool call");
+    }
+    expect(JSON.parse(tool.input)).toEqual({
+      content: "ok",
+    });
     expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
     expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
@@ -1971,6 +1977,7 @@ describe("hermesProtocol streaming JSON repair", () => {
     if (!hasStringToolCallId(metadata)) {
       throw new Error("Expected onError metadata with a toolCallId");
     }
+    expect(metadata.toolCallId).toBe(tool.toolCallId);
   });
 
   it("rejects keys that may match unsafe false patterns with escaped range endpoints", async () => {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -34,6 +34,15 @@ function makeSchemaTool(
   return { type: "function", name, inputSchema };
 }
 
+function hasStringToolCallId(value: unknown): value is { toolCallId: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "toolCallId" in value &&
+    typeof value.toolCallId === "string"
+  );
+}
+
 describe("hermesProtocol streaming JSON repair", () => {
   it("repairs streaming tool call with unescaped quotes and emits tool-call", async () => {
     const protocol = hermesProtocol();
@@ -1658,12 +1667,21 @@ describe("hermesProtocol streaming JSON repair", () => {
 
     const tool = out.find((c) => c.type === "tool-call");
     expect(tool).toBeTruthy();
-    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+    if (tool?.type !== "tool-call") {
+      throw new Error("Expected speculative tool call");
+    }
+    expect(JSON.parse(tool.input)).toEqual({
       content: "ok",
     });
     expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
     expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
     expect(onError).toHaveBeenCalled();
+    const metadata = onError.mock.calls[0]?.[1];
+    expect(hasStringToolCallId(metadata)).toBe(true);
+    if (!hasStringToolCallId(metadata)) {
+      throw new Error("Expected onError metadata with a toolCallId");
+    }
+    expect(metadata.toolCallId).toBe(tool.toolCallId);
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -1631,6 +1631,67 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("accepts null for nullable object and array properties", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [
+        makeSchemaTool("write", {
+          type: "object",
+          properties: {
+            payload: {
+              type: ["object", "null"],
+              properties: { content: { type: "string" } },
+              required: ["content"],
+              additionalProperties: false,
+            },
+            rows: {
+              type: ["array", "null"],
+              items: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: ["payload", "rows"],
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"payload":null,"rows":null}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: null,
+      rows: null,
+    });
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("rejects non-object arguments for allOf-wrapped strict object input schemas", async () => {
     const argumentBodies = ["[]", '"scalar"'];
     for (const argumentBody of argumentBodies) {
@@ -2048,6 +2109,115 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("does not count numeric strings as numeric oneOf matches", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "integer" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"value":"123"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: { value: "123" },
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects decimal strings for integer oneOf branches", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "integer" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"value":"1.5"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts oneOf object branches distinguished by nested enum values", async () => {
     const tools = [
       makeSchemaTool("edit", {
@@ -2108,6 +2278,137 @@ describe("hermesProtocol streaming JSON repair", () => {
       expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
       expect(onError).not.toHaveBeenCalled();
     }
+  });
+
+  it("accepts oneOf object branches distinguished by nested const values", async () => {
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "text" },
+                  value: { type: "string" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "count" },
+                  value: { type: "integer" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    for (const [kind, value] of [
+      ["text", '"hello"'],
+      ["count", "3"],
+    ]) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools,
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: `<tool_call>{"name":"edit","arguments":{"payload":{"kind":"${kind}","value":${value}}}}</tool_call>`,
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      const tool = out.find((c) => c.type === "tool-call");
+      expect(tool?.type).toBe("tool-call");
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
+      expect(onError).not.toHaveBeenCalled();
+    }
+  });
+
+  it("rejects oneOf object branches with mismatched const values", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "text" },
+                  value: { type: "string" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: {
+                  kind: { const: "count" },
+                  value: { type: "integer" },
+                },
+                required: ["kind", "value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"kind":"count","value":"hello"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
   });
 
   it("does not let primitive oneOf branches bypass object key constraints", async () => {
@@ -2267,6 +2568,47 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("rejects unsafe positive patternProperties that may match constrained keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        patternProperties: {
+          "^(a+)+$": { type: "string", enum: ["allowed"] },
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"write","arguments":{"aaaa":123}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("rejects unsafe false patternProperties that may match key substrings", async () => {
     const onError = vi.fn();
     const tools = [
@@ -2312,7 +2654,52 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
-  it("uses matching ids when a later chunk invalidates a speculative tool-call", async () => {
+  it("rejects unsafe false patternProperties that may match unanchored suffixes", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "(a+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","ba":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("does not emit stale speculative tool-calls after later invalid chunks", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({
@@ -2352,15 +2739,9 @@ describe("hermesProtocol streaming JSON repair", () => {
     await writer.close();
     await done;
 
-    const tool = out.find((c) => c.type === "tool-call");
-    expect(tool).toBeTruthy();
-    if (tool?.type !== "tool-call") {
-      throw new Error("Expected speculative tool call");
-    }
-    expect(JSON.parse(tool.input)).toEqual({
-      content: "ok",
-    });
-    expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
+    const start = out.find((c) => c.type === "tool-input-start");
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(start).toBeTruthy();
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
     expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
     expect(onError).toHaveBeenCalled();
@@ -2369,7 +2750,9 @@ describe("hermesProtocol streaming JSON repair", () => {
     if (!hasStringToolCallId(metadata)) {
       throw new Error("Expected onError metadata with a toolCallId");
     }
-    expect(metadata.toolCallId).toBe(tool.toolCallId);
+    expect(metadata.toolCallId).toBe(
+      start?.type === "tool-input-start" ? start.id : undefined
+    );
   });
 
   it("rejects keys that may match unsafe false patterns with escaped range endpoints", async () => {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -852,6 +852,96 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("fails closed for unsafe false patternProperties with escaped literals", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(\\x61+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","aaaa":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties with unknown matchers", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^([^\\n]+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","secret":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("preserves allowed keys when an unsafe false pattern contains character classes", async () => {
     const onError = vi.fn();
     const tools = [
@@ -1260,6 +1350,61 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects nested array item keys through allOf schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            allOf: [
+              {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    value: { type: "string" },
+                  },
+                  additionalProperties: false,
+                },
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"payload":[{"value":"ok","secret":"leak"}]}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("applies every matching property and pattern schema", async () => {
     const onError = vi.fn();
     const tools = [
@@ -1405,10 +1550,14 @@ describe("hermesProtocol streaming JSON repair", () => {
     await writer.close();
     await done;
 
-    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
-    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
-    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
-    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool).toBeTruthy();
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      content: "ok",
+    });
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
     expect(onError).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -328,6 +328,48 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects unquoted strict RJSON with prototype-sensitive argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{name:"write",arguments:{__proto__:{polluted:true},content:"ok"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts coercible keys before strict schema validation", async () => {
     const tools = [
       makeSchemaTool("translate", {
@@ -450,7 +492,7 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
-  it("accepts patternProperties keys for strict schemas", async () => {
+  it("accepts common grouped and quantified patternProperties for strict schemas", async () => {
     const tools = [
       makeSchemaTool("write", {
         type: "object",
@@ -459,7 +501,8 @@ describe("hermesProtocol streaming JSON repair", () => {
           content: { type: "string" },
         },
         patternProperties: {
-          "^x-": { type: "string" },
+          "^(x|y)-": { type: "string" },
+          "^z-[0-9]+$": { type: "string" },
         },
         additionalProperties: false,
       }),
@@ -472,7 +515,7 @@ describe("hermesProtocol streaming JSON repair", () => {
           type: "text-delta",
           id: "1",
           delta:
-            '<tool_call>{"name":"write","arguments":{"content":"ok","x-debug":"kept","path":"/tmp/a"}}}</tool_call>',
+            '<tool_call>{"name":"write","arguments":{"content":"ok","x-debug":"kept","y-trace":"yes","z-123":"num","path":"/tmp/a"}}}</tool_call>',
         });
         ctrl.enqueue({
           type: "finish",
@@ -485,10 +528,15 @@ describe("hermesProtocol streaming JSON repair", () => {
     const out = await convertReadableStreamToArray(
       pipeWithTransformer(rs, transformer)
     );
-    const tool = out.find((c) => c.type === "tool-call") as any;
+    const tool = out.find((c) => c.type === "tool-call");
     expect(tool).toBeTruthy();
+    if (tool?.type !== "tool-call") {
+      throw new Error("expected tool call");
+    }
     const args = JSON.parse(tool.input);
     expect(args["x-debug"]).toBe("kept");
+    expect(args["y-trace"]).toBe("yes");
+    expect(args["z-123"]).toBe("num");
   });
 
   it("rejects patternProperties false matches for strict schemas", async () => {
@@ -517,6 +565,49 @@ describe("hermesProtocol streaming JSON repair", () => {
           id: "1",
           delta:
             '<tool_call>{"name":"write","arguments":{"content":"ok","x-secret":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects false property schemas for strict schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+          secret: false,
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","secret":"blocked"}}</tool_call>',
         });
         ctrl.enqueue({
           type: "finish",

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -933,6 +933,147 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects missing required argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"write","arguments":{}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested schema-unknown argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            additionalProperties: false,
+          },
+        },
+        required: ["payload"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"payload":{"value":"ok","secret":"blocked"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested argument keys disallowed by false schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            type: "object",
+            properties: {
+              secret: false,
+              value: { type: "string" },
+            },
+            additionalProperties: true,
+          },
+        },
+        required: ["payload"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"payload":{"value":"ok","secret":"blocked"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("does not leak tool-input events when a later chunk invalidates a complete arguments object", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -286,6 +286,48 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects clean strict JSON with prototype-sensitive argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","__proto__":{"polluted":true}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts coercible keys before strict schema validation", async () => {
     const tools = [
       makeSchemaTool("translate", {
@@ -449,6 +491,51 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(args["x-debug"]).toBe("kept");
   });
 
+  it("rejects patternProperties false matches for strict schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^x-": false,
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","x-secret":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("fails closed for unsafe patternProperties without leaking tool-input events", async () => {
     const onError = vi.fn();
     const slowKey = `${"a".repeat(24)}!`;
@@ -460,6 +547,53 @@ describe("hermesProtocol streaming JSON repair", () => {
         },
         patternProperties: {
           "^(a+)+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`,
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const started = performance.now();
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe repeated patternProperties without groups", async () => {
+    const onError = vi.fn();
+    const slowKey = `${"a".repeat(24)}!`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^a+a+$": { type: "string" },
         },
         additionalProperties: false,
       }),

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -805,6 +805,53 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("fails closed for unsafe false patternProperties with character classes", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a|[0-9])+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","123":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const started = performance.now();
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("fails closed for unsafe repeated patternProperties without groups", async () => {
     const onError = vi.fn();
     const slowKey = `${"a".repeat(24)}!`;

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -1705,6 +1705,64 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("accepts oneOf object branches distinguished by nested primitive value types", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "number" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"value":"abc"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: { value: "abc" },
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("does not let primitive oneOf branches bypass object key constraints", async () => {
     const onError = vi.fn();
     const tools = [

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -732,6 +732,48 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(args["z-123"]).toBe("num");
   });
 
+  it("accepts non-capturing patternProperties groups for strict schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        patternProperties: {
+          "^(?:x-)+$": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: '<tool_call>{"name":"write","arguments":{"x-":"ok"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      "x-": "ok",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("rejects patternProperties false matches for strict schemas", async () => {
     const onError = vi.fn();
     const tools = [
@@ -1535,6 +1577,97 @@ describe("hermesProtocol streaming JSON repair", () => {
       expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
       expect(onError).toHaveBeenCalled();
     }
+  });
+
+  it("rejects non-object arguments for allOf-wrapped strict object input schemas", async () => {
+    const argumentBodies = ["[]", '"scalar"'];
+    for (const argumentBody of argumentBodies) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools: [
+          makeSchemaTool("write", {
+            allOf: [
+              {
+                type: "object",
+                properties: {
+                  content: { type: "string" },
+                },
+                required: ["content"],
+                additionalProperties: false,
+              },
+            ],
+          }),
+        ],
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`,
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
+  it("rejects strict primitive property values that cannot be coerced", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("count", {
+        type: "object",
+        properties: {
+          count: { type: "integer" },
+        },
+        required: ["count"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"count","arguments":{"count":"abc"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
   });
 
   it("rejects unknown keys through strict allOf schemas", async () => {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -1493,6 +1493,50 @@ describe("hermesProtocol streaming JSON repair", () => {
     }
   });
 
+  it("rejects non-object arguments for object input schemas", async () => {
+    const argumentBodies = ["[]", "null", '"x"'];
+    for (const argumentBody of argumentBodies) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools: [
+          makeSchemaTool("write", {
+            type: "object",
+            properties: {
+              content: { type: "string" },
+            },
+            required: ["content"],
+            additionalProperties: false,
+          }),
+        ],
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`,
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+      expect(onError).toHaveBeenCalled();
+    }
+  });
+
   it("rejects unknown keys through strict allOf schemas", async () => {
     const onError = vi.fn();
     const tools = [
@@ -1576,6 +1620,62 @@ describe("hermesProtocol streaming JSON repair", () => {
           id: "1",
           delta:
             '<tool_call>{"name":"write","arguments":{"payload":[{"value":"ok","secret":"leak"}]}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects nested tuple item keys through draft-07 items arrays", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          rows: {
+            type: "array",
+            items: [
+              {
+                type: "object",
+                properties: {
+                  value: { type: "string" },
+                },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+            additionalItems: false,
+          },
+        },
+        required: ["rows"],
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"rows":[{"value":"ok","secret":"leak"}]}}</tool_call>',
         });
         ctrl.enqueue({
           type: "finish",
@@ -1763,6 +1863,68 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("accepts oneOf object branches distinguished by nested enum values", async () => {
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { value: { type: "string", enum: ["a"] } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { value: { type: "string", enum: ["b"] } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    for (const value of ["a", "b"]) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools,
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: `<tool_call>{"name":"edit","arguments":{"payload":{"value":"${value}"}}}</tool_call>`,
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      const tool = out.find((c) => c.type === "tool-call");
+      expect(tool?.type).toBe("tool-call");
+      expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+        payload: { value },
+      });
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
+      expect(onError).not.toHaveBeenCalled();
+    }
+  });
+
   it("does not let primitive oneOf branches bypass object key constraints", async () => {
     const onError = vi.fn();
     const tools = [
@@ -1918,6 +2080,51 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
     expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsafe false patternProperties that may match key substrings", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "(secret+)+": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","x-secret":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
   });
 
   it("uses matching ids when a later chunk invalidates a speculative tool-call", async () => {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -27,6 +27,13 @@ function makeTool(
   };
 }
 
+function makeSchemaTool(
+  name: string,
+  inputSchema: LanguageModelV3FunctionTool["inputSchema"]
+): LanguageModelV3FunctionTool {
+  return { type: "function", name, inputSchema };
+}
+
 describe("hermesProtocol streaming JSON repair", () => {
   it("repairs streaming tool call with unescaped quotes and emits tool-call", async () => {
     const protocol = hermesProtocol();
@@ -192,5 +199,88 @@ describe("hermesProtocol streaming JSON repair", () => {
     );
     expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects schema-unknown keys for jsonSchema-wrapped strict schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        jsonSchema: {
+          type: "object",
+          properties: {
+            path: { type: "string" },
+            content: { type: "string" },
+          },
+          additionalProperties: false,
+        },
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("accepts patternProperties keys for strict schemas", async () => {
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^x-": { type: "string" },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({ tools });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","x-debug":"kept","path":"/tmp/a"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call") as any;
+    expect(tool).toBeTruthy();
+    const args = JSON.parse(tool.input);
+    expect(args["x-debug"]).toBe("kept");
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -446,6 +446,39 @@ describe("hermesProtocol streaming JSON repair", () => {
     }
   });
 
+  it("rejects prototype-sensitive RJSON keys after leading comments", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [makeTool("write", { content: { type: "string" } }, true)],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>/*{}*/{name:"write",arguments:{__proto__:{polluted:true},content:"ok"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("rejects prototype-sensitive argument keys even when unknown keys are allowed", async () => {
     const onError = vi.fn();
     const tools = [
@@ -1501,6 +1534,63 @@ describe("hermesProtocol streaming JSON repair", () => {
           id: "1",
           delta:
             '<tool_call>{"name":"write","arguments":{"payload":[{"value":"ok","secret":"leak"}]}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects values that match multiple oneOf schemas", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: false,
+              },
+              {
+                type: "object",
+                properties: { a: { type: "string" } },
+                required: ["a"],
+                additionalProperties: false,
+              },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"payload":{"a":"ok"}}}</tool_call>',
         });
         ctrl.enqueue({
           type: "finish",

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -370,6 +370,90 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects prototype-sensitive argument keys even when unknown keys are allowed", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        true
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","constructor":{"polluted":true}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects escaped single-quoted strict RJSON prototype-sensitive argument keys", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            "<tool_call>{name:\"write\",arguments:{'\\u005f\\u005fproto__':{polluted:true},content:\"ok\"}}</tool_call>",
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts coercible keys before strict schema validation", async () => {
     const tools = [
       makeSchemaTool("translate", {
@@ -640,6 +724,53 @@ describe("hermesProtocol streaming JSON repair", () => {
           "^(a+)+$": { type: "string" },
         },
         additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: `<tool_call>{"name":"write","arguments":{"content":"ok","${slowKey}":"blocked"}}</tool_call>`,
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const started = performance.now();
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(performance.now() - started).toBeLessThan(150);
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("fails closed for unsafe false patternProperties when unknown keys are allowed", async () => {
+    const onError = vi.fn();
+    const slowKey = `${"a".repeat(24)}!`;
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": false,
+        },
+        additionalProperties: true,
       }),
     ];
     const protocol = hermesProtocol();

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -1537,46 +1537,98 @@ describe("hermesProtocol streaming JSON repair", () => {
 
   it("rejects non-object arguments for object input schemas", async () => {
     const argumentBodies = ["[]", "null", '"x"'];
-    for (const argumentBody of argumentBodies) {
-      const onError = vi.fn();
-      const protocol = hermesProtocol();
-      const transformer = protocol.createStreamParser({
-        tools: [
-          makeSchemaTool("write", {
-            type: "object",
-            properties: {
-              content: { type: "string" },
-            },
-            required: ["content"],
-            additionalProperties: false,
-          }),
-        ],
-        options: { onError },
-      });
-      const rs = new ReadableStream<LanguageModelV3StreamPart>({
-        start(ctrl) {
-          ctrl.enqueue({
-            type: "text-delta",
-            id: "1",
-            delta: `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`,
-          });
-          ctrl.enqueue({
-            type: "finish",
-            finishReason: stopFinishReason,
-            usage: zeroUsage,
-          });
-          ctrl.close();
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      {
+        type: "object",
+        properties: {
+          content: { type: "string" },
         },
-      });
-      const out = await convertReadableStreamToArray(
-        pipeWithTransformer(rs, transformer)
-      );
-      expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
-      expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
-      expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
-      expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
-      expect(onError).toHaveBeenCalled();
+        required: ["content"],
+      },
+      {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        required: ["content"],
+        additionalProperties: false,
+      },
+    ];
+    for (const inputSchema of schemas) {
+      for (const argumentBody of argumentBodies) {
+        const onError = vi.fn();
+        const protocol = hermesProtocol();
+        const transformer = protocol.createStreamParser({
+          tools: [makeSchemaTool("write", inputSchema)],
+          options: { onError },
+        });
+        const rs = new ReadableStream<LanguageModelV3StreamPart>({
+          start(ctrl) {
+            ctrl.enqueue({
+              type: "text-delta",
+              id: "1",
+              delta: `<tool_call>{"name":"write","arguments":${argumentBody}}</tool_call>`,
+            });
+            ctrl.enqueue({
+              type: "finish",
+              finishReason: stopFinishReason,
+              usage: zeroUsage,
+            });
+            ctrl.close();
+          },
+        });
+        const out = await convertReadableStreamToArray(
+          pipeWithTransformer(rs, transformer)
+        );
+        expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+        expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+        expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+        expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+        expect(onError).toHaveBeenCalled();
+      }
     }
+  });
+
+  it("rejects null for non-nullable typed object properties", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [
+        makeSchemaTool("write", {
+          type: "object",
+          properties: {
+            content: { type: "string" },
+          },
+          required: ["content"],
+          additionalProperties: false,
+        }),
+      ],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":null}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
   });
 
   it("rejects non-object arguments for allOf-wrapped strict object input schemas", async () => {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -1740,6 +1740,53 @@ describe("hermesProtocol streaming JSON repair", () => {
     }
   });
 
+  it("coerces keys before validating allOf-wrapped strict object schemas", async () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [
+        makeSchemaTool("translate", {
+          allOf: [
+            {
+              type: "object",
+              properties: {
+                targetLanguage: { type: "string" },
+              },
+              required: ["targetLanguage"],
+              additionalProperties: false,
+            },
+          ],
+        }),
+      ],
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"translate","arguments":{"target_language":"ko"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      targetLanguage: "ko",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("rejects strict primitive property values that cannot be coerced", async () => {
     const onError = vi.fn();
     const tools = [
@@ -2165,6 +2212,53 @@ describe("hermesProtocol streaming JSON repair", () => {
       payload: { value: "123" },
     });
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-finite numeric strings for number and integer schemas", async () => {
+    const cases = [
+      { schemaType: "number", value: "1e999" },
+      { schemaType: "integer", value: "9".repeat(400) },
+    ];
+    for (const { schemaType, value } of cases) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools: [
+          makeSchemaTool("edit", {
+            type: "object",
+            properties: {
+              value: { type: schemaType },
+            },
+            required: ["value"],
+            additionalProperties: false,
+          }),
+        ],
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: `<tool_call>{"name":"edit","arguments":{"value":${JSON.stringify(value)}}}</tool_call>`,
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+      expect(onError).toHaveBeenCalled();
+    }
   });
 
   it("rejects decimal strings for integer oneOf branches", async () => {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -1451,6 +1451,48 @@ describe("hermesProtocol streaming JSON repair", () => {
     }
   });
 
+  it("rejects non-object arguments for top-level boolean false input schemas", async () => {
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      false,
+      { jsonSchema: false },
+    ];
+    const argumentBodies = ["[]", "null", '"x"'];
+
+    for (const inputSchema of schemas) {
+      for (const argumentBody of argumentBodies) {
+        const onError = vi.fn();
+        const protocol = hermesProtocol();
+        const transformer = protocol.createStreamParser({
+          tools: [makeSchemaTool("deny", inputSchema)],
+          options: { onError },
+        });
+        const rs = new ReadableStream<LanguageModelV3StreamPart>({
+          start(ctrl) {
+            ctrl.enqueue({
+              type: "text-delta",
+              id: "1",
+              delta: `<tool_call>{"name":"deny","arguments":${argumentBody}}</tool_call>`,
+            });
+            ctrl.enqueue({
+              type: "finish",
+              finishReason: stopFinishReason,
+              usage: zeroUsage,
+            });
+            ctrl.close();
+          },
+        });
+        const out = await convertReadableStreamToArray(
+          pipeWithTransformer(rs, transformer)
+        );
+        expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+        expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+        expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+        expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+        expect(onError).toHaveBeenCalled();
+      }
+    }
+  });
+
   it("rejects unknown keys through strict allOf schemas", async () => {
     const onError = vi.fn();
     const tools = [
@@ -1610,6 +1652,111 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("accepts values that match a primitive oneOf branch", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { content: { type: "string" } },
+                required: ["content"],
+                additionalProperties: false,
+              },
+              { type: "string" },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":"abc"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      payload: "abc",
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("does not let primitive oneOf branches bypass object key constraints", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("edit", {
+        type: "object",
+        properties: {
+          payload: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { content: { type: "string" } },
+                required: ["content"],
+                additionalProperties: false,
+              },
+              { type: "string" },
+            ],
+          },
+        },
+        additionalProperties: false,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"payload":{"content":"ok","extra":"bad"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("applies every matching property and pattern schema", async () => {
     const onError = vi.fn();
     const tools = [
@@ -1715,7 +1862,7 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
-  it("does not leak tool-input events when a later chunk invalidates a complete arguments object", async () => {
+  it("does not promote a speculative tool-call when a later chunk invalidates a complete arguments object", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();
     const transformer = protocol.createStreamParser({
@@ -1756,13 +1903,7 @@ describe("hermesProtocol streaming JSON repair", () => {
     await done;
 
     const tool = out.find((c) => c.type === "tool-call");
-    expect(tool).toBeTruthy();
-    if (tool?.type !== "tool-call") {
-      throw new Error("Expected speculative tool call");
-    }
-    expect(JSON.parse(tool.input)).toEqual({
-      content: "ok",
-    });
+    expect(tool).toBeUndefined();
     expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
     expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
@@ -1772,6 +1913,50 @@ describe("hermesProtocol streaming JSON repair", () => {
     if (!hasStringToolCallId(metadata)) {
       throw new Error("Expected onError metadata with a toolCallId");
     }
-    expect(metadata.toolCallId).toBe(tool.toolCallId);
+  });
+
+  it("rejects keys that may match unsafe false patterns with escaped range endpoints", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          [String.raw`^([a-\x7a]+)+$`]: false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","m":"blocked"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -286,6 +286,40 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("rejects inherited tool call fields from __proto__ wrappers", async () => {
+    const onError = vi.fn();
+    const tools = [makeTool("write", { content: { type: "string" } })];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"__proto__":{"name":"write","arguments":{"content":"ok"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+
   it("accepts patternProperties keys for strict schemas", async () => {
     const tools = [
       makeSchemaTool("write", {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -153,4 +153,44 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
     expect(onError).toHaveBeenCalled();
   });
+
+  it("rejects schema-unknown keys in strict repair even when arguments parse cleanly", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeTool(
+        "write",
+        {
+          path: { type: "string" },
+          content: { type: "string" },
+        },
+        false
+      ),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","debug":"drop me","path":"/tmp/a"}}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+    expect(onError).toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -70,6 +70,38 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(textDeltas).not.toContain("<tool_call>");
   });
 
+  it("repairs streaming unescaped quotes before a right brace character", async () => {
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools: [makeTool("edit", { content: { type: "string" } }, false)],
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"edit","arguments":{"content":"He said "}" there"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool?.type).toBe("tool-call");
+    if (tool?.type !== "tool-call") {
+      throw new Error("Expected repaired tool call");
+    }
+    expect(JSON.parse(tool.input)).toEqual({ content: 'He said "}" there' });
+  });
+
   it("repairs with known tool schema (tools parameter provided)", async () => {
     const tools = [
       makeTool("write", {
@@ -368,6 +400,41 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
     expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
     expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects unquoted prototype-sensitive RJSON keys after comments", async () => {
+    const tools = [makeTool("write", { content: { type: "string" } }, false)];
+    for (const prefix of ["/* comment */", "// comment\n"]) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools,
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta: `<tool_call>{name:"write",arguments:{${prefix}__proto__:{polluted:true},content:"ok"}}</tool_call>`,
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+      expect(onError).toHaveBeenCalled();
+    }
   });
 
   it("rejects prototype-sensitive argument keys even when unknown keys are allowed", async () => {
@@ -1301,6 +1368,45 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
     expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
     expect(onError).toHaveBeenCalled();
+  });
+
+  it("rejects top-level boolean false input schemas", async () => {
+    const schemas: LanguageModelV3FunctionTool["inputSchema"][] = [
+      false,
+      { jsonSchema: false },
+    ];
+    for (const inputSchema of schemas) {
+      const onError = vi.fn();
+      const protocol = hermesProtocol();
+      const transformer = protocol.createStreamParser({
+        tools: [makeSchemaTool("deny", inputSchema)],
+        options: { onError },
+      });
+      const rs = new ReadableStream<LanguageModelV3StreamPart>({
+        start(ctrl) {
+          ctrl.enqueue({
+            type: "text-delta",
+            id: "1",
+            delta:
+              '<tool_call>{"name":"deny","arguments":{"content":"ok"}}</tool_call>',
+          });
+          ctrl.enqueue({
+            type: "finish",
+            finishReason: stopFinishReason,
+            usage: zeroUsage,
+          });
+          ctrl.close();
+        },
+      });
+      const out = await convertReadableStreamToArray(
+        pipeWithTransformer(rs, transformer)
+      );
+      expect(out.find((c) => c.type === "tool-call")).toBeUndefined();
+      expect(out.some((c) => c.type === "tool-input-start")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-delta")).toBe(false);
+      expect(out.some((c) => c.type === "tool-input-end")).toBe(false);
+      expect(onError).toHaveBeenCalled();
+    }
   });
 
   it("rejects unknown keys through strict allOf schemas", async () => {

--- a/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts
@@ -1074,6 +1074,56 @@ describe("hermesProtocol streaming JSON repair", () => {
     expect(onError).toHaveBeenCalled();
   });
 
+  it("preserves allowed extra argument keys when a denied pattern is unsafe", async () => {
+    const onError = vi.fn();
+    const tools = [
+      makeSchemaTool("write", {
+        type: "object",
+        properties: {
+          content: { type: "string" },
+        },
+        patternProperties: {
+          "^(a+)+$": false,
+        },
+        additionalProperties: true,
+      }),
+    ];
+    const protocol = hermesProtocol();
+    const transformer = protocol.createStreamParser({
+      tools,
+      options: { onError },
+    });
+    const rs = new ReadableStream<LanguageModelV3StreamPart>({
+      start(ctrl) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta:
+            '<tool_call>{"name":"write","arguments":{"content":"ok","note":"safe"}}</tool_call>',
+        });
+        ctrl.enqueue({
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        });
+        ctrl.close();
+      },
+    });
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(rs, transformer)
+    );
+    const tool = out.find((c) => c.type === "tool-call");
+    expect(tool).toBeTruthy();
+    expect(tool?.type === "tool-call" ? JSON.parse(tool.input) : null).toEqual({
+      content: "ok",
+      note: "safe",
+    });
+    expect(out.some((c) => c.type === "tool-input-start")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-delta")).toBe(true);
+    expect(out.some((c) => c.type === "tool-input-end")).toBe(true);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("does not leak tool-input events when a later chunk invalidates a complete arguments object", async () => {
     const onError = vi.fn();
     const protocol = hermesProtocol();

--- a/src/__tests__/schema-coerce/pattern-property-regex.unit.test.ts
+++ b/src/__tests__/schema-coerce/pattern-property-regex.unit.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { compileSafePatternPropertyRegex } from "../../schema-coerce";
+
+describe("compileSafePatternPropertyRegex", () => {
+  it("accepts non-capturing group prefixes as safe syntax", () => {
+    const regex = compileSafePatternPropertyRegex("^(?:x-)+$");
+    expect(regex).toBeInstanceOf(RegExp);
+    expect(regex?.test("x-")).toBe(true);
+  });
+});

--- a/src/__tests__/stream-handler/coercion.test.ts
+++ b/src/__tests__/stream-handler/coercion.test.ts
@@ -867,8 +867,8 @@ describe("wrapStream tool-call coercion", () => {
           type: "object",
           properties: {
             finite_int: { type: "integer" },
-            overflow_num: { type: "number" },
-            huge_int: { type: "integer" },
+            overflow_num: { type: ["number", "string"] },
+            huge_int: { type: ["integer", "string"] },
           },
           required: ["finite_int", "overflow_num", "huge_int"],
         },

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -5,6 +5,8 @@ import {
 } from "../../schema-coerce";
 import { unsafeDeniedPatternMayMatchKey } from "./hermes-unsafe-pattern";
 
+const NUMERIC_STRING_RE = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
+
 interface PatternSchemaMatches {
   schemas: unknown[];
   unsafeDeniedPatterns: string[];
@@ -74,11 +76,17 @@ function valueMatchesSchemaType(value: unknown, schemaType: string): boolean {
     case "boolean":
       return typeof value === "boolean";
     case "integer":
-      return typeof value === "number" && Number.isInteger(value);
+      return (
+        (typeof value === "number" && Number.isInteger(value)) ||
+        (typeof value === "string" && NUMERIC_STRING_RE.test(value))
+      );
     case "null":
       return value === null;
     case "number":
-      return typeof value === "number";
+      return (
+        typeof value === "number" ||
+        (typeof value === "string" && NUMERIC_STRING_RE.test(value))
+      );
     case "object":
       return isRecord(value);
     case "string":
@@ -125,6 +133,9 @@ function valueMatchesSchemaKind(
     !schema.enum.some((allowed) => jsonValuesEqual(value, allowed))
   ) {
     return false;
+  }
+  if (value === null) {
+    return true;
   }
   const schemaTypes = explicitSchemaTypes(schema);
   if (schemaTypes.length > 0) {

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -188,13 +188,13 @@ function schemaCombinatorsMatch(
   }
 
   const oneOf = Array.isArray(schema.oneOf) ? schema.oneOf : undefined;
-  if (
-    oneOf &&
-    !oneOf.some((subSchema) =>
+  if (oneOf) {
+    const matchCount = oneOf.filter((subSchema) =>
       argumentValueMatchesSchemaKeyShape(value, subSchema, branchSeen())
-    )
-  ) {
-    return false;
+    ).length;
+    if (matchCount !== 1) {
+      return false;
+    }
   }
 
   return true;

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -125,7 +125,8 @@ function requiredKeys(schema: Record<string, unknown>): string[] {
 function objectMatchesSchemaKeyShape(
   value: Record<string, unknown>,
   schema: Record<string, unknown>,
-  seen: Set<object>
+  seen: Set<object>,
+  enforceValueKinds: boolean
 ): boolean {
   if (requiredKeys(schema).some((key) => !Object.hasOwn(value, key))) {
     return false;
@@ -163,7 +164,8 @@ function objectMatchesSchemaKeyShape(
           argumentValueMatchesSchemaKeyShape(
             nestedValue,
             nestedSchema,
-            new Set(seen)
+            new Set(seen),
+            enforceValueKinds
           )
         )
       ) {
@@ -181,7 +183,8 @@ function objectMatchesSchemaKeyShape(
       !argumentValueMatchesSchemaKeyShape(
         nestedValue,
         additionalSchema,
-        new Set(seen)
+        new Set(seen),
+        enforceValueKinds
       )
     ) {
       return false;
@@ -194,7 +197,8 @@ function objectMatchesSchemaKeyShape(
 function arrayMatchesSchemaKeyShape(
   value: unknown[],
   schema: Record<string, unknown>,
-  seen: Set<object>
+  seen: Set<object>,
+  enforceValueKinds: boolean
 ): boolean {
   const prefixItems = Array.isArray(schema.prefixItems)
     ? schema.prefixItems
@@ -202,11 +206,21 @@ function arrayMatchesSchemaKeyShape(
   if (prefixItems) {
     return value.every((item, index) => {
       const itemSchema = prefixItems[index] ?? schema.items;
-      return argumentValueMatchesSchemaKeyShape(item, itemSchema, seen);
+      return argumentValueMatchesSchemaKeyShape(
+        item,
+        itemSchema,
+        seen,
+        enforceValueKinds
+      );
     });
   }
   return value.every((item) =>
-    argumentValueMatchesSchemaKeyShape(item, schema.items, seen)
+    argumentValueMatchesSchemaKeyShape(
+      item,
+      schema.items,
+      seen,
+      enforceValueKinds
+    )
   );
 }
 
@@ -227,7 +241,12 @@ function schemaCombinatorsMatch(
     if (isRecord(unwrapped) && !valueMatchesSchemaKind(value, unwrapped)) {
       return false;
     }
-    return argumentValueMatchesSchemaKeyShape(value, subSchema, branchSeen());
+    return argumentValueMatchesSchemaKeyShape(
+      value,
+      subSchema,
+      branchSeen(),
+      true
+    );
   };
   const allOf = Array.isArray(schema.allOf) ? schema.allOf : undefined;
   if (allOf && !allOf.every((subSchema) => branchMatches(subSchema))) {
@@ -255,7 +274,8 @@ function schemaCombinatorsMatch(
 export function argumentValueMatchesSchemaKeyShape(
   value: unknown,
   schema: unknown,
-  seen = new Set<object>()
+  seen = new Set<object>(),
+  enforceValueKinds = false
 ): boolean {
   const unwrapped = unwrapJsonSchema(schema);
   if (unwrapped === false) {
@@ -263,6 +283,9 @@ export function argumentValueMatchesSchemaKeyShape(
   }
   if (!isRecord(unwrapped)) {
     return true;
+  }
+  if (enforceValueKinds && !valueMatchesSchemaKind(value, unwrapped)) {
+    return false;
   }
   if (isRecord(value) || Array.isArray(value)) {
     if (seen.has(value)) {
@@ -274,10 +297,15 @@ export function argumentValueMatchesSchemaKeyShape(
     return false;
   }
   if (Array.isArray(value)) {
-    return arrayMatchesSchemaKeyShape(value, unwrapped, seen);
+    return arrayMatchesSchemaKeyShape(value, unwrapped, seen, enforceValueKinds);
   }
   if (isRecord(value) && isObjectSchema(unwrapped)) {
-    return objectMatchesSchemaKeyShape(value, unwrapped, seen);
+    return objectMatchesSchemaKeyShape(
+      value,
+      unwrapped,
+      seen,
+      enforceValueKinds
+    );
   }
   return true;
 }

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -218,11 +218,11 @@ export function argumentValueMatchesSchemaKeyShape(
     }
     seen.add(value);
   }
-  if (Array.isArray(value)) {
-    return arrayMatchesSchemaKeyShape(value, unwrapped, seen);
-  }
   if (!schemaCombinatorsMatch(value, unwrapped, seen)) {
     return false;
+  }
+  if (Array.isArray(value)) {
+    return arrayMatchesSchemaKeyShape(value, unwrapped, seen);
   }
   if (isRecord(value) && isObjectSchema(unwrapped)) {
     return objectMatchesSchemaKeyShape(value, unwrapped, seen);

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -5,9 +5,6 @@ import {
 } from "../../schema-coerce";
 import { unsafeDeniedPatternMayMatchKey } from "./hermes-unsafe-pattern";
 
-const INTEGER_STRING_RE = /^-?\d+$/;
-const NUMERIC_STRING_RE = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
-
 interface PatternSchemaMatches {
   schemas: unknown[];
   unsafeDeniedPatterns: string[];
@@ -77,21 +74,11 @@ function valueMatchesSchemaType(value: unknown, schemaType: string): boolean {
     case "boolean":
       return typeof value === "boolean";
     case "integer":
-      return (
-        (typeof value === "number" && Number.isInteger(value)) ||
-        (typeof value === "string" &&
-          INTEGER_STRING_RE.test(value) &&
-          !Number.isFinite(Number(value)))
-      );
+      return typeof value === "number" && Number.isInteger(value);
     case "null":
       return value === null;
     case "number":
-      return (
-        (typeof value === "number" && Number.isFinite(value)) ||
-        (typeof value === "string" &&
-          NUMERIC_STRING_RE.test(value) &&
-          !Number.isFinite(Number(value)))
-      );
+      return typeof value === "number" && Number.isFinite(value);
     case "object":
       return isRecord(value);
     case "string":

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -3,6 +3,7 @@ import {
   getSchemaType,
   unwrapJsonSchema,
 } from "../../schema-coerce";
+import { unsafeDeniedPatternMayMatchKey } from "./hermes-unsafe-pattern";
 
 interface PatternSchemaMatches {
   schemas: unknown[];
@@ -35,102 +36,6 @@ function getPatternSchemaMatches(
     }
   }
   return { schemas, unsafeDeniedPatterns };
-}
-
-function regexLiteralCharacters(pattern: string): Set<string> {
-  const literals = new Set<string>();
-  let escaped = false;
-  let inCharClass = false;
-  for (let index = 0; index < pattern.length; index += 1) {
-    const char = pattern.charAt(index);
-    if (escaped) {
-      if (/^[A-Za-z0-9_-]$/.test(char)) {
-        literals.add(char);
-      }
-      escaped = false;
-      continue;
-    }
-    if (char === "\\") {
-      escaped = true;
-      continue;
-    }
-    if (char === "[" && !inCharClass) {
-      inCharClass = true;
-      continue;
-    }
-    if (char === "]" && inCharClass) {
-      inCharClass = false;
-      continue;
-    }
-    if (inCharClass) {
-      continue;
-    }
-    if (/^[A-Za-z0-9_-]$/.test(char)) {
-      literals.add(char);
-    }
-  }
-  return literals;
-}
-
-function patternHasConservativeCharacterMatcher(pattern: string): boolean {
-  let escaped = false;
-  let inCharClass = false;
-  for (let index = 0; index < pattern.length; index += 1) {
-    const char = pattern.charAt(index);
-    if (escaped) {
-      if ("dDsSwWpP".includes(char)) {
-        return true;
-      }
-      escaped = false;
-      continue;
-    }
-    if (char === "\\") {
-      escaped = true;
-      continue;
-    }
-    if (inCharClass) {
-      if (char === "]") {
-        inCharClass = false;
-      }
-      continue;
-    }
-    if (char === "[") {
-      return true;
-    }
-    if (char === ".") {
-      return true;
-    }
-  }
-  return inCharClass;
-}
-
-export function unsafeDeniedPatternMayMatchKey(
-  pattern: string,
-  key: string
-): boolean {
-  const literals = regexLiteralCharacters(pattern);
-  if (literals.size === 0) {
-    return true;
-  }
-
-  let comparable = 0;
-  let matching = 0;
-  for (const char of key) {
-    if (!/^[A-Za-z0-9_-]$/.test(char)) {
-      continue;
-    }
-    comparable += 1;
-    if (literals.has(char)) {
-      matching += 1;
-    }
-  }
-  if (comparable === 0) {
-    return true;
-  }
-  if (patternHasConservativeCharacterMatcher(pattern)) {
-    return true;
-  }
-  return matching === comparable || (key.length >= 16 && matching / comparable >= 0.75);
 }
 
 function isObjectSchema(schema: Record<string, unknown>): boolean {
@@ -250,6 +155,51 @@ function arrayMatchesSchemaKeyShape(
   );
 }
 
+function schemaCombinatorsMatch(
+  value: unknown,
+  schema: Record<string, unknown>,
+  seen: Set<object>
+): boolean {
+  const branchSeen = () => {
+    const nextSeen = new Set(seen);
+    if (isRecord(value) || Array.isArray(value)) {
+      nextSeen.delete(value);
+    }
+    return nextSeen;
+  };
+  const allOf = Array.isArray(schema.allOf) ? schema.allOf : undefined;
+  if (
+    allOf &&
+    !allOf.every((subSchema) =>
+      argumentValueMatchesSchemaKeyShape(value, subSchema, branchSeen())
+    )
+  ) {
+    return false;
+  }
+
+  const anyOf = Array.isArray(schema.anyOf) ? schema.anyOf : undefined;
+  if (
+    anyOf &&
+    !anyOf.some((subSchema) =>
+      argumentValueMatchesSchemaKeyShape(value, subSchema, branchSeen())
+    )
+  ) {
+    return false;
+  }
+
+  const oneOf = Array.isArray(schema.oneOf) ? schema.oneOf : undefined;
+  if (
+    oneOf &&
+    !oneOf.some((subSchema) =>
+      argumentValueMatchesSchemaKeyShape(value, subSchema, branchSeen())
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 export function argumentValueMatchesSchemaKeyShape(
   value: unknown,
   schema: unknown,
@@ -270,6 +220,9 @@ export function argumentValueMatchesSchemaKeyShape(
   }
   if (Array.isArray(value)) {
     return arrayMatchesSchemaKeyShape(value, unwrapped, seen);
+  }
+  if (!schemaCombinatorsMatch(value, unwrapped, seen)) {
+    return false;
   }
   if (isRecord(value) && isObjectSchema(unwrapped)) {
     return objectMatchesSchemaKeyShape(value, unwrapped, seen);

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -5,6 +5,7 @@ import {
 } from "../../schema-coerce";
 import { unsafeDeniedPatternMayMatchKey } from "./hermes-unsafe-pattern";
 
+const INTEGER_STRING_RE = /^-?\d+$/;
 const NUMERIC_STRING_RE = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
 
 interface PatternSchemaMatches {
@@ -28,7 +29,7 @@ function getPatternSchemaMatches(
   for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
     const regex = compileSafePatternPropertyRegex(pattern);
     if (!regex) {
-      if (patternSchema === false) {
+      if (patternSchema !== true) {
         unsafeDeniedPatterns.push(pattern);
       }
       continue;
@@ -78,14 +79,18 @@ function valueMatchesSchemaType(value: unknown, schemaType: string): boolean {
     case "integer":
       return (
         (typeof value === "number" && Number.isInteger(value)) ||
-        (typeof value === "string" && NUMERIC_STRING_RE.test(value))
+        (typeof value === "string" &&
+          INTEGER_STRING_RE.test(value) &&
+          !Number.isFinite(Number(value)))
       );
     case "null":
       return value === null;
     case "number":
       return (
-        typeof value === "number" ||
-        (typeof value === "string" && NUMERIC_STRING_RE.test(value))
+        (typeof value === "number" && Number.isFinite(value)) ||
+        (typeof value === "string" &&
+          NUMERIC_STRING_RE.test(value) &&
+          !Number.isFinite(Number(value)))
       );
     case "object":
       return isRecord(value);
@@ -351,6 +356,9 @@ export function argumentValueMatchesSchemaKeyShape(
   }
   if (!schemaCombinatorsMatch(value, unwrapped, seen)) {
     return false;
+  }
+  if (value === null && explicitSchemaTypes(unwrapped).includes("null")) {
+    return true;
   }
   if (isObjectSchema(unwrapped) && !isRecord(value)) {
     return false;

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -48,6 +48,61 @@ function isObjectSchema(schema: Record<string, unknown>): boolean {
   );
 }
 
+function isArraySchema(schema: Record<string, unknown>): boolean {
+  return getSchemaType(schema) === "array" || Array.isArray(schema.prefixItems);
+}
+
+function explicitSchemaTypes(schema: Record<string, unknown>): string[] {
+  const schemaType = schema.type;
+  if (typeof schemaType === "string") {
+    return [schemaType];
+  }
+  if (!Array.isArray(schemaType)) {
+    return [];
+  }
+  return schemaType.filter((type): type is string => typeof type === "string");
+}
+
+function valueMatchesSchemaType(value: unknown, schemaType: string): boolean {
+  switch (schemaType) {
+    case "array":
+      return Array.isArray(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "null":
+      return value === null;
+    case "number":
+      return typeof value === "number";
+    case "object":
+      return isRecord(value);
+    case "string":
+      return typeof value === "string";
+    default:
+      return true;
+  }
+}
+
+function valueMatchesSchemaKind(
+  value: unknown,
+  schema: Record<string, unknown>
+): boolean {
+  const schemaTypes = explicitSchemaTypes(schema);
+  if (schemaTypes.length > 0) {
+    return schemaTypes.some((schemaType) =>
+      valueMatchesSchemaType(value, schemaType)
+    );
+  }
+  if (isObjectSchema(schema)) {
+    return isRecord(value);
+  }
+  if (isArraySchema(schema)) {
+    return Array.isArray(value);
+  }
+  return true;
+}
+
 function getPropertySchema(
   schema: Record<string, unknown>,
   key: string
@@ -167,30 +222,27 @@ function schemaCombinatorsMatch(
     }
     return nextSeen;
   };
+  const branchMatches = (subSchema: unknown) => {
+    const unwrapped = unwrapJsonSchema(subSchema);
+    if (isRecord(unwrapped) && !valueMatchesSchemaKind(value, unwrapped)) {
+      return false;
+    }
+    return argumentValueMatchesSchemaKeyShape(value, subSchema, branchSeen());
+  };
   const allOf = Array.isArray(schema.allOf) ? schema.allOf : undefined;
-  if (
-    allOf &&
-    !allOf.every((subSchema) =>
-      argumentValueMatchesSchemaKeyShape(value, subSchema, branchSeen())
-    )
-  ) {
+  if (allOf && !allOf.every((subSchema) => branchMatches(subSchema))) {
     return false;
   }
 
   const anyOf = Array.isArray(schema.anyOf) ? schema.anyOf : undefined;
-  if (
-    anyOf &&
-    !anyOf.some((subSchema) =>
-      argumentValueMatchesSchemaKeyShape(value, subSchema, branchSeen())
-    )
-  ) {
+  if (anyOf && !anyOf.some((subSchema) => branchMatches(subSchema))) {
     return false;
   }
 
   const oneOf = Array.isArray(schema.oneOf) ? schema.oneOf : undefined;
   if (oneOf) {
     const matchCount = oneOf.filter((subSchema) =>
-      argumentValueMatchesSchemaKeyShape(value, subSchema, branchSeen())
+      branchMatches(subSchema)
     ).length;
     if (matchCount !== 1) {
       return false;

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -5,8 +5,8 @@ import {
 } from "../../schema-coerce";
 
 interface PatternSchemaMatches {
-  hasUnsafeDeniedPattern: boolean;
   schemas: unknown[];
+  unsafeDeniedPatterns: string[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -18,15 +18,15 @@ function getPatternSchemaMatches(
   key: string
 ): PatternSchemaMatches {
   if (!isRecord(patternProperties)) {
-    return { hasUnsafeDeniedPattern: false, schemas: [] };
+    return { schemas: [], unsafeDeniedPatterns: [] };
   }
   const schemas: unknown[] = [];
-  let hasUnsafeDeniedPattern = false;
+  const unsafeDeniedPatterns: string[] = [];
   for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
     const regex = compileSafePatternPropertyRegex(pattern);
     if (!regex) {
       if (patternSchema === false) {
-        hasUnsafeDeniedPattern = true;
+        unsafeDeniedPatterns.push(pattern);
       }
       continue;
     }
@@ -34,7 +34,68 @@ function getPatternSchemaMatches(
       schemas.push(patternSchema);
     }
   }
-  return { hasUnsafeDeniedPattern, schemas };
+  return { schemas, unsafeDeniedPatterns };
+}
+
+function regexLiteralCharacters(pattern: string): Set<string> {
+  const literals = new Set<string>();
+  let escaped = false;
+  let inCharClass = false;
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern.charAt(index);
+    if (escaped) {
+      if (/^[A-Za-z0-9_-]$/.test(char)) {
+        literals.add(char);
+      }
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === "[" && !inCharClass) {
+      inCharClass = true;
+      continue;
+    }
+    if (char === "]" && inCharClass) {
+      inCharClass = false;
+      continue;
+    }
+    if (inCharClass) {
+      continue;
+    }
+    if (/^[A-Za-z0-9_-]$/.test(char)) {
+      literals.add(char);
+    }
+  }
+  return literals;
+}
+
+export function unsafeDeniedPatternMayMatchKey(
+  pattern: string,
+  key: string
+): boolean {
+  const literals = regexLiteralCharacters(pattern);
+  if (literals.size === 0) {
+    return true;
+  }
+
+  let comparable = 0;
+  let matching = 0;
+  for (const char of key) {
+    if (!/^[A-Za-z0-9_-]$/.test(char)) {
+      continue;
+    }
+    comparable += 1;
+    if (literals.has(char)) {
+      matching += 1;
+    }
+  }
+  if (comparable === 0) {
+    return true;
+  }
+  return matching === comparable || (key.length >= 16 && matching / comparable >= 0.75);
 }
 
 function isObjectSchema(schema: Record<string, unknown>): boolean {
@@ -85,15 +146,21 @@ function objectMatchesSchemaKeyShape(
       schema.patternProperties,
       key
     );
-    if (patternMatches.schemas.some((patternSchema) => patternSchema === false)) {
+    const patternSchemas = patternMatches.schemas;
+    if (patternSchemas.some((patternSchema) => patternSchema === false)) {
+      return false;
+    }
+    if (
+      patternMatches.unsafeDeniedPatterns.some((pattern) =>
+        unsafeDeniedPatternMayMatchKey(pattern, key)
+      )
+    ) {
       return false;
     }
 
     const schemasToValidate = [
       ...(propertySchema === undefined ? [] : [propertySchema]),
-      ...patternMatches.schemas.filter(
-        (patternSchema) => patternSchema !== false
-      ),
+      ...patternSchemas.filter((patternSchema) => patternSchema !== false),
     ];
     if (schemasToValidate.length > 0) {
       if (
@@ -107,7 +174,7 @@ function objectMatchesSchemaKeyShape(
     }
 
     const additionalSchema = schema.additionalProperties;
-    if (additionalSchema === false || patternMatches.hasUnsafeDeniedPattern) {
+    if (additionalSchema === false) {
       return false;
     }
     if (

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -49,7 +49,11 @@ function isObjectSchema(schema: Record<string, unknown>): boolean {
 }
 
 function isArraySchema(schema: Record<string, unknown>): boolean {
-  return getSchemaType(schema) === "array" || Array.isArray(schema.prefixItems);
+  return (
+    getSchemaType(schema) === "array" ||
+    Array.isArray(schema.prefixItems) ||
+    Array.isArray(schema.items)
+  );
 }
 
 function explicitSchemaTypes(schema: Record<string, unknown>): string[] {
@@ -84,10 +88,44 @@ function valueMatchesSchemaType(value: unknown, schemaType: string): boolean {
   }
 }
 
+function jsonValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((item, index) => jsonValuesEqual(item, right[index]))
+    );
+  }
+  if (!isRecord(left) || !isRecord(right)) {
+    return false;
+  }
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) => Object.hasOwn(right, key) && jsonValuesEqual(left[key], right[key])
+    )
+  );
+}
+
 function valueMatchesSchemaKind(
   value: unknown,
   schema: Record<string, unknown>
 ): boolean {
+  if (Object.hasOwn(schema, "const") && !jsonValuesEqual(value, schema.const)) {
+    return false;
+  }
+  if (
+    Array.isArray(schema.enum) &&
+    !schema.enum.some((allowed) => jsonValuesEqual(value, allowed))
+  ) {
+    return false;
+  }
   const schemaTypes = explicitSchemaTypes(schema);
   if (schemaTypes.length > 0) {
     return schemaTypes.some((schemaType) =>
@@ -200,12 +238,19 @@ function arrayMatchesSchemaKeyShape(
   seen: Set<object>,
   enforceValueKinds: boolean
 ): boolean {
-  const prefixItems = Array.isArray(schema.prefixItems)
+  const tupleItems = Array.isArray(schema.prefixItems)
     ? schema.prefixItems
-    : undefined;
-  if (prefixItems) {
+    : Array.isArray(schema.items)
+      ? schema.items
+      : undefined;
+  if (tupleItems) {
     return value.every((item, index) => {
-      const itemSchema = prefixItems[index] ?? schema.items;
+      const itemSchema =
+        tupleItems[index] ??
+        (Array.isArray(schema.items) ? schema.additionalItems : schema.items);
+      if (itemSchema === false) {
+        return false;
+      }
       return argumentValueMatchesSchemaKeyShape(
         item,
         itemSchema,
@@ -294,6 +339,12 @@ export function argumentValueMatchesSchemaKeyShape(
     seen.add(value);
   }
   if (!schemaCombinatorsMatch(value, unwrapped, seen)) {
+    return false;
+  }
+  if (isObjectSchema(unwrapped) && !isRecord(value)) {
+    return false;
+  }
+  if (isArraySchema(unwrapped) && !Array.isArray(value)) {
     return false;
   }
   if (Array.isArray(value)) {

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -134,14 +134,14 @@ function valueMatchesSchemaKind(
   ) {
     return false;
   }
-  if (value === null) {
-    return true;
-  }
   const schemaTypes = explicitSchemaTypes(schema);
   if (schemaTypes.length > 0) {
     return schemaTypes.some((schemaType) =>
       valueMatchesSchemaType(value, schemaType)
     );
+  }
+  if (value === null) {
+    return true;
   }
   if (isObjectSchema(schema)) {
     return isRecord(value);

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -165,7 +165,11 @@ function objectMatchesSchemaKeyShape(
     if (schemasToValidate.length > 0) {
       if (
         !schemasToValidate.every((nestedSchema) =>
-          argumentValueMatchesSchemaKeyShape(nestedValue, nestedSchema, seen)
+          argumentValueMatchesSchemaKeyShape(
+            nestedValue,
+            nestedSchema,
+            new Set(seen)
+          )
         )
       ) {
         return false;
@@ -179,7 +183,11 @@ function objectMatchesSchemaKeyShape(
     }
     if (
       isRecord(additionalSchema) &&
-      !argumentValueMatchesSchemaKeyShape(nestedValue, additionalSchema, seen)
+      !argumentValueMatchesSchemaKeyShape(
+        nestedValue,
+        additionalSchema,
+        new Set(seen)
+      )
     ) {
       return false;
     }

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -72,6 +72,38 @@ function regexLiteralCharacters(pattern: string): Set<string> {
   return literals;
 }
 
+function patternHasConservativeCharacterMatcher(pattern: string): boolean {
+  let escaped = false;
+  let inCharClass = false;
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern.charAt(index);
+    if (escaped) {
+      if ("dDsSwWpP".includes(char)) {
+        return true;
+      }
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (inCharClass) {
+      if (char === "]") {
+        inCharClass = false;
+      }
+      continue;
+    }
+    if (char === "[") {
+      return true;
+    }
+    if (char === ".") {
+      return true;
+    }
+  }
+  return inCharClass;
+}
+
 export function unsafeDeniedPatternMayMatchKey(
   pattern: string,
   key: string
@@ -93,6 +125,9 @@ export function unsafeDeniedPatternMayMatchKey(
     }
   }
   if (comparable === 0) {
+    return true;
+  }
+  if (patternHasConservativeCharacterMatcher(pattern)) {
     return true;
   }
   return matching === comparable || (key.length >= 16 && matching / comparable >= 0.75);

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -1,0 +1,168 @@
+import {
+  compileSafePatternPropertyRegex,
+  getSchemaType,
+  unwrapJsonSchema,
+} from "../../schema-coerce";
+
+interface PatternSchemaMatches {
+  hasUnsafeDeniedPattern: boolean;
+  schemas: unknown[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getPatternSchemaMatches(
+  patternProperties: unknown,
+  key: string
+): PatternSchemaMatches {
+  if (!isRecord(patternProperties)) {
+    return { hasUnsafeDeniedPattern: false, schemas: [] };
+  }
+  const schemas: unknown[] = [];
+  let hasUnsafeDeniedPattern = false;
+  for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
+    const regex = compileSafePatternPropertyRegex(pattern);
+    if (!regex) {
+      if (patternSchema === false) {
+        hasUnsafeDeniedPattern = true;
+      }
+      continue;
+    }
+    if (regex.test(key)) {
+      schemas.push(patternSchema);
+    }
+  }
+  return { hasUnsafeDeniedPattern, schemas };
+}
+
+function isObjectSchema(schema: Record<string, unknown>): boolean {
+  return (
+    getSchemaType(schema) === "object" ||
+    isRecord(schema.properties) ||
+    isRecord(schema.patternProperties) ||
+    Array.isArray(schema.required) ||
+    Object.hasOwn(schema, "additionalProperties")
+  );
+}
+
+function getPropertySchema(
+  schema: Record<string, unknown>,
+  key: string
+): unknown | undefined {
+  const properties = schema.properties;
+  if (!isRecord(properties) || !Object.hasOwn(properties, key)) {
+    return;
+  }
+  return properties[key];
+}
+
+function requiredKeys(schema: Record<string, unknown>): string[] {
+  return Array.isArray(schema.required)
+    ? schema.required.filter(
+        (key): key is string => typeof key === "string" && key.length > 0
+      )
+    : [];
+}
+
+function objectMatchesSchemaKeyShape(
+  value: Record<string, unknown>,
+  schema: Record<string, unknown>,
+  seen: Set<object>
+): boolean {
+  if (requiredKeys(schema).some((key) => !Object.hasOwn(value, key))) {
+    return false;
+  }
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const propertySchema = getPropertySchema(schema, key);
+    if (propertySchema === false) {
+      return false;
+    }
+
+    const patternMatches = getPatternSchemaMatches(
+      schema.patternProperties,
+      key
+    );
+    if (patternMatches.schemas.some((patternSchema) => patternSchema === false)) {
+      return false;
+    }
+
+    const schemasToValidate = [
+      ...(propertySchema === undefined ? [] : [propertySchema]),
+      ...patternMatches.schemas.filter(
+        (patternSchema) => patternSchema !== false
+      ),
+    ];
+    if (schemasToValidate.length > 0) {
+      if (
+        !schemasToValidate.every((nestedSchema) =>
+          argumentValueMatchesSchemaKeyShape(nestedValue, nestedSchema, seen)
+        )
+      ) {
+        return false;
+      }
+      continue;
+    }
+
+    const additionalSchema = schema.additionalProperties;
+    if (additionalSchema === false || patternMatches.hasUnsafeDeniedPattern) {
+      return false;
+    }
+    if (
+      isRecord(additionalSchema) &&
+      !argumentValueMatchesSchemaKeyShape(nestedValue, additionalSchema, seen)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function arrayMatchesSchemaKeyShape(
+  value: unknown[],
+  schema: Record<string, unknown>,
+  seen: Set<object>
+): boolean {
+  const prefixItems = Array.isArray(schema.prefixItems)
+    ? schema.prefixItems
+    : undefined;
+  if (prefixItems) {
+    return value.every((item, index) => {
+      const itemSchema = prefixItems[index] ?? schema.items;
+      return argumentValueMatchesSchemaKeyShape(item, itemSchema, seen);
+    });
+  }
+  return value.every((item) =>
+    argumentValueMatchesSchemaKeyShape(item, schema.items, seen)
+  );
+}
+
+export function argumentValueMatchesSchemaKeyShape(
+  value: unknown,
+  schema: unknown,
+  seen = new Set<object>()
+): boolean {
+  const unwrapped = unwrapJsonSchema(schema);
+  if (unwrapped === false) {
+    return false;
+  }
+  if (!isRecord(unwrapped)) {
+    return true;
+  }
+  if (isRecord(value) || Array.isArray(value)) {
+    if (seen.has(value)) {
+      return true;
+    }
+    seen.add(value);
+  }
+  if (Array.isArray(value)) {
+    return arrayMatchesSchemaKeyShape(value, unwrapped, seen);
+  }
+  if (isRecord(value) && isObjectSchema(unwrapped)) {
+    return objectMatchesSchemaKeyShape(value, unwrapped, seen);
+  }
+  return true;
+}

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -582,6 +582,9 @@ function applyArgumentKeyPolicy(
   args: Record<string, unknown>,
   keyPolicy?: ArgumentKeyPolicy
 ): Record<string, unknown> | null {
+  if (containsPrototypeSensitiveArgumentKey(args)) {
+    return null;
+  }
   if (
     keyPolicy &&
     Object.keys(args).some((key) => argumentKeyDeniedByPolicy(key, keyPolicy))
@@ -590,6 +593,9 @@ function applyArgumentKeyPolicy(
   }
   const policyArgs = keyPolicy ? coerceBySchema(args, keyPolicy.schema) : args;
   if (!isRecord(policyArgs)) {
+    return null;
+  }
+  if (containsPrototypeSensitiveArgumentKey(policyArgs)) {
     return null;
   }
   if (
@@ -650,6 +656,33 @@ const PROTOTYPE_SENSITIVE_ARGUMENT_KEYS = new Set([
   "constructor",
   "prototype",
 ]);
+
+function containsPrototypeSensitiveArgumentKey(
+  value: unknown,
+  seen = new Set<object>()
+): boolean {
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return false;
+    }
+    seen.add(value);
+    return value.some((item) =>
+      containsPrototypeSensitiveArgumentKey(item, seen)
+    );
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+  return Object.keys(value).some(
+    (key) =>
+      PROTOTYPE_SENSITIVE_ARGUMENT_KEYS.has(key) ||
+      containsPrototypeSensitiveArgumentKey(value[key], seen)
+  );
+}
 
 function isUnquotedRjsonKeyStart(char: string): boolean {
   return (
@@ -847,12 +880,8 @@ function collectTopLevelObjectKeys(
 }
 
 function strictPolicyHasPrototypeSensitiveArgumentKey(
-  argumentsText: string,
-  keyPolicy?: ArgumentKeyPolicy
+  argumentsText: string
 ): boolean {
-  if (!keyPolicy) {
-    return false;
-  }
   const objectStart = skipJsonWhitespace(argumentsText, 0);
   const keys = collectTopLevelObjectKeys(argumentsText, objectStart);
   return (
@@ -861,12 +890,8 @@ function strictPolicyHasPrototypeSensitiveArgumentKey(
 }
 
 function strictToolCallHasPrototypeSensitiveArgumentKey(
-  toolCallJson: string,
-  keyPolicy?: ArgumentKeyPolicy
+  toolCallJson: string
 ): boolean {
-  if (!keyPolicy) {
-    return false;
-  }
   const argsValueStart = findTopLevelPropertyValueStart(
     toolCallJson,
     "arguments"
@@ -875,8 +900,7 @@ function strictToolCallHasPrototypeSensitiveArgumentKey(
     return false;
   }
   return strictPolicyHasPrototypeSensitiveArgumentKey(
-    toolCallJson.slice(argsValueStart),
-    keyPolicy
+    toolCallJson.slice(argsValueStart)
   );
 }
 
@@ -947,7 +971,7 @@ function repairToolCallJson(
   toolName: string,
   keyPolicy?: ArgumentKeyPolicy
 ): { name: string; arguments: Record<string, unknown> } | null {
-  if (strictToolCallHasPrototypeSensitiveArgumentKey(raw, keyPolicy)) {
+  if (strictToolCallHasPrototypeSensitiveArgumentKey(raw)) {
     return null;
   }
 
@@ -1226,9 +1250,8 @@ function processToolCallJson(
     if (!isParsedToolCallRecord(parsedToolCall)) {
       throw new Error("Tool call object is missing own name or arguments");
     }
-    const keyPolicy = extractArgumentKeyPolicy(tools, parsedToolCall.name);
     if (
-      strictToolCallHasPrototypeSensitiveArgumentKey(toolCallJson, keyPolicy)
+      strictToolCallHasPrototypeSensitiveArgumentKey(toolCallJson)
     ) {
       throw new Error("Tool call arguments contain prototype-sensitive keys");
     }
@@ -1629,76 +1652,6 @@ function emitToolCallFromParsed(
   } as LanguageModelV3StreamPart);
 }
 
-function canonicalizeArgumentsProgressInput(
-  progress: {
-    argumentsText: string | undefined;
-    argumentsComplete: boolean;
-  },
-  toolName: string,
-  tools: LanguageModelV3FunctionTool[]
-): string | undefined {
-  if (progress.argumentsText === undefined || !progress.argumentsComplete) {
-    return undefined;
-  }
-
-  try {
-    const keyPolicy = extractArgumentKeyPolicy(tools, toolName);
-    if (
-      strictPolicyHasPrototypeSensitiveArgumentKey(
-        progress.argumentsText,
-        keyPolicy
-      )
-    ) {
-      return undefined;
-    }
-    const parsedArguments = parseRJSON(
-      normalizeJsonStringCtrl(progress.argumentsText)
-    );
-    if (!isRecord(parsedArguments)) {
-      return undefined;
-    }
-    const policyArgs = applyArgumentKeyPolicy(parsedArguments, keyPolicy);
-    const policyArguments =
-      policyArgs === null ? null : { args: policyArgs };
-    if (policyArguments === null) {
-      return undefined;
-    }
-    return stringifyToolInputWithSchema({
-      toolName,
-      args: policyArguments.args,
-      tools,
-      fallback: canonicalizeToolInput,
-    });
-  } catch {
-    return undefined;
-  }
-}
-
-function emitToolInputProgress(
-  state: StreamState,
-  controller: StreamController,
-  tools: LanguageModelV3FunctionTool[]
-) {
-  if (!(state.isInsideToolCall && state.currentToolCallJson)) {
-    return;
-  }
-
-  const progress = extractStreamingToolCallProgress(state.currentToolCallJson);
-  if (!progress.toolName) {
-    return;
-  }
-
-  const canonicalProgressInput = canonicalizeArgumentsProgressInput(
-    progress,
-    progress.toolName,
-    tools
-  );
-  if (canonicalProgressInput !== undefined) {
-    ensureToolInputStart(state, controller, progress.toolName);
-    emitToolInputDelta(state, controller, canonicalProgressInput);
-  }
-}
-
 function flushBuffer(
   state: StreamState,
   controller: StreamController,
@@ -1761,11 +1714,9 @@ function emitIncompleteToolCall(
       if (!isParsedToolCallRecord(parsedToolCall)) {
         throw new Error("Tool call object is missing own name or arguments");
       }
-      const keyPolicy = extractArgumentKeyPolicy(tools, parsedToolCall.name);
       if (
         strictToolCallHasPrototypeSensitiveArgumentKey(
-          state.currentToolCallJson,
-          keyPolicy
+          state.currentToolCallJson
         )
       ) {
         throw new Error("Tool call arguments contain prototype-sensitive keys");
@@ -1880,13 +1831,11 @@ function handleFinishChunk(
 function publishText(
   text: string,
   state: StreamState,
-  controller: StreamController,
-  tools: LanguageModelV3FunctionTool[]
+  controller: StreamController
 ) {
   if (state.isInsideToolCall) {
     closeTextBlock(state, controller);
     state.currentToolCallJson += text;
-    emitToolInputProgress(state, controller, tools);
   } else if (text.length > 0) {
     if (!state.currentTextId) {
       state.currentTextId = generateId();
@@ -1914,11 +1863,9 @@ function emitToolCall(context: TagProcessingContext) {
     if (!isParsedToolCallRecord(parsedToolCall)) {
       throw new Error("Tool call object is missing own name or arguments");
     }
-    const keyPolicy = extractArgumentKeyPolicy(tools, parsedToolCall.name);
     if (
       strictToolCallHasPrototypeSensitiveArgumentKey(
-        state.currentToolCallJson,
-        keyPolicy
+        state.currentToolCallJson
       )
     ) {
       throw new Error("Tool call arguments contain prototype-sensitive keys");
@@ -2073,7 +2020,7 @@ function recoverNestedStreamingToolCall(options: {
 }
 
 function processInsideToolCallBoundary(context: TagProcessingContext): boolean {
-  const { state, controller, toolCallStart, toolCallEnd, tools } = context;
+  const { state, controller, toolCallStart, toolCallEnd } = context;
   const currentLength = state.currentToolCallJson.length;
   const combined = state.currentToolCallJson + state.buffer;
   const boundary = findToolCallBoundaryOutsideRjsonSyntax(
@@ -2105,8 +2052,7 @@ function processInsideToolCallBoundary(context: TagProcessingContext): boolean {
   publishText(
     state.buffer.slice(0, relativeEndIndex),
     state,
-    controller,
-    tools
+    controller
   );
   state.buffer = state.buffer.slice(relativeEndIndex + toolCallEnd.length);
   processTagMatch(context);
@@ -2114,7 +2060,7 @@ function processInsideToolCallBoundary(context: TagProcessingContext): boolean {
 }
 
 function processBufferTags(context: TagProcessingContext) {
-  const { state, controller, toolCallStart, tools } = context;
+  const { state, controller, toolCallStart } = context;
 
   while (state.isInsideToolCall) {
     if (!processInsideToolCallBoundary(context)) {
@@ -2129,7 +2075,7 @@ function processBufferTags(context: TagProcessingContext) {
       break;
     }
 
-    publishText(state.buffer.slice(0, startIndex), state, controller, tools);
+    publishText(state.buffer.slice(0, startIndex), state, controller);
     state.buffer = state.buffer.slice(startIndex + toolCallStart.length);
     processTagMatch(context);
 
@@ -2147,8 +2093,7 @@ function handlePartialTag(
   state: StreamState,
   controller: StreamController,
   toolCallStart: string,
-  toolCallEnd: string,
-  tools: LanguageModelV3FunctionTool[]
+  toolCallEnd: string
 ) {
   if (state.isInsideToolCall) {
     const potentialEndIndex = getPotentialStartIndex(state.buffer, toolCallEnd);
@@ -2159,12 +2104,11 @@ function handlePartialTag(
       publishText(
         state.buffer.slice(0, potentialEndIndex),
         state,
-        controller,
-        tools
+        controller
       );
       state.buffer = state.buffer.slice(potentialEndIndex);
     } else {
-      publishText(state.buffer, state, controller, tools);
+      publishText(state.buffer, state, controller);
       state.buffer = "";
     }
     return;
@@ -2178,12 +2122,11 @@ function handlePartialTag(
     publishText(
       state.buffer.slice(0, potentialIndex),
       state,
-      controller,
-      tools
+      controller
     );
     state.buffer = state.buffer.slice(potentialIndex);
   } else {
-    publishText(state.buffer, state, controller, tools);
+    publishText(state.buffer, state, controller);
     state.buffer = "";
   }
 }
@@ -2335,7 +2278,7 @@ export const hermesProtocol = ({
           options,
           tools,
         });
-        handlePartialTag(state, controller, toolCallStart, toolCallEnd, tools);
+        handlePartialTag(state, controller, toolCallStart, toolCallEnd);
       },
     });
   },

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -927,12 +927,12 @@ const FIRST_KEY_RE = /^\s*"([^"]+)"\s*:\s*/;
 const KV_PATTERN_RE = /,\s*"([^"]+)"\s*:\s*/g;
 const TRAILING_COMMA_RE = /,\s*$/;
 
-function getTopLevelPositionMap(argsBody: string): boolean[] {
-  const topLevelAtPosition = Array<boolean>(argsBody.length + 1);
+function getTopLevelPositionMap(argsBody: string): Uint8Array {
+  const topLevelAtPosition = new Uint8Array(argsBody.length + 1);
   let depth = 0;
   let inStr = false;
   let esc = false;
-  topLevelAtPosition[0] = true;
+  topLevelAtPosition[0] = 1;
   for (let i = 0; i < argsBody.length; i++) {
     const ch = argsBody[i];
     if (esc) {
@@ -949,7 +949,7 @@ function getTopLevelPositionMap(argsBody: string): boolean[] {
         depth--;
       }
     }
-    topLevelAtPosition[i + 1] = depth === 0;
+    topLevelAtPosition[i + 1] = depth === 0 ? 1 : 0;
   }
   return topLevelAtPosition;
 }
@@ -1068,7 +1068,7 @@ function repairToolCallJson(
   const topLevelAtPosition = getTopLevelPositionMap(argsBody);
   allKeys = allKeys.filter(
     (entry) =>
-      entry.matchStart === 0 || topLevelAtPosition[entry.matchStart]
+      entry.matchStart === 0 || topLevelAtPosition[entry.matchStart] === 1
   );
 
   // 7. Handle duplicate key names with scoring heuristic

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -8,6 +8,7 @@ import { parse as parseRJSON } from "../../rjson";
 import {
   coerceBySchema,
   compileSafePatternPropertyRegex,
+  getSchemaType,
   unwrapJsonSchema,
 } from "../../schema-coerce";
 import { logParseFailure } from "../utils/debug";
@@ -549,7 +550,13 @@ function schemaRejectsNonRecordArguments(
     return false;
   }
   seen.add(unwrapped);
-  if (unwrapped.additionalProperties === false) {
+  if (
+    getSchemaType(unwrapped) === "object" ||
+    isRecord(unwrapped.properties) ||
+    isRecord(unwrapped.patternProperties) ||
+    Array.isArray(unwrapped.required) ||
+    Object.hasOwn(unwrapped, "additionalProperties")
+  ) {
     return true;
   }
 

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -1436,7 +1436,6 @@ interface StreamState {
   pendingToolInputProgressVersion: number;
   speculativeToolCall: {
     input: string;
-    toolCallJson: string;
     toolName: string;
   } | null;
 }
@@ -1780,7 +1779,6 @@ function emitStreamingToolInputProgress(options: {
     emitToolInputDelta(state, controller, input);
     state.speculativeToolCall = {
       input,
-      toolCallJson,
       toolName: parsedToolCall.name,
     };
     return true;
@@ -1831,10 +1829,6 @@ function emitSpeculativeToolCall(
   controller: StreamController
 ): boolean {
   if (!state.activeToolInput || !state.speculativeToolCall) {
-    return false;
-  }
-  if (state.speculativeToolCall.toolCallJson !== state.currentToolCallJson) {
-    state.speculativeToolCall = null;
     return false;
   }
   const toolCallId = state.activeToolInput.id;

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -22,7 +22,10 @@ import {
   shouldEmitRawToolCallTextOnError,
   stringifyToolInputWithSchema,
 } from "../utils/tool-input-streaming";
-import { argumentValueMatchesSchemaKeyShape } from "./hermes-argument-schema";
+import {
+  argumentValueMatchesSchemaKeyShape,
+  unsafeDeniedPatternMayMatchKey,
+} from "./hermes-argument-schema";
 import type { ParserOptions, TCMProtocol } from "./protocol-interface";
 
 interface HermesProtocolOptions {
@@ -519,10 +522,10 @@ interface ArgumentKeyPolicy {
   allowUnknownKeys: boolean;
   deniedKeys: Set<string>;
   deniedPatterns: RegExp[];
-  hasUnsafeDeniedPattern: boolean;
   keyPatterns: RegExp[];
   knownKeys: Set<string>;
   schema: unknown;
+  unsafeDeniedPatterns: string[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -543,15 +546,15 @@ function extractArgumentKeyPolicy(
     ? schema.patternProperties
     : {};
   const deniedPatterns: RegExp[] = [];
-  let hasUnsafeDeniedPattern = false;
   const keyPatterns: RegExp[] = [];
+  const unsafeDeniedPatterns: string[] = [];
   for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
     const regex = compileSafePatternPropertyRegex(pattern);
     if (patternSchema === false) {
       if (regex) {
         deniedPatterns.push(regex);
       } else {
-        hasUnsafeDeniedPattern = true;
+        unsafeDeniedPatterns.push(pattern);
       }
       continue;
     }
@@ -568,7 +571,6 @@ function extractArgumentKeyPolicy(
         .map(([key]) => key)
     ),
     deniedPatterns,
-    hasUnsafeDeniedPattern,
     keyPatterns,
     knownKeys: new Set(
       propertyEntries
@@ -576,6 +578,7 @@ function extractArgumentKeyPolicy(
         .map(([key]) => key)
     ),
     schema,
+    unsafeDeniedPatterns,
   };
 }
 
@@ -643,8 +646,9 @@ function argumentKeyDeniedByPolicy(
     PROTOTYPE_SENSITIVE_ARGUMENT_KEYS.has(key) ||
     keyPolicy.deniedKeys.has(key) ||
     keyPolicy.deniedPatterns.some((pattern) => pattern.test(key)) ||
-    (keyPolicy.hasUnsafeDeniedPattern &&
-      !argumentKeyMatchesPolicy(key, keyPolicy))
+    keyPolicy.unsafeDeniedPatterns.some((pattern) =>
+      unsafeDeniedPatternMayMatchKey(pattern, key)
+    )
   );
 }
 

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -5,7 +5,11 @@ import type {
   LanguageModelV3ToolCall,
 } from "@ai-sdk/provider";
 import { parse as parseRJSON } from "../../rjson";
-import { unwrapJsonSchema } from "../../schema-coerce";
+import {
+  coerceBySchema,
+  compileSafePatternPropertyRegex,
+  unwrapJsonSchema,
+} from "../../schema-coerce";
 import { logParseFailure } from "../utils/debug";
 import { getPotentialStartIndex } from "../utils/get-potential-start-index";
 import { generateId, generateToolCallId } from "../utils/id";
@@ -514,6 +518,7 @@ interface ArgumentKeyPolicy {
   allowUnknownKeys: boolean;
   keyPatterns: RegExp[];
   knownKeys: Set<string>;
+  schema: unknown;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -535,15 +540,16 @@ function extractArgumentKeyPolicy(
     : {};
   const keyPatterns: RegExp[] = [];
   for (const pattern of Object.keys(patternProperties)) {
-    try {
-      keyPatterns.push(new RegExp(pattern));
-    } catch {
+    const regex = compileSafePatternPropertyRegex(pattern);
+    if (regex) {
+      keyPatterns.push(regex);
     }
   }
   return {
     allowUnknownKeys: schema.additionalProperties !== false,
     keyPatterns,
     knownKeys: new Set(Object.keys(properties)),
+    schema,
   };
 }
 
@@ -551,17 +557,40 @@ function applyArgumentKeyPolicy(
   args: Record<string, unknown>,
   keyPolicy?: ArgumentKeyPolicy
 ): Record<string, unknown> | null {
+  const policyArgs = keyPolicy ? coerceBySchema(args, keyPolicy.schema) : args;
+  if (!isRecord(policyArgs)) {
+    return null;
+  }
   if (keyPolicy && !keyPolicy.allowUnknownKeys) {
-    for (const key of Object.keys(args)) {
-      if (
-        !keyPolicy.knownKeys.has(key) &&
-        !keyPolicy.keyPatterns.some((pattern) => pattern.test(key))
-      ) {
-        return null;
-      }
+    const rawUnknownKeys = Object.keys(args).filter(
+      (key) => !argumentKeyMatchesPolicy(key, keyPolicy)
+    );
+    const rawKnownKeys = new Set(
+      Object.keys(args).filter((key) =>
+        argumentKeyMatchesPolicy(key, keyPolicy)
+      )
+    );
+    const coercedKnownKeys = Object.keys(policyArgs).filter((key) =>
+      argumentKeyMatchesPolicy(key, keyPolicy)
+    );
+    const newCoercedKnownKeys = coercedKnownKeys.filter(
+      (key) => !rawKnownKeys.has(key)
+    );
+    if (newCoercedKnownKeys.length < rawUnknownKeys.length) {
+      return null;
     }
   }
-  return args;
+  return policyArgs;
+}
+
+function argumentKeyMatchesPolicy(
+  key: string,
+  keyPolicy: ArgumentKeyPolicy
+): boolean {
+  return (
+    keyPolicy.knownKeys.has(key) ||
+    keyPolicy.keyPatterns.some((pattern) => pattern.test(key))
+  );
 }
 
 function applyToolArgumentKeyPolicy(
@@ -728,19 +757,19 @@ function repairToolCallJson(
   );
 
   // 7. Handle duplicate key names with scoring heuristic
-  const firstByKey: Record<string, number> = {};
-  const lastByKey: Record<string, number> = {};
+  const firstByKey = new Map<string, number>();
+  const lastByKey = new Map<string, number>();
   for (let idx = 0; idx < allKeys.length; idx++) {
-    if (!(allKeys[idx].key in firstByKey)) {
-      firstByKey[allKeys[idx].key] = idx;
+    if (!firstByKey.has(allKeys[idx].key)) {
+      firstByKey.set(allKeys[idx].key, idx);
     }
-    lastByKey[allKeys[idx].key] = idx;
+    lastByKey.set(allKeys[idx].key, idx);
   }
   const firstPositions = allKeys.filter(
-    (_, i) => firstByKey[allKeys[i].key] === i
+    (_, i) => firstByKey.get(allKeys[i].key) === i
   );
   const lastPositions = allKeys.filter(
-    (_, i) => lastByKey[allKeys[i].key] === i
+    (_, i) => lastByKey.get(allKeys[i].key) === i
   );
 
   let keyPositions: typeof allKeys;
@@ -821,14 +850,6 @@ function repairToolCallJson(
   const args = Object.create(null) as Record<string, unknown>;
   for (let i = 0; i < allKeys.length; i++) {
     const kp = allKeys[i];
-    const rejectsUnknownArgument =
-      keyPolicy &&
-      !keyPolicy.allowUnknownKeys &&
-      !keyPolicy.knownKeys.has(kp.key) &&
-      !keyPolicy.keyPatterns.some((pattern) => pattern.test(kp.key));
-    if (rejectsUnknownArgument) {
-      return null;
-    }
     const vs = kp.valueStart;
     const ve =
       i + 1 < allKeys.length ? allKeys[i + 1].matchStart : argsBody.length;
@@ -881,7 +902,8 @@ function repairToolCallJson(
   if (Object.keys(args).length === 0) {
     return null;
   }
-  return { name: toolName, arguments: args };
+  const policyArgs = applyArgumentKeyPolicy(args, keyPolicy);
+  return policyArgs === null ? null : { name: toolName, arguments: policyArgs };
 }
 
 function repairToolCallJsonForTools(

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -298,6 +298,20 @@ function canonicalizeToolInput(argumentsValue: unknown): string {
   return JSON.stringify(argumentsValue ?? {});
 }
 
+function isParsedToolCallRecord(
+  value: unknown
+): value is { name: string; arguments: unknown } {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    Object.prototype.hasOwnProperty.call(record, "name") &&
+    Object.prototype.hasOwnProperty.call(record, "arguments") &&
+    typeof record.name === "string"
+  );
+}
+
 const CHAR_CODE_BACKSLASH = 0x5c;
 const CHAR_CODE_QUOTE = 0x22;
 const CHAR_CODE_LF = 0x0a;
@@ -895,10 +909,10 @@ function processToolCallJson(
   try {
     const parsedToolCall = parseRJSON(
       normalizeJsonStringCtrl(toolCallJson)
-    ) as {
-      name: string;
-      arguments: unknown;
-    };
+    );
+    if (!isParsedToolCallRecord(parsedToolCall)) {
+      throw new Error("Tool call object is missing own name or arguments");
+    }
     const policyArguments = applyToolArgumentKeyPolicy(
       parsedToolCall.name,
       parsedToolCall.arguments,
@@ -1419,10 +1433,10 @@ function emitIncompleteToolCall(
     try {
       const parsedToolCall = parseRJSON(
         normalizeJsonStringCtrl(state.currentToolCallJson)
-      ) as {
-        name: string;
-        arguments: unknown;
-      };
+      );
+      if (!isParsedToolCallRecord(parsedToolCall)) {
+        throw new Error("Tool call object is missing own name or arguments");
+      }
       const policyArguments = applyToolArgumentKeyPolicy(
         parsedToolCall.name,
         parsedToolCall.arguments,
@@ -1563,10 +1577,10 @@ function emitToolCall(context: TagProcessingContext) {
   try {
     const parsedToolCall = parseRJSON(
       normalizeJsonStringCtrl(state.currentToolCallJson)
-    ) as {
-      name: string;
-      arguments: unknown;
-    };
+    );
+    if (!isParsedToolCallRecord(parsedToolCall)) {
+      throw new Error("Tool call object is missing own name or arguments");
+    }
     const policyArguments = applyToolArgumentKeyPolicy(
       parsedToolCall.name,
       parsedToolCall.arguments,

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -2095,6 +2095,8 @@ function emitToolCall(context: TagProcessingContext) {
       emitToolCallFromParsed(state, controller, repaired, tools);
       return;
     }
+    const activeToolCallId = state.activeToolInput?.id;
+    const activeToolName = state.activeToolInput?.toolName;
     const emittedSpeculativeToolCall = emitSpeculativeToolCall(
       state,
       controller
@@ -2102,10 +2104,9 @@ function emitToolCall(context: TagProcessingContext) {
 
     const errorContent = `${toolCallStart}${state.currentToolCallJson}${toolCallEnd}`;
     const shouldEmitRawFallback = shouldEmitRawToolCallTextOnError(options);
-    const streamingToolCallId =
-      state.activeToolInput?.id ?? generateToolCallId();
+    const streamingToolCallId = activeToolCallId ?? generateToolCallId();
     const streamingToolName =
-      state.activeToolInput?.toolName ??
+      activeToolName ??
       extractStreamingToolCallProgress(state.currentToolCallJson).toolName;
 
     logParseFailure({

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -525,6 +525,7 @@ interface ArgumentKeyPolicy {
   keyPatterns: RegExp[];
   knownKeys: Set<string>;
   rejectAll: boolean;
+  rejectNonRecordArguments: boolean;
   schema: unknown;
   unsafeDeniedPatterns: string[];
 }
@@ -547,6 +548,7 @@ function extractArgumentKeyPolicy(
       keyPatterns: [],
       knownKeys: new Set(),
       rejectAll: true,
+      rejectNonRecordArguments: true,
       schema,
       unsafeDeniedPatterns: [],
     };
@@ -591,6 +593,7 @@ function extractArgumentKeyPolicy(
         .map(([key]) => key)
     ),
     rejectAll: false,
+    rejectNonRecordArguments: schema.additionalProperties === false,
     schema,
     unsafeDeniedPatterns,
   };
@@ -981,6 +984,9 @@ function applyToolArgumentKeyPolicy(
     return null;
   }
   if (!isRecord(args)) {
+    if (keyPolicy?.rejectNonRecordArguments) {
+      return null;
+    }
     return { args };
   }
   const policyArgs = applyArgumentKeyPolicy(args, keyPolicy);

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -673,7 +673,7 @@ function applyArgumentKeyPolicy(
   ) {
     return null;
   }
-  const policyArgs = keyPolicy ? coerceBySchema(args, keyPolicy.schema) : args;
+  const policyArgs = coerceArgsForKeyPolicy(args, keyPolicy);
   if (!isRecord(policyArgs)) {
     return null;
   }
@@ -719,6 +719,13 @@ function applyArgumentKeyPolicy(
     return null;
   }
   return policyArgs;
+}
+
+function coerceArgsForKeyPolicy(
+  args: Record<string, unknown>,
+  keyPolicy?: ArgumentKeyPolicy
+): unknown {
+  return keyPolicy ? coerceBySchema(args, keyPolicy.schema) : args;
 }
 
 function argumentKeyDeniedByPolicy(

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -516,6 +516,8 @@ function normalizeJsonStringCtrl(json: string): string {
 
 interface ArgumentKeyPolicy {
   allowUnknownKeys: boolean;
+  deniedKeys: Set<string>;
+  deniedPatterns: RegExp[];
   keyPatterns: RegExp[];
   knownKeys: Set<string>;
   schema: unknown;
@@ -538,20 +540,35 @@ function extractArgumentKeyPolicy(
   const patternProperties = isRecord(schema.patternProperties)
     ? schema.patternProperties
     : {};
+  const deniedPatterns: RegExp[] = [];
   const keyPatterns: RegExp[] = [];
   for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
+    const regex = compileSafePatternPropertyRegex(pattern);
     if (patternSchema === false) {
+      if (regex) {
+        deniedPatterns.push(regex);
+      }
       continue;
     }
-    const regex = compileSafePatternPropertyRegex(pattern);
     if (regex) {
       keyPatterns.push(regex);
     }
   }
+  const propertyEntries = Object.entries(properties);
   return {
     allowUnknownKeys: schema.additionalProperties !== false,
+    deniedKeys: new Set(
+      propertyEntries
+        .filter(([, propertySchema]) => propertySchema === false)
+        .map(([key]) => key)
+    ),
+    deniedPatterns,
     keyPatterns,
-    knownKeys: new Set(Object.keys(properties)),
+    knownKeys: new Set(
+      propertyEntries
+        .filter(([, propertySchema]) => propertySchema !== false)
+        .map(([key]) => key)
+    ),
     schema,
   };
 }
@@ -560,8 +577,22 @@ function applyArgumentKeyPolicy(
   args: Record<string, unknown>,
   keyPolicy?: ArgumentKeyPolicy
 ): Record<string, unknown> | null {
+  if (
+    keyPolicy &&
+    Object.keys(args).some((key) => argumentKeyDeniedByPolicy(key, keyPolicy))
+  ) {
+    return null;
+  }
   const policyArgs = keyPolicy ? coerceBySchema(args, keyPolicy.schema) : args;
   if (!isRecord(policyArgs)) {
+    return null;
+  }
+  if (
+    keyPolicy &&
+    Object.keys(policyArgs).some((key) =>
+      argumentKeyDeniedByPolicy(key, keyPolicy)
+    )
+  ) {
     return null;
   }
   if (keyPolicy && !keyPolicy.allowUnknownKeys) {
@@ -586,6 +617,16 @@ function applyArgumentKeyPolicy(
   return policyArgs;
 }
 
+function argumentKeyDeniedByPolicy(
+  key: string,
+  keyPolicy: ArgumentKeyPolicy
+): boolean {
+  return (
+    keyPolicy.deniedKeys.has(key) ||
+    keyPolicy.deniedPatterns.some((pattern) => pattern.test(key))
+  );
+}
+
 function argumentKeyMatchesPolicy(
   key: string,
   keyPolicy: ArgumentKeyPolicy
@@ -602,10 +643,28 @@ const PROTOTYPE_SENSITIVE_ARGUMENT_KEYS = new Set([
   "prototype",
 ]);
 
-function parseJsonObjectKey(text: string, keyStart: number): {
+function isUnquotedRjsonKeyStart(char: string): boolean {
+  return (
+    char === "_" ||
+    char === "$" ||
+    (char >= "A" && char <= "Z") ||
+    (char >= "a" && char <= "z")
+  );
+}
+
+function isUnquotedRjsonKeyChar(char: string): boolean {
+  return (
+    isUnquotedRjsonKeyStart(char) ||
+    (char >= "0" && char <= "9") ||
+    char === "-"
+  );
+}
+
+function parseQuotedObjectKey(text: string, keyStart: number): {
   key: string;
   end: number;
 } | null {
+  const quote = text.charAt(keyStart);
   let index = keyStart + 1;
   let escaped = false;
   while (index < text.length) {
@@ -614,16 +673,48 @@ function parseJsonObjectKey(text: string, keyStart: number): {
       escaped = false;
     } else if (char === "\\") {
       escaped = true;
-    } else if (char === '"') {
-      try {
-        return { key: JSON.parse(text.slice(keyStart, index + 1)), end: index };
-      } catch {
-        return null;
+    } else if (char === quote) {
+      if (quote === '"') {
+        try {
+          return {
+            key: JSON.parse(text.slice(keyStart, index + 1)),
+            end: index,
+          };
+        } catch {
+          return null;
+        }
       }
+      return { key: text.slice(keyStart + 1, index), end: index };
     }
     index += 1;
   }
   return null;
+}
+
+function parseUnquotedObjectKey(text: string, keyStart: number): {
+  key: string;
+  end: number;
+} | null {
+  if (!isUnquotedRjsonKeyStart(text.charAt(keyStart))) {
+    return null;
+  }
+  let index = keyStart + 1;
+  while (index < text.length && isUnquotedRjsonKeyChar(text.charAt(index))) {
+    index += 1;
+  }
+  return { key: text.slice(keyStart, index), end: index - 1 };
+}
+
+function previousSignificantChar(text: string, index: number): string {
+  let cursor = index - 1;
+  while (cursor >= 0) {
+    const char = text.charAt(cursor);
+    if (!/\s/.test(char)) {
+      return char;
+    }
+    cursor -= 1;
+  }
+  return "";
 }
 
 function collectTopLevelObjectKeys(
@@ -636,19 +727,19 @@ function collectTopLevelObjectKeys(
 
   const keys: string[] = [];
   let depth = 0;
-  let inString = false;
+  let quoteChar: string | null = null;
   let escaping = false;
 
   for (let index = objectStart; index < text.length; index += 1) {
     const char = text.charAt(index);
 
-    if (inString) {
+    if (quoteChar) {
       if (escaping) {
         escaping = false;
       } else if (char === "\\") {
         escaping = true;
-      } else if (char === '"') {
-        inString = false;
+      } else if (char === quoteChar) {
+        quoteChar = null;
       }
       continue;
     }
@@ -664,15 +755,33 @@ function collectTopLevelObjectKeys(
       }
       continue;
     }
-    if (char !== '"') {
-      continue;
-    }
     if (depth !== 1) {
-      inString = true;
+      if (char === '"' || char === "'") {
+        quoteChar = char;
+      }
       continue;
     }
 
-    const parsedKey = parseJsonObjectKey(text, index);
+    if (char !== '"' && char !== "'") {
+      if (
+        (previousSignificantChar(text, index) === "{" ||
+          previousSignificantChar(text, index) === ",") &&
+        isUnquotedRjsonKeyStart(char)
+      ) {
+        const parsedKey = parseUnquotedObjectKey(text, index);
+        if (!parsedKey) {
+          return null;
+        }
+        const valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
+        if (text.charAt(valueCursor) === ":") {
+          keys.push(parsedKey.key);
+          index = valueCursor;
+        }
+      }
+      continue;
+    }
+
+    const parsedKey = parseQuotedObjectKey(text, index);
     if (!parsedKey) {
       return null;
     }
@@ -1169,13 +1278,13 @@ function findTopLevelPropertyValueStart(
   }
 
   let depth = 0;
-  let inString = false;
+  let quoteChar: string | null = null;
   let escaping = false;
 
   for (let index = objectStart; index < text.length; index += 1) {
     const char = text.charAt(index);
 
-    if (inString) {
+    if (quoteChar) {
       if (escaping) {
         escaping = false;
         continue;
@@ -1184,8 +1293,8 @@ function findTopLevelPropertyValueStart(
         escaping = true;
         continue;
       }
-      if (char === '"') {
-        inString = false;
+      if (char === quoteChar) {
+        quoteChar = null;
       }
       continue;
     }
@@ -1199,43 +1308,38 @@ function findTopLevelPropertyValueStart(
       continue;
     }
 
-    if (char !== '"') {
-      continue;
-    }
-
     if (depth !== 1) {
-      inString = true;
+      if (char === '"' || char === "'") {
+        quoteChar = char;
+      }
       continue;
     }
 
-    const keyStart = index + 1;
-    let keyEnd = keyStart;
-    let keyEscaped = false;
-    while (keyEnd < text.length) {
-      const keyChar = text.charAt(keyEnd);
-      if (keyEscaped) {
-        keyEscaped = false;
-      } else if (keyChar === "\\") {
-        keyEscaped = true;
-      } else if (keyChar === '"') {
-        break;
-      }
-      keyEnd += 1;
+    let parsedKey: { key: string; end: number } | null = null;
+    if (char === '"' || char === "'") {
+      parsedKey = parseQuotedObjectKey(text, index);
+    } else if (
+      (previousSignificantChar(text, index) === "{" ||
+        previousSignificantChar(text, index) === ",") &&
+      isUnquotedRjsonKeyStart(char)
+    ) {
+      parsedKey = parseUnquotedObjectKey(text, index);
+    } else {
+      continue;
     }
 
-    if (keyEnd >= text.length || text.charAt(keyEnd) !== '"') {
+    if (!parsedKey) {
       return null;
     }
 
-    const key = text.slice(keyStart, keyEnd);
-    let valueCursor = skipJsonWhitespace(text, keyEnd + 1);
+    let valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
     if (valueCursor >= text.length || text.charAt(valueCursor) !== ":") {
-      index = keyEnd;
+      index = parsedKey.end;
       continue;
     }
 
     valueCursor = skipJsonWhitespace(text, valueCursor + 1);
-    if (key === property) {
+    if (parsedKey.key === property) {
       return valueCursor < text.length ? valueCursor : null;
     }
 

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -22,6 +22,7 @@ import {
   shouldEmitRawToolCallTextOnError,
   stringifyToolInputWithSchema,
 } from "../utils/tool-input-streaming";
+import { argumentValueMatchesSchemaKeyShape } from "./hermes-argument-schema";
 import type { ParserOptions, TCMProtocol } from "./protocol-interface";
 
 interface HermesProtocolOptions {
@@ -624,6 +625,12 @@ function applyArgumentKeyPolicy(
     if (newCoercedKnownKeys.length < rawUnknownKeys.length) {
       return null;
     }
+  }
+  if (
+    keyPolicy &&
+    !argumentValueMatchesSchemaKeyShape(policyArgs, keyPolicy.schema)
+  ) {
+    return null;
   }
   return policyArgs;
 }

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -518,6 +518,7 @@ interface ArgumentKeyPolicy {
   allowUnknownKeys: boolean;
   deniedKeys: Set<string>;
   deniedPatterns: RegExp[];
+  hasUnsafeDeniedPattern: boolean;
   keyPatterns: RegExp[];
   knownKeys: Set<string>;
   schema: unknown;
@@ -541,12 +542,15 @@ function extractArgumentKeyPolicy(
     ? schema.patternProperties
     : {};
   const deniedPatterns: RegExp[] = [];
+  let hasUnsafeDeniedPattern = false;
   const keyPatterns: RegExp[] = [];
   for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
     const regex = compileSafePatternPropertyRegex(pattern);
     if (patternSchema === false) {
       if (regex) {
         deniedPatterns.push(regex);
+      } else {
+        hasUnsafeDeniedPattern = true;
       }
       continue;
     }
@@ -563,6 +567,7 @@ function extractArgumentKeyPolicy(
         .map(([key]) => key)
     ),
     deniedPatterns,
+    hasUnsafeDeniedPattern,
     keyPatterns,
     knownKeys: new Set(
       propertyEntries
@@ -622,8 +627,11 @@ function argumentKeyDeniedByPolicy(
   keyPolicy: ArgumentKeyPolicy
 ): boolean {
   return (
+    PROTOTYPE_SENSITIVE_ARGUMENT_KEYS.has(key) ||
     keyPolicy.deniedKeys.has(key) ||
-    keyPolicy.deniedPatterns.some((pattern) => pattern.test(key))
+    keyPolicy.deniedPatterns.some((pattern) => pattern.test(key)) ||
+    (keyPolicy.hasUnsafeDeniedPattern &&
+      !argumentKeyMatchesPolicy(key, keyPolicy))
   );
 }
 
@@ -684,12 +692,53 @@ function parseQuotedObjectKey(text: string, keyStart: number): {
           return null;
         }
       }
-      return { key: text.slice(keyStart + 1, index), end: index };
+      return {
+        key: parseSingleQuotedObjectKey(text.slice(keyStart + 1, index)),
+        end: index,
+      };
     }
     index += 1;
   }
   return null;
 }
+
+function parseSingleQuotedObjectKey(body: string): string {
+  let result = "";
+  for (let index = 0; index < body.length; index += 1) {
+    const char = body.charAt(index);
+    if (char !== "\\" || index === body.length - 1) {
+      result += char;
+      continue;
+    }
+
+    const escaped = body.charAt(index + 1);
+    if (escaped === "u") {
+      const hex = body.slice(index + 2, index + 6);
+      if (/^[0-9A-Fa-f]{4}$/.test(hex)) {
+        result += String.fromCharCode(Number.parseInt(hex, 16));
+        index += 5;
+        continue;
+      }
+    }
+
+    const decoded = SINGLE_QUOTED_KEY_ESCAPES.get(escaped);
+    result += decoded ?? escaped;
+    index += 1;
+  }
+  return result;
+}
+
+const SINGLE_QUOTED_KEY_ESCAPES = new Map<string, string>([
+  ["'", "'"],
+  ['"', '"'],
+  ["\\", "\\"],
+  ["/", "/"],
+  ["b", "\b"],
+  ["f", "\f"],
+  ["n", "\n"],
+  ["r", "\r"],
+  ["t", "\t"],
+]);
 
 function parseUnquotedObjectKey(text: string, keyStart: number): {
   key: string;
@@ -801,7 +850,7 @@ function strictPolicyHasPrototypeSensitiveArgumentKey(
   argumentsText: string,
   keyPolicy?: ArgumentKeyPolicy
 ): boolean {
-  if (!keyPolicy || keyPolicy.allowUnknownKeys) {
+  if (!keyPolicy) {
     return false;
   }
   const objectStart = skipJsonWhitespace(argumentsText, 0);
@@ -815,7 +864,7 @@ function strictToolCallHasPrototypeSensitiveArgumentKey(
   toolCallJson: string,
   keyPolicy?: ArgumentKeyPolicy
 ): boolean {
-  if (!keyPolicy || keyPolicy.allowUnknownKeys) {
+  if (!keyPolicy) {
     return false;
   }
   const argsValueStart = findTopLevelPropertyValueStart(

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -520,6 +520,20 @@ function extractArgumentKeyPolicy(
   };
 }
 
+function applyArgumentKeyPolicy(
+  args: Record<string, unknown>,
+  keyPolicy?: ArgumentKeyPolicy
+): Record<string, unknown> | null {
+  if (keyPolicy && !keyPolicy.allowUnknownKeys) {
+    for (const key of Object.keys(args)) {
+      if (!keyPolicy.knownKeys.has(key)) {
+        return null;
+      }
+    }
+  }
+  return args;
+}
+
 /** Maximum size (in UTF-16 code units) for the arguments body before bailing out of repair. */
 const REPAIR_MAX_ARGS_BODY_SIZE = 102_400;
 
@@ -619,9 +633,14 @@ function repairToolCallJson(
 
   // 4. Try standard parse first
   try {
+    const parsedArgs = JSON.parse(`{${argsBody}}`) as Record<string, unknown>;
+    const policyArgs = applyArgumentKeyPolicy(parsedArgs, keyPolicy);
+    if (!policyArgs) {
+      return null;
+    }
     return {
       name: toolName,
-      arguments: JSON.parse(`{${argsBody}}`) as Record<string, unknown>,
+      arguments: policyArgs,
     };
   } catch {
     /* fall through to repair */

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -24,8 +24,8 @@ import {
 } from "../utils/tool-input-streaming";
 import {
   argumentValueMatchesSchemaKeyShape,
-  unsafeDeniedPatternMayMatchKey,
 } from "./hermes-argument-schema";
+import { unsafeDeniedPatternMayMatchKey } from "./hermes-unsafe-pattern";
 import type { ParserOptions, TCMProtocol } from "./protocol-interface";
 
 interface HermesProtocolOptions {
@@ -980,6 +980,15 @@ function repairToolCallJson(
   if (argsValueStart == null || raw.charAt(argsValueStart) !== "{") {
     return null;
   }
+  const completeArgsSlice = extractJsonValueSlice(raw, argsValueStart);
+  if (completeArgsSlice?.complete) {
+    const afterArgs = raw
+      .slice(argsValueStart + completeArgsSlice.text.length)
+      .trim();
+    if (!/^}+$/.test(afterArgs)) {
+      return null;
+    }
+  }
   const argsStart = argsValueStart + 1;
 
   // 3. Find closing braces from end (arguments + outer object).
@@ -1315,7 +1324,6 @@ interface StreamState {
   currentToolCallJson: string;
   hasEmittedTextStart: boolean;
   isInsideToolCall: boolean;
-  pendingToolInputProgressVersion: number;
 }
 
 type StreamController =
@@ -1610,73 +1618,6 @@ function emitToolInputDelta(
     state: active,
     fullInput,
     mode: "full-json",
-  });
-}
-
-function emitStreamingToolInputProgress(options: {
-  state: StreamState;
-  controller: StreamController;
-  toolCallJson: string;
-  tools: LanguageModelV3FunctionTool[];
-}): boolean {
-  const { state, controller, toolCallJson, tools } = options;
-  const progress = extractStreamingToolCallProgress(toolCallJson);
-  if (!progress.toolName || !progress.argumentsComplete) {
-    return false;
-  }
-  try {
-    const parsedToolCall = parseRJSON(normalizeJsonStringCtrl(toolCallJson));
-    if (!isParsedToolCallRecord(parsedToolCall)) {
-      return false;
-    }
-    if (hasPrototypeSensitiveKeyInJsonLikeObject(toolCallJson)) {
-      return false;
-    }
-    const policyArguments = applyToolArgumentKeyPolicy(
-      parsedToolCall.name,
-      parsedToolCall.arguments,
-      tools
-    );
-    if (policyArguments === null) {
-      return false;
-    }
-    const input = stringifyToolInputWithSchema({
-      toolName: parsedToolCall.name,
-      args: policyArguments.args,
-      tools,
-      fallback: canonicalizeToolInput,
-    });
-    ensureToolInputStart(state, controller, parsedToolCall.name);
-    emitToolInputDelta(state, controller, input);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function scheduleStreamingToolInputProgress(options: {
-  state: StreamState;
-  controller: StreamController;
-  toolCallJson: string;
-  tools: LanguageModelV3FunctionTool[];
-}) {
-  const { state, controller, toolCallJson, tools } = options;
-  state.pendingToolInputProgressVersion += 1;
-  const version = state.pendingToolInputProgressVersion;
-  setTimeout(() => {
-    if (
-      !state.isInsideToolCall ||
-      state.pendingToolInputProgressVersion !== version ||
-      state.currentToolCallJson !== toolCallJson
-    ) {
-      return;
-    }
-    emitStreamingToolInputProgress({
-      state,
-      controller,
-      toolCallJson,
-      tools,
-    });
   });
 }
 
@@ -2157,8 +2098,7 @@ function handlePartialTag(
   state: StreamState,
   controller: StreamController,
   toolCallStart: string,
-  toolCallEnd: string,
-  tools: LanguageModelV3FunctionTool[]
+  toolCallEnd: string
 ) {
   if (state.isInsideToolCall) {
     const potentialEndIndex = getPotentialStartIndex(state.buffer, toolCallEnd);
@@ -2171,21 +2111,9 @@ function handlePartialTag(
         state,
         controller
       );
-      scheduleStreamingToolInputProgress({
-        state,
-        controller,
-        toolCallJson: state.currentToolCallJson,
-        tools,
-      });
       state.buffer = state.buffer.slice(potentialEndIndex);
     } else {
       publishText(state.buffer, state, controller);
-      scheduleStreamingToolInputProgress({
-        state,
-        controller,
-        toolCallJson: state.currentToolCallJson,
-        tools,
-      });
       state.buffer = "";
     }
     return;
@@ -2321,7 +2249,6 @@ export const hermesProtocol = ({
       currentTextId: null,
       hasEmittedTextStart: false,
       activeToolInput: null,
-      pendingToolInputProgressVersion: 0,
     };
 
     return new TransformStream<
@@ -2356,7 +2283,7 @@ export const hermesProtocol = ({
           options,
           tools,
         });
-        handlePartialTag(state, controller, toolCallStart, toolCallEnd, tools);
+        handlePartialTag(state, controller, toolCallStart, toolCallEnd);
       },
     });
   },

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -1324,6 +1324,8 @@ interface StreamState {
   currentToolCallJson: string;
   hasEmittedTextStart: boolean;
   isInsideToolCall: boolean;
+  pendingToolInputProgressVersion: number;
+  speculativeToolCall: { input: string; toolName: string } | null;
 }
 
 type StreamController =
@@ -1621,6 +1623,77 @@ function emitToolInputDelta(
   });
 }
 
+function emitStreamingToolInputProgress(options: {
+  state: StreamState;
+  controller: StreamController;
+  toolCallJson: string;
+  tools: LanguageModelV3FunctionTool[];
+}): boolean {
+  const { state, controller, toolCallJson, tools } = options;
+  const progress = extractStreamingToolCallProgress(toolCallJson);
+  if (!progress.toolName || !progress.argumentsComplete) {
+    return false;
+  }
+  try {
+    const parsedToolCall = parseRJSON(normalizeJsonStringCtrl(toolCallJson));
+    if (!isParsedToolCallRecord(parsedToolCall)) {
+      return false;
+    }
+    if (hasPrototypeSensitiveKeyInJsonLikeObject(toolCallJson)) {
+      return false;
+    }
+    const policyArguments = applyToolArgumentKeyPolicy(
+      parsedToolCall.name,
+      parsedToolCall.arguments,
+      tools
+    );
+    if (policyArguments === null) {
+      return false;
+    }
+    const input = stringifyToolInputWithSchema({
+      toolName: parsedToolCall.name,
+      args: policyArguments.args,
+      tools,
+      fallback: canonicalizeToolInput,
+    });
+    ensureToolInputStart(state, controller, parsedToolCall.name);
+    emitToolInputDelta(state, controller, input);
+    state.speculativeToolCall = {
+      input,
+      toolName: parsedToolCall.name,
+    };
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function scheduleStreamingToolInputProgress(options: {
+  state: StreamState;
+  controller: StreamController;
+  toolCallJson: string;
+  tools: LanguageModelV3FunctionTool[];
+}) {
+  const { state, controller, toolCallJson, tools } = options;
+  state.pendingToolInputProgressVersion += 1;
+  const version = state.pendingToolInputProgressVersion;
+  setTimeout(() => {
+    if (
+      !state.isInsideToolCall ||
+      state.pendingToolInputProgressVersion !== version ||
+      state.currentToolCallJson !== toolCallJson
+    ) {
+      return;
+    }
+    emitStreamingToolInputProgress({
+      state,
+      controller,
+      toolCallJson,
+      tools,
+    });
+  });
+}
+
 function closeToolInput(state: StreamState, controller: StreamController) {
   if (!state.activeToolInput) {
     return;
@@ -1630,6 +1703,26 @@ function closeToolInput(state: StreamState, controller: StreamController) {
     id: state.activeToolInput.id,
   } as LanguageModelV3StreamPart);
   state.activeToolInput = null;
+}
+
+function emitSpeculativeToolCall(
+  state: StreamState,
+  controller: StreamController
+): boolean {
+  if (!state.activeToolInput || !state.speculativeToolCall) {
+    return false;
+  }
+  const toolCallId = state.activeToolInput.id;
+  const { input, toolName } = state.speculativeToolCall;
+  closeToolInput(state, controller);
+  controller.enqueue({
+    type: "tool-call",
+    toolCallId,
+    toolName,
+    input,
+  } as LanguageModelV3StreamPart);
+  state.speculativeToolCall = null;
+  return true;
 }
 
 function emitToolCallFromParsed(
@@ -1653,6 +1746,7 @@ function emitToolCallFromParsed(
   emitToolInputDelta(state, controller, input);
   const toolCallId = state.activeToolInput?.id ?? generateToolCallId();
   closeToolInput(state, controller);
+  state.speculativeToolCall = null;
   controller.enqueue({
     type: "tool-call",
     toolCallId,
@@ -1896,6 +1990,10 @@ function emitToolCall(context: TagProcessingContext) {
       emitToolCallFromParsed(state, controller, repaired, tools);
       return;
     }
+    const emittedSpeculativeToolCall = emitSpeculativeToolCall(
+      state,
+      controller
+    );
 
     const errorContent = `${toolCallStart}${state.currentToolCallJson}${toolCallEnd}`;
     const shouldEmitRawFallback = shouldEmitRawToolCallTextOnError(options);
@@ -1927,7 +2025,9 @@ function emitToolCall(context: TagProcessingContext) {
         id: errorId,
       } as LanguageModelV3StreamPart);
     }
-    closeToolInput(state, controller);
+    if (!emittedSpeculativeToolCall) {
+      closeToolInput(state, controller);
+    }
     options?.onError?.(
       shouldEmitRawFallback
         ? "Could not process streaming JSON tool call; emitting original text."
@@ -2098,7 +2198,8 @@ function handlePartialTag(
   state: StreamState,
   controller: StreamController,
   toolCallStart: string,
-  toolCallEnd: string
+  toolCallEnd: string,
+  tools: LanguageModelV3FunctionTool[]
 ) {
   if (state.isInsideToolCall) {
     const potentialEndIndex = getPotentialStartIndex(state.buffer, toolCallEnd);
@@ -2111,9 +2212,21 @@ function handlePartialTag(
         state,
         controller
       );
+      scheduleStreamingToolInputProgress({
+        state,
+        controller,
+        toolCallJson: state.currentToolCallJson,
+        tools,
+      });
       state.buffer = state.buffer.slice(potentialEndIndex);
     } else {
       publishText(state.buffer, state, controller);
+      scheduleStreamingToolInputProgress({
+        state,
+        controller,
+        toolCallJson: state.currentToolCallJson,
+        tools,
+      });
       state.buffer = "";
     }
     return;
@@ -2249,6 +2362,8 @@ export const hermesProtocol = ({
       currentTextId: null,
       hasEmittedTextStart: false,
       activeToolInput: null,
+      pendingToolInputProgressVersion: 0,
+      speculativeToolCall: null,
     };
 
     return new TransformStream<
@@ -2283,7 +2398,7 @@ export const hermesProtocol = ({
           options,
           tools,
         });
-        handlePartialTag(state, controller, toolCallStart, toolCallEnd);
+        handlePartialTag(state, controller, toolCallStart, toolCallEnd, tools);
       },
     });
   },

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -550,6 +550,21 @@ function applyArgumentKeyPolicy(
   return args;
 }
 
+function applyToolArgumentKeyPolicy(
+  toolName: string,
+  args: unknown,
+  tools: LanguageModelV3FunctionTool[]
+): { args: unknown } | null {
+  if (!isRecord(args)) {
+    return { args };
+  }
+  const policyArgs = applyArgumentKeyPolicy(
+    args,
+    extractArgumentKeyPolicy(tools, toolName)
+  );
+  return policyArgs === null ? null : { args: policyArgs };
+}
+
 /** Maximum size (in UTF-16 code units) for the arguments body before bailing out of repair. */
 const REPAIR_MAX_ARGS_BODY_SIZE = 102_400;
 
@@ -884,11 +899,19 @@ function processToolCallJson(
       name: string;
       arguments: unknown;
     };
+    const policyArguments = applyToolArgumentKeyPolicy(
+      parsedToolCall.name,
+      parsedToolCall.arguments,
+      tools
+    );
+    if (policyArguments === null) {
+      throw new Error("Tool call arguments contain schema-unknown keys");
+    }
     processedElements.push({
       type: "tool-call",
       toolCallId: generateToolCallId(),
       toolName: parsedToolCall.name,
-      input: canonicalizeToolInput(parsedToolCall.arguments),
+      input: canonicalizeToolInput(policyArguments.args),
     });
   } catch (error) {
     // Attempt repair for unescaped quotes
@@ -1294,9 +1317,17 @@ function canonicalizeArgumentsProgressInput(
     const parsedArguments = parseRJSON(
       normalizeJsonStringCtrl(progress.argumentsText)
     );
+    const policyArguments = applyToolArgumentKeyPolicy(
+      toolName,
+      parsedArguments,
+      tools
+    );
+    if (policyArguments === null) {
+      return undefined;
+    }
     return stringifyToolInputWithSchema({
       toolName,
-      args: parsedArguments,
+      args: policyArguments.args,
       tools,
       fallback: canonicalizeToolInput,
     });
@@ -1319,13 +1350,13 @@ function emitToolInputProgress(
     return;
   }
 
-  ensureToolInputStart(state, controller, progress.toolName);
   const canonicalProgressInput = canonicalizeArgumentsProgressInput(
     progress,
     progress.toolName,
     tools
   );
   if (canonicalProgressInput !== undefined) {
+    ensureToolInputStart(state, controller, progress.toolName);
     emitToolInputDelta(state, controller, canonicalProgressInput);
   }
 }
@@ -1392,7 +1423,20 @@ function emitIncompleteToolCall(
         name: string;
         arguments: unknown;
       };
-      emitToolCallFromParsed(state, controller, parsedToolCall, tools);
+      const policyArguments = applyToolArgumentKeyPolicy(
+        parsedToolCall.name,
+        parsedToolCall.arguments,
+        tools
+      );
+      if (policyArguments === null) {
+        throw new Error("Tool call arguments contain schema-unknown keys");
+      }
+      emitToolCallFromParsed(
+        state,
+        controller,
+        { ...parsedToolCall, arguments: policyArguments.args },
+        tools
+      );
       state.currentToolCallJson = "";
       state.isInsideToolCall = false;
       return;
@@ -1523,7 +1567,20 @@ function emitToolCall(context: TagProcessingContext) {
       name: string;
       arguments: unknown;
     };
-    emitToolCallFromParsed(state, controller, parsedToolCall, tools);
+    const policyArguments = applyToolArgumentKeyPolicy(
+      parsedToolCall.name,
+      parsedToolCall.arguments,
+      tools
+    );
+    if (policyArguments === null) {
+      throw new Error("Tool call arguments contain schema-unknown keys");
+    }
+    emitToolCallFromParsed(
+      state,
+      controller,
+      { ...parsedToolCall, arguments: policyArguments.args },
+      tools
+    );
   } catch (error) {
     // Attempt repair for unescaped quotes
     const repaired = repairToolCallJsonForTools(state.currentToolCallJson, tools);

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -713,7 +713,17 @@ function containsPrototypeSensitiveArgumentKey(
 }
 
 function hasPrototypeSensitiveKeyInJsonLikeObject(text: string): boolean {
-  const firstBrace = text.indexOf("{");
+  let firstBrace = skipJsonWhitespace(text, 0);
+  while (true) {
+    const commentEnd = skipJsonComment(text, firstBrace);
+    if (commentEnd === null) {
+      break;
+    }
+    firstBrace = skipJsonWhitespace(text, commentEnd + 1);
+  }
+  if (text.charAt(firstBrace) !== "{") {
+    firstBrace = text.indexOf("{", firstBrace);
+  }
   if (firstBrace === -1) {
     return false;
   }

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -534,6 +534,55 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function schemaRejectsNonRecordArguments(
+  schema: unknown,
+  seen = new Set<object>()
+): boolean {
+  const unwrapped = unwrapJsonSchema(schema);
+  if (unwrapped === false) {
+    return true;
+  }
+  if (!isRecord(unwrapped)) {
+    return false;
+  }
+  if (seen.has(unwrapped)) {
+    return false;
+  }
+  seen.add(unwrapped);
+  if (unwrapped.additionalProperties === false) {
+    return true;
+  }
+
+  const allOf = Array.isArray(unwrapped.allOf) ? unwrapped.allOf : undefined;
+  if (
+    allOf?.some((subSchema) =>
+      schemaRejectsNonRecordArguments(subSchema, new Set(seen))
+    )
+  ) {
+    return true;
+  }
+
+  const anyOf = Array.isArray(unwrapped.anyOf) ? unwrapped.anyOf : undefined;
+  if (
+    anyOf &&
+    anyOf.length > 0 &&
+    anyOf.every((subSchema) =>
+      schemaRejectsNonRecordArguments(subSchema, new Set(seen))
+    )
+  ) {
+    return true;
+  }
+
+  const oneOf = Array.isArray(unwrapped.oneOf) ? unwrapped.oneOf : undefined;
+  return (
+    oneOf !== undefined &&
+    oneOf.length > 0 &&
+    oneOf.every((subSchema) =>
+      schemaRejectsNonRecordArguments(subSchema, new Set(seen))
+    )
+  );
+}
+
 function extractArgumentKeyPolicy(
   tools: LanguageModelV3FunctionTool[],
   toolName: string
@@ -593,7 +642,7 @@ function extractArgumentKeyPolicy(
         .map(([key]) => key)
     ),
     rejectAll: false,
-    rejectNonRecordArguments: schema.additionalProperties === false,
+    rejectNonRecordArguments: schemaRejectsNonRecordArguments(schema),
     schema,
     unsafeDeniedPatterns,
   };
@@ -651,7 +700,12 @@ function applyArgumentKeyPolicy(
   }
   if (
     keyPolicy &&
-    !argumentValueMatchesSchemaKeyShape(policyArgs, keyPolicy.schema)
+    !argumentValueMatchesSchemaKeyShape(
+      policyArgs,
+      keyPolicy.schema,
+      new Set(),
+      true
+    )
   ) {
     return null;
   }

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -5,6 +5,7 @@ import type {
   LanguageModelV3ToolCall,
 } from "@ai-sdk/provider";
 import { parse as parseRJSON } from "../../rjson";
+import { unwrapJsonSchema } from "../../schema-coerce";
 import { logParseFailure } from "../utils/debug";
 import { getPotentialStartIndex } from "../utils/get-potential-start-index";
 import { generateId, generateToolCallId } from "../utils/id";
@@ -497,6 +498,7 @@ function normalizeJsonStringCtrl(json: string): string {
 
 interface ArgumentKeyPolicy {
   allowUnknownKeys: boolean;
+  keyPatterns: RegExp[];
   knownKeys: Set<string>;
 }
 
@@ -509,13 +511,24 @@ function extractArgumentKeyPolicy(
   toolName: string
 ): ArgumentKeyPolicy | undefined {
   const tool = tools.find((t) => t.name === toolName);
-  const schema = tool?.inputSchema;
+  const schema = unwrapJsonSchema(tool?.inputSchema);
   if (!isRecord(schema)) {
     return undefined;
   }
   const properties = isRecord(schema.properties) ? schema.properties : {};
+  const patternProperties = isRecord(schema.patternProperties)
+    ? schema.patternProperties
+    : {};
+  const keyPatterns: RegExp[] = [];
+  for (const pattern of Object.keys(patternProperties)) {
+    try {
+      keyPatterns.push(new RegExp(pattern));
+    } catch {
+    }
+  }
   return {
     allowUnknownKeys: schema.additionalProperties !== false,
+    keyPatterns,
     knownKeys: new Set(Object.keys(properties)),
   };
 }
@@ -526,7 +539,10 @@ function applyArgumentKeyPolicy(
 ): Record<string, unknown> | null {
   if (keyPolicy && !keyPolicy.allowUnknownKeys) {
     for (const key of Object.keys(args)) {
-      if (!keyPolicy.knownKeys.has(key)) {
+      if (
+        !keyPolicy.knownKeys.has(key) &&
+        !keyPolicy.keyPatterns.some((pattern) => pattern.test(key))
+      ) {
         return null;
       }
     }
@@ -773,13 +789,14 @@ function repairToolCallJson(
     return null;
   }
 
-  const args: Record<string, unknown> = {};
+  const args = Object.create(null) as Record<string, unknown>;
   for (let i = 0; i < allKeys.length; i++) {
     const kp = allKeys[i];
     const rejectsUnknownArgument =
       keyPolicy &&
       !keyPolicy.allowUnknownKeys &&
-      !keyPolicy.knownKeys.has(kp.key);
+      !keyPolicy.knownKeys.has(kp.key) &&
+      !keyPolicy.keyPatterns.some((pattern) => pattern.test(kp.key));
     if (rejectsUnknownArgument) {
       return null;
     }

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -631,6 +631,8 @@ function extractArgumentKeyPolicy(
     }
     if (regex) {
       keyPatterns.push(regex);
+    } else if (patternSchema !== true) {
+      unsafeDeniedPatterns.push(pattern);
     }
   }
   const propertyEntries = Object.entries(properties);
@@ -1891,26 +1893,6 @@ function closeToolInput(state: StreamState, controller: StreamController) {
   state.activeToolInput = null;
 }
 
-function emitSpeculativeToolCall(
-  state: StreamState,
-  controller: StreamController
-): boolean {
-  if (!state.activeToolInput || !state.speculativeToolCall) {
-    return false;
-  }
-  const toolCallId = state.activeToolInput.id;
-  const { input, toolName } = state.speculativeToolCall;
-  closeToolInput(state, controller);
-  controller.enqueue({
-    type: "tool-call",
-    toolCallId,
-    toolName,
-    input,
-  } as LanguageModelV3StreamPart);
-  state.speculativeToolCall = null;
-  return true;
-}
-
 function emitToolCallFromParsed(
   state: StreamState,
   controller: StreamController,
@@ -2178,10 +2160,7 @@ function emitToolCall(context: TagProcessingContext) {
     }
     const activeToolCallId = state.activeToolInput?.id;
     const activeToolName = state.activeToolInput?.toolName;
-    const emittedSpeculativeToolCall = emitSpeculativeToolCall(
-      state,
-      controller
-    );
+    state.speculativeToolCall = null;
 
     const errorContent = `${toolCallStart}${state.currentToolCallJson}${toolCallEnd}`;
     const shouldEmitRawFallback = shouldEmitRawToolCallTextOnError(options);
@@ -2212,9 +2191,7 @@ function emitToolCall(context: TagProcessingContext) {
         id: errorId,
       } as LanguageModelV3StreamPart);
     }
-    if (!emittedSpeculativeToolCall) {
-      closeToolInput(state, controller);
-    }
+    closeToolInput(state, controller);
     options?.onError?.(
       shouldEmitRawFallback
         ? "Could not process streaming JSON tool call; emitting original text."

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -976,13 +976,14 @@ function applyToolArgumentKeyPolicy(
   args: unknown,
   tools: LanguageModelV3FunctionTool[]
 ): { args: unknown } | null {
+  const keyPolicy = extractArgumentKeyPolicy(tools, toolName);
+  if (keyPolicy?.rejectAll) {
+    return null;
+  }
   if (!isRecord(args)) {
     return { args };
   }
-  const policyArgs = applyArgumentKeyPolicy(
-    args,
-    extractArgumentKeyPolicy(tools, toolName)
-  );
+  const policyArgs = applyArgumentKeyPolicy(args, keyPolicy);
   return policyArgs === null ? null : { args: policyArgs };
 }
 
@@ -1433,7 +1434,11 @@ interface StreamState {
   hasEmittedTextStart: boolean;
   isInsideToolCall: boolean;
   pendingToolInputProgressVersion: number;
-  speculativeToolCall: { input: string; toolName: string } | null;
+  speculativeToolCall: {
+    input: string;
+    toolCallJson: string;
+    toolName: string;
+  } | null;
 }
 
 type StreamController =
@@ -1775,6 +1780,7 @@ function emitStreamingToolInputProgress(options: {
     emitToolInputDelta(state, controller, input);
     state.speculativeToolCall = {
       input,
+      toolCallJson,
       toolName: parsedToolCall.name,
     };
     return true;
@@ -1825,6 +1831,10 @@ function emitSpeculativeToolCall(
   controller: StreamController
 ): boolean {
   if (!state.activeToolInput || !state.speculativeToolCall) {
+    return false;
+  }
+  if (state.speculativeToolCall.toolCallJson !== state.currentToolCallJson) {
+    state.speculativeToolCall = null;
     return false;
   }
   const toolCallId = state.activeToolInput.id;

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -495,23 +495,29 @@ function normalizeJsonStringCtrl(json: string): string {
   return parts.join("");
 }
 
-/**
- * Extract known argument key names from the tool schema matching the
- * tool name found in a (possibly malformed) JSON string.
- */
-function extractKnownArgKeys(
+interface ArgumentKeyPolicy {
+  allowUnknownKeys: boolean;
+  knownKeys: Set<string>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function extractArgumentKeyPolicy(
   tools: LanguageModelV3FunctionTool[],
-  toolCallJson: string
-): string[] | undefined {
-  const toolName = extractTopLevelStringProperty(toolCallJson, "name");
-  if (!toolName) {
-    return undefined;
-  }
+  toolName: string
+): ArgumentKeyPolicy | undefined {
   const tool = tools.find((t) => t.name === toolName);
-  if (!tool?.inputSchema?.properties) {
+  const schema = tool?.inputSchema;
+  if (!isRecord(schema)) {
     return undefined;
   }
-  return Object.keys(tool.inputSchema.properties as Record<string, unknown>);
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  return {
+    allowUnknownKeys: schema.additionalProperties !== false,
+    knownKeys: new Set(Object.keys(properties)),
+  };
 }
 
 /** Maximum size (in UTF-16 code units) for the arguments body before bailing out of repair. */
@@ -522,29 +528,21 @@ const FIRST_KEY_RE = /^\s*"([^"]+)"\s*:\s*/;
 const KV_PATTERN_RE = /,\s*"([^"]+)"\s*:\s*/g;
 const TRAILING_COMMA_RE = /,\s*$/;
 
-/**
- * Returns true if `position` in `argsBody` is at nesting depth 0
- * (not inside a nested `{}` or `[]`).
- */
-function isAtTopLevel(argsBody: string, position: number): boolean {
+function getTopLevelPositionMap(argsBody: string): boolean[] {
+  const topLevelAtPosition = Array<boolean>(argsBody.length + 1);
   let depth = 0;
   let inStr = false;
   let esc = false;
-  for (let i = 0; i < position; i++) {
+  topLevelAtPosition[0] = true;
+  for (let i = 0; i < argsBody.length; i++) {
     const ch = argsBody[i];
     if (esc) {
       esc = false;
-      continue;
-    }
-    if (ch === "\\" && inStr) {
+    } else if (ch === "\\" && inStr) {
       esc = true;
-      continue;
-    }
-    if (ch === '"') {
+    } else if (ch === '"') {
       inStr = !inStr;
-      continue;
-    }
-    if (!inStr) {
+    } else if (!inStr) {
       if (ch === "{" || ch === "[") {
         depth++;
       }
@@ -552,8 +550,9 @@ function isAtTopLevel(argsBody: string, position: number): boolean {
         depth--;
       }
     }
+    topLevelAtPosition[i + 1] = depth === 0;
   }
-  return depth === 0;
+  return topLevelAtPosition;
 }
 
 /**
@@ -570,14 +569,9 @@ function isAtTopLevel(argsBody: string, position: number): boolean {
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: JSON repair requires manual character-level scanning with multiple heuristic passes.
 function repairToolCallJson(
   raw: string,
-  knownArgKeys?: string[]
+  toolName: string,
+  keyPolicy?: ArgumentKeyPolicy
 ): { name: string; arguments: Record<string, unknown> } | null {
-  // 1. Extract tool name (depth-aware to avoid matching nested "name" keys)
-  const toolName = extractTopLevelStringProperty(raw, "name");
-  if (!toolName) {
-    return null;
-  }
-
   // 2. Find arguments object boundaries (top-level aware, like name extraction)
   const argsValueStart = findTopLevelPropertyValueStart(raw, "arguments");
   if (argsValueStart == null || raw.charAt(argsValueStart) !== "{") {
@@ -663,11 +657,10 @@ function repairToolCallJson(
   //     value slices, because their ,"extra":... text gets merged into
   //     the previous value. Schema filtering is applied later when
   //     assigning parsed values into args (step 8 below).
-  const knownKeySet =
-    knownArgKeys && knownArgKeys.length > 0 ? new Set(knownArgKeys) : null;
+  const topLevelAtPosition = getTopLevelPositionMap(argsBody);
   allKeys = allKeys.filter(
     (entry) =>
-      entry.matchStart === 0 || isAtTopLevel(argsBody, entry.matchStart)
+      entry.matchStart === 0 || topLevelAtPosition[entry.matchStart]
   );
 
   // 7. Handle duplicate key names with scoring heuristic
@@ -761,14 +754,15 @@ function repairToolCallJson(
     return null;
   }
 
-  // 8. Repair each value by escaping unescaped quotes.
-  //    Schema-unknown keys are skipped here (their slice was still needed
-  //    for correct boundary detection in step 5b).
   const args: Record<string, unknown> = {};
   for (let i = 0; i < allKeys.length; i++) {
     const kp = allKeys[i];
-    if (knownKeySet && !knownKeySet.has(kp.key)) {
-      continue;
+    const rejectsUnknownArgument =
+      keyPolicy &&
+      !keyPolicy.allowUnknownKeys &&
+      !keyPolicy.knownKeys.has(kp.key);
+    if (rejectsUnknownArgument) {
+      return null;
     }
     const vs = kp.valueStart;
     const ve =
@@ -819,13 +813,25 @@ function repairToolCallJson(
       return null;
     }
   }
-  // Guard: if the schema filter skipped every parsed key, we have nothing
-  // meaningful to emit. Returning {arguments: {}} here would trigger a
-  // tool invocation with empty args — worse than reporting parse failure.
-  if (knownKeySet && Object.keys(args).length === 0) {
+  if (Object.keys(args).length === 0) {
     return null;
   }
   return { name: toolName, arguments: args };
+}
+
+function repairToolCallJsonForTools(
+  raw: string,
+  tools: LanguageModelV3FunctionTool[]
+): { name: string; arguments: Record<string, unknown> } | null {
+  const toolName = extractTopLevelStringProperty(raw, "name");
+  if (!toolName) {
+    return null;
+  }
+  return repairToolCallJson(
+    raw,
+    toolName,
+    extractArgumentKeyPolicy(tools, toolName)
+  );
 }
 
 function processToolCallJson(
@@ -850,10 +856,7 @@ function processToolCallJson(
     });
   } catch (error) {
     // Attempt repair for unescaped quotes
-    const repaired = repairToolCallJson(
-      toolCallJson,
-      extractKnownArgKeys(tools, toolCallJson)
-    );
+    const repaired = repairToolCallJsonForTools(toolCallJson, tools);
     if (repaired) {
       processedElements.push({
         type: "tool-call",
@@ -1487,10 +1490,7 @@ function emitToolCall(context: TagProcessingContext) {
     emitToolCallFromParsed(state, controller, parsedToolCall, tools);
   } catch (error) {
     // Attempt repair for unescaped quotes
-    const repaired = repairToolCallJson(
-      state.currentToolCallJson,
-      extractKnownArgKeys(tools, state.currentToolCallJson)
-    );
+    const repaired = repairToolCallJsonForTools(state.currentToolCallJson, tools);
     if (repaired) {
       emitToolCallFromParsed(state, controller, repaired, tools);
       return;

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -695,6 +695,16 @@ function containsPrototypeSensitiveArgumentKey(
   );
 }
 
+function hasPrototypeSensitiveKeyInJsonLikeObject(text: string): boolean {
+  const firstBrace = text.indexOf("{");
+  if (firstBrace === -1) {
+    return false;
+  }
+  return (collectObjectKeys(text, firstBrace, true) ?? []).some((key) =>
+    PROTOTYPE_SENSITIVE_ARGUMENT_KEYS.has(key)
+  );
+}
+
 function isUnquotedRjsonKeyStart(char: string): boolean {
   return (
     char === "_" ||
@@ -810,9 +820,10 @@ function previousSignificantChar(text: string, index: number): string {
   return "";
 }
 
-function collectTopLevelObjectKeys(
+function collectObjectKeys(
   text: string,
-  objectStart: number
+  objectStart: number,
+  includeNested: boolean
 ): string[] | null {
   if (text.charAt(objectStart) !== "{") {
     return null;
@@ -848,10 +859,13 @@ function collectTopLevelObjectKeys(
       }
       continue;
     }
-    if (depth !== 1) {
+    if (depth !== 1 && !includeNested) {
       if (char === '"' || char === "'") {
         quoteChar = char;
       }
+      continue;
+    }
+    if (depth < 1) {
       continue;
     }
 
@@ -888,31 +902,6 @@ function collectTopLevelObjectKeys(
   }
 
   return null;
-}
-
-function strictPolicyHasPrototypeSensitiveArgumentKey(
-  argumentsText: string
-): boolean {
-  const objectStart = skipJsonWhitespace(argumentsText, 0);
-  const keys = collectTopLevelObjectKeys(argumentsText, objectStart);
-  return (
-    keys?.some((key) => PROTOTYPE_SENSITIVE_ARGUMENT_KEYS.has(key)) ?? false
-  );
-}
-
-function strictToolCallHasPrototypeSensitiveArgumentKey(
-  toolCallJson: string
-): boolean {
-  const argsValueStart = findTopLevelPropertyValueStart(
-    toolCallJson,
-    "arguments"
-  );
-  if (argsValueStart == null) {
-    return false;
-  }
-  return strictPolicyHasPrototypeSensitiveArgumentKey(
-    toolCallJson.slice(argsValueStart)
-  );
 }
 
 function applyToolArgumentKeyPolicy(
@@ -982,7 +971,7 @@ function repairToolCallJson(
   toolName: string,
   keyPolicy?: ArgumentKeyPolicy
 ): { name: string; arguments: Record<string, unknown> } | null {
-  if (strictToolCallHasPrototypeSensitiveArgumentKey(raw)) {
+  if (hasPrototypeSensitiveKeyInJsonLikeObject(raw)) {
     return null;
   }
 
@@ -1262,7 +1251,7 @@ function processToolCallJson(
       throw new Error("Tool call object is missing own name or arguments");
     }
     if (
-      strictToolCallHasPrototypeSensitiveArgumentKey(toolCallJson)
+      hasPrototypeSensitiveKeyInJsonLikeObject(toolCallJson)
     ) {
       throw new Error("Tool call arguments contain prototype-sensitive keys");
     }
@@ -1326,6 +1315,7 @@ interface StreamState {
   currentToolCallJson: string;
   hasEmittedTextStart: boolean;
   isInsideToolCall: boolean;
+  pendingToolInputProgressVersion: number;
 }
 
 type StreamController =
@@ -1623,6 +1613,73 @@ function emitToolInputDelta(
   });
 }
 
+function emitStreamingToolInputProgress(options: {
+  state: StreamState;
+  controller: StreamController;
+  toolCallJson: string;
+  tools: LanguageModelV3FunctionTool[];
+}): boolean {
+  const { state, controller, toolCallJson, tools } = options;
+  const progress = extractStreamingToolCallProgress(toolCallJson);
+  if (!progress.toolName || !progress.argumentsComplete) {
+    return false;
+  }
+  try {
+    const parsedToolCall = parseRJSON(normalizeJsonStringCtrl(toolCallJson));
+    if (!isParsedToolCallRecord(parsedToolCall)) {
+      return false;
+    }
+    if (hasPrototypeSensitiveKeyInJsonLikeObject(toolCallJson)) {
+      return false;
+    }
+    const policyArguments = applyToolArgumentKeyPolicy(
+      parsedToolCall.name,
+      parsedToolCall.arguments,
+      tools
+    );
+    if (policyArguments === null) {
+      return false;
+    }
+    const input = stringifyToolInputWithSchema({
+      toolName: parsedToolCall.name,
+      args: policyArguments.args,
+      tools,
+      fallback: canonicalizeToolInput,
+    });
+    ensureToolInputStart(state, controller, parsedToolCall.name);
+    emitToolInputDelta(state, controller, input);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function scheduleStreamingToolInputProgress(options: {
+  state: StreamState;
+  controller: StreamController;
+  toolCallJson: string;
+  tools: LanguageModelV3FunctionTool[];
+}) {
+  const { state, controller, toolCallJson, tools } = options;
+  state.pendingToolInputProgressVersion += 1;
+  const version = state.pendingToolInputProgressVersion;
+  setTimeout(() => {
+    if (
+      !state.isInsideToolCall ||
+      state.pendingToolInputProgressVersion !== version ||
+      state.currentToolCallJson !== toolCallJson
+    ) {
+      return;
+    }
+    emitStreamingToolInputProgress({
+      state,
+      controller,
+      toolCallJson,
+      tools,
+    });
+  });
+}
+
 function closeToolInput(state: StreamState, controller: StreamController) {
   if (!state.activeToolInput) {
     return;
@@ -1726,9 +1783,7 @@ function emitIncompleteToolCall(
         throw new Error("Tool call object is missing own name or arguments");
       }
       if (
-        strictToolCallHasPrototypeSensitiveArgumentKey(
-          state.currentToolCallJson
-        )
+        hasPrototypeSensitiveKeyInJsonLikeObject(state.currentToolCallJson)
       ) {
         throw new Error("Tool call arguments contain prototype-sensitive keys");
       }
@@ -1875,9 +1930,7 @@ function emitToolCall(context: TagProcessingContext) {
       throw new Error("Tool call object is missing own name or arguments");
     }
     if (
-      strictToolCallHasPrototypeSensitiveArgumentKey(
-        state.currentToolCallJson
-      )
+      hasPrototypeSensitiveKeyInJsonLikeObject(state.currentToolCallJson)
     ) {
       throw new Error("Tool call arguments contain prototype-sensitive keys");
     }
@@ -2104,7 +2157,8 @@ function handlePartialTag(
   state: StreamState,
   controller: StreamController,
   toolCallStart: string,
-  toolCallEnd: string
+  toolCallEnd: string,
+  tools: LanguageModelV3FunctionTool[]
 ) {
   if (state.isInsideToolCall) {
     const potentialEndIndex = getPotentialStartIndex(state.buffer, toolCallEnd);
@@ -2117,9 +2171,21 @@ function handlePartialTag(
         state,
         controller
       );
+      scheduleStreamingToolInputProgress({
+        state,
+        controller,
+        toolCallJson: state.currentToolCallJson,
+        tools,
+      });
       state.buffer = state.buffer.slice(potentialEndIndex);
     } else {
       publishText(state.buffer, state, controller);
+      scheduleStreamingToolInputProgress({
+        state,
+        controller,
+        toolCallJson: state.currentToolCallJson,
+        tools,
+      });
       state.buffer = "";
     }
     return;
@@ -2255,6 +2321,7 @@ export const hermesProtocol = ({
       currentTextId: null,
       hasEmittedTextStart: false,
       activeToolInput: null,
+      pendingToolInputProgressVersion: 0,
     };
 
     return new TransformStream<
@@ -2289,7 +2356,7 @@ export const hermesProtocol = ({
           options,
           tools,
         });
-        handlePartialTag(state, controller, toolCallStart, toolCallEnd);
+        handlePartialTag(state, controller, toolCallStart, toolCallEnd, tools);
       },
     });
   },

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -539,7 +539,10 @@ function extractArgumentKeyPolicy(
     ? schema.patternProperties
     : {};
   const keyPatterns: RegExp[] = [];
-  for (const pattern of Object.keys(patternProperties)) {
+  for (const [pattern, patternSchema] of Object.entries(patternProperties)) {
+    if (patternSchema === false) {
+      continue;
+    }
     const regex = compileSafePatternPropertyRegex(pattern);
     if (regex) {
       keyPatterns.push(regex);
@@ -590,6 +593,132 @@ function argumentKeyMatchesPolicy(
   return (
     keyPolicy.knownKeys.has(key) ||
     keyPolicy.keyPatterns.some((pattern) => pattern.test(key))
+  );
+}
+
+const PROTOTYPE_SENSITIVE_ARGUMENT_KEYS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+function parseJsonObjectKey(text: string, keyStart: number): {
+  key: string;
+  end: number;
+} | null {
+  let index = keyStart + 1;
+  let escaped = false;
+  while (index < text.length) {
+    const char = text.charAt(index);
+    if (escaped) {
+      escaped = false;
+    } else if (char === "\\") {
+      escaped = true;
+    } else if (char === '"') {
+      try {
+        return { key: JSON.parse(text.slice(keyStart, index + 1)), end: index };
+      } catch {
+        return null;
+      }
+    }
+    index += 1;
+  }
+  return null;
+}
+
+function collectTopLevelObjectKeys(
+  text: string,
+  objectStart: number
+): string[] | null {
+  if (text.charAt(objectStart) !== "{") {
+    return null;
+  }
+
+  const keys: string[] = [];
+  let depth = 0;
+  let inString = false;
+  let escaping = false;
+
+  for (let index = objectStart; index < text.length; index += 1) {
+    const char = text.charAt(index);
+
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (char === "\\") {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return keys;
+      }
+      continue;
+    }
+    if (char !== '"') {
+      continue;
+    }
+    if (depth !== 1) {
+      inString = true;
+      continue;
+    }
+
+    const parsedKey = parseJsonObjectKey(text, index);
+    if (!parsedKey) {
+      return null;
+    }
+    const valueCursor = skipJsonWhitespace(text, parsedKey.end + 1);
+    if (text.charAt(valueCursor) === ":") {
+      keys.push(parsedKey.key);
+      index = valueCursor;
+      continue;
+    }
+    index = parsedKey.end;
+  }
+
+  return null;
+}
+
+function strictPolicyHasPrototypeSensitiveArgumentKey(
+  argumentsText: string,
+  keyPolicy?: ArgumentKeyPolicy
+): boolean {
+  if (!keyPolicy || keyPolicy.allowUnknownKeys) {
+    return false;
+  }
+  const objectStart = skipJsonWhitespace(argumentsText, 0);
+  const keys = collectTopLevelObjectKeys(argumentsText, objectStart);
+  return (
+    keys?.some((key) => PROTOTYPE_SENSITIVE_ARGUMENT_KEYS.has(key)) ?? false
+  );
+}
+
+function strictToolCallHasPrototypeSensitiveArgumentKey(
+  toolCallJson: string,
+  keyPolicy?: ArgumentKeyPolicy
+): boolean {
+  if (!keyPolicy || keyPolicy.allowUnknownKeys) {
+    return false;
+  }
+  const argsValueStart = findTopLevelPropertyValueStart(
+    toolCallJson,
+    "arguments"
+  );
+  if (argsValueStart == null) {
+    return false;
+  }
+  return strictPolicyHasPrototypeSensitiveArgumentKey(
+    toolCallJson.slice(argsValueStart),
+    keyPolicy
   );
 }
 
@@ -660,6 +789,10 @@ function repairToolCallJson(
   toolName: string,
   keyPolicy?: ArgumentKeyPolicy
 ): { name: string; arguments: Record<string, unknown> } | null {
+  if (strictToolCallHasPrototypeSensitiveArgumentKey(raw, keyPolicy)) {
+    return null;
+  }
+
   // 2. Find arguments object boundaries (top-level aware, like name extraction)
   const argsValueStart = findTopLevelPropertyValueStart(raw, "arguments");
   if (argsValueStart == null || raw.charAt(argsValueStart) !== "{") {
@@ -934,6 +1067,12 @@ function processToolCallJson(
     );
     if (!isParsedToolCallRecord(parsedToolCall)) {
       throw new Error("Tool call object is missing own name or arguments");
+    }
+    const keyPolicy = extractArgumentKeyPolicy(tools, parsedToolCall.name);
+    if (
+      strictToolCallHasPrototypeSensitiveArgumentKey(toolCallJson, keyPolicy)
+    ) {
+      throw new Error("Tool call arguments contain prototype-sensitive keys");
     }
     const policyArguments = applyToolArgumentKeyPolicy(
       parsedToolCall.name,
@@ -1350,14 +1489,24 @@ function canonicalizeArgumentsProgressInput(
   }
 
   try {
+    const keyPolicy = extractArgumentKeyPolicy(tools, toolName);
+    if (
+      strictPolicyHasPrototypeSensitiveArgumentKey(
+        progress.argumentsText,
+        keyPolicy
+      )
+    ) {
+      return undefined;
+    }
     const parsedArguments = parseRJSON(
       normalizeJsonStringCtrl(progress.argumentsText)
     );
-    const policyArguments = applyToolArgumentKeyPolicy(
-      toolName,
-      parsedArguments,
-      tools
-    );
+    if (!isRecord(parsedArguments)) {
+      return undefined;
+    }
+    const policyArgs = applyArgumentKeyPolicy(parsedArguments, keyPolicy);
+    const policyArguments =
+      policyArgs === null ? null : { args: policyArgs };
     if (policyArguments === null) {
       return undefined;
     }
@@ -1458,6 +1607,15 @@ function emitIncompleteToolCall(
       );
       if (!isParsedToolCallRecord(parsedToolCall)) {
         throw new Error("Tool call object is missing own name or arguments");
+      }
+      const keyPolicy = extractArgumentKeyPolicy(tools, parsedToolCall.name);
+      if (
+        strictToolCallHasPrototypeSensitiveArgumentKey(
+          state.currentToolCallJson,
+          keyPolicy
+        )
+      ) {
+        throw new Error("Tool call arguments contain prototype-sensitive keys");
       }
       const policyArguments = applyToolArgumentKeyPolicy(
         parsedToolCall.name,
@@ -1602,6 +1760,15 @@ function emitToolCall(context: TagProcessingContext) {
     );
     if (!isParsedToolCallRecord(parsedToolCall)) {
       throw new Error("Tool call object is missing own name or arguments");
+    }
+    const keyPolicy = extractArgumentKeyPolicy(tools, parsedToolCall.name);
+    if (
+      strictToolCallHasPrototypeSensitiveArgumentKey(
+        state.currentToolCallJson,
+        keyPolicy
+      )
+    ) {
+      throw new Error("Tool call arguments contain prototype-sensitive keys");
     }
     const policyArguments = applyToolArgumentKeyPolicy(
       parsedToolCall.name,

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -524,6 +524,7 @@ interface ArgumentKeyPolicy {
   deniedPatterns: RegExp[];
   keyPatterns: RegExp[];
   knownKeys: Set<string>;
+  rejectAll: boolean;
   schema: unknown;
   unsafeDeniedPatterns: string[];
 }
@@ -538,6 +539,18 @@ function extractArgumentKeyPolicy(
 ): ArgumentKeyPolicy | undefined {
   const tool = tools.find((t) => t.name === toolName);
   const schema = unwrapJsonSchema(tool?.inputSchema);
+  if (schema === false) {
+    return {
+      allowUnknownKeys: false,
+      deniedKeys: new Set(),
+      deniedPatterns: [],
+      keyPatterns: [],
+      knownKeys: new Set(),
+      rejectAll: true,
+      schema,
+      unsafeDeniedPatterns: [],
+    };
+  }
   if (!isRecord(schema)) {
     return undefined;
   }
@@ -577,6 +590,7 @@ function extractArgumentKeyPolicy(
         .filter(([, propertySchema]) => propertySchema !== false)
         .map(([key]) => key)
     ),
+    rejectAll: false,
     schema,
     unsafeDeniedPatterns,
   };
@@ -586,6 +600,9 @@ function applyArgumentKeyPolicy(
   args: Record<string, unknown>,
   keyPolicy?: ArgumentKeyPolicy
 ): Record<string, unknown> | null {
+  if (keyPolicy?.rejectAll) {
+    return null;
+  }
   if (containsPrototypeSensitiveArgumentKey(args)) {
     return null;
   }
@@ -811,13 +828,47 @@ function parseUnquotedObjectKey(text: string, keyStart: number): {
 function previousSignificantChar(text: string, index: number): string {
   let cursor = index - 1;
   while (cursor >= 0) {
-    const char = text.charAt(cursor);
-    if (!/\s/.test(char)) {
-      return char;
+    while (cursor >= 0 && /\s/.test(text.charAt(cursor))) {
+      cursor -= 1;
     }
-    cursor -= 1;
+    if (cursor < 0) {
+      return "";
+    }
+    if (text.charAt(cursor) === "/" && text.charAt(cursor - 1) === "*") {
+      const commentStart = text.lastIndexOf("/*", cursor - 2);
+      if (commentStart === -1) {
+        return "/";
+      }
+      cursor = commentStart - 1;
+      continue;
+    }
+    const lineStart = text.lastIndexOf("\n", cursor) + 1;
+    const lineCommentStart = text.lastIndexOf("//", cursor);
+    if (lineCommentStart >= lineStart) {
+      cursor = lineCommentStart - 1;
+      continue;
+    }
+    return text.charAt(cursor);
   }
   return "";
+}
+
+function skipJsonComment(text: string, index: number): number | null {
+  if (text.charAt(index) !== "/") {
+    return null;
+  }
+  const next = text.charAt(index + 1);
+  if (next === "/") {
+    const lf = text.indexOf("\n", index + 2);
+    const cr = text.indexOf("\r", index + 2);
+    const end = lf === -1 ? cr : cr === -1 ? lf : Math.min(lf, cr);
+    return end === -1 ? text.length - 1 : end - 1;
+  }
+  if (next === "*") {
+    const end = text.indexOf("*/", index + 2);
+    return end === -1 ? text.length - 1 : end + 1;
+  }
+  return null;
 }
 
 function collectObjectKeys(
@@ -848,6 +899,12 @@ function collectObjectKeys(
       continue;
     }
 
+    const commentEnd = skipJsonComment(text, index);
+    if (commentEnd !== null) {
+      index = commentEnd;
+      continue;
+    }
+
     if (char === "{") {
       depth += 1;
       continue;
@@ -870,11 +927,11 @@ function collectObjectKeys(
     }
 
     if (char !== '"' && char !== "'") {
-      if (
-        (previousSignificantChar(text, index) === "{" ||
-          previousSignificantChar(text, index) === ",") &&
-        isUnquotedRjsonKeyStart(char)
-      ) {
+      if (!isUnquotedRjsonKeyStart(char)) {
+        continue;
+      }
+      const previous = previousSignificantChar(text, index);
+      if (previous === "{" || previous === ",") {
         const parsedKey = parseUnquotedObjectKey(text, index);
         if (!parsedKey) {
           return null;
@@ -954,6 +1011,53 @@ function getTopLevelPositionMap(argsBody: string): Uint8Array {
   return topLevelAtPosition;
 }
 
+function hasTrailingTopLevelFieldAfterArgumentsObject(argsBody: string): boolean {
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  const hasCommaAfterWhitespace = (fromIndex: number): boolean => {
+    let cursor = fromIndex;
+    while (cursor < argsBody.length && WHITESPACE_RE.test(argsBody[cursor])) {
+      cursor += 1;
+    }
+    return argsBody.charAt(cursor) === ",";
+  };
+  for (let index = 0; index < argsBody.length; index += 1) {
+    const char = argsBody.charAt(index);
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (inStr) {
+      if (char === "\\") {
+        esc = true;
+      } else if (char === '"') {
+        inStr = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inStr = true;
+      continue;
+    }
+    if (char === "{" || char === "[") {
+      depth += 1;
+      continue;
+    }
+    if (char !== "}" && char !== "]") {
+      continue;
+    }
+    if (depth > 0) {
+      depth -= 1;
+      continue;
+    }
+    if (hasCommaAfterWhitespace(index + 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Attempt to repair a malformed tool-call JSON string where the model
  * failed to escape double-quotes inside string values.  Returns the
@@ -979,15 +1083,6 @@ function repairToolCallJson(
   const argsValueStart = findTopLevelPropertyValueStart(raw, "arguments");
   if (argsValueStart == null || raw.charAt(argsValueStart) !== "{") {
     return null;
-  }
-  const completeArgsSlice = extractJsonValueSlice(raw, argsValueStart);
-  if (completeArgsSlice?.complete) {
-    const afterArgs = raw
-      .slice(argsValueStart + completeArgsSlice.text.length)
-      .trim();
-    if (!/^}+$/.test(afterArgs)) {
-      return null;
-    }
   }
   const argsStart = argsValueStart + 1;
 
@@ -1026,6 +1121,9 @@ function repairToolCallJson(
 
   // Size guard: bail out on unreasonably large argument bodies
   if (argsBody.length > REPAIR_MAX_ARGS_BODY_SIZE) {
+    return null;
+  }
+  if (hasTrailingTopLevelFieldAfterArgumentsObject(argsBody)) {
     return null;
   }
 
@@ -1382,6 +1480,12 @@ function findTopLevelPropertyValueStart(
       continue;
     }
 
+    const commentEnd = skipJsonComment(text, index);
+    if (commentEnd !== null) {
+      index = commentEnd;
+      continue;
+    }
+
     if (char === "{") {
       depth += 1;
       continue;
@@ -1401,14 +1505,15 @@ function findTopLevelPropertyValueStart(
     let parsedKey: { key: string; end: number } | null = null;
     if (char === '"' || char === "'") {
       parsedKey = parseQuotedObjectKey(text, index);
-    } else if (
-      (previousSignificantChar(text, index) === "{" ||
-        previousSignificantChar(text, index) === ",") &&
-      isUnquotedRjsonKeyStart(char)
-    ) {
-      parsedKey = parseUnquotedObjectKey(text, index);
     } else {
-      continue;
+      if (!isUnquotedRjsonKeyStart(char)) {
+        continue;
+      }
+      const previous = previousSignificantChar(text, index);
+      if (previous !== "{" && previous !== ",") {
+        continue;
+      }
+      parsedKey = parseUnquotedObjectKey(text, index);
     }
 
     if (!parsedKey) {

--- a/src/core/protocols/hermes-unsafe-pattern.ts
+++ b/src/core/protocols/hermes-unsafe-pattern.ts
@@ -23,6 +23,26 @@ function pushCharacterClassRange(
   }
 }
 
+function readCharacterClassRangeEnd(
+  pattern: string,
+  index: number
+): { char: string; nextIndex: number; unknown: boolean } | null {
+  const char = pattern.charAt(index);
+  if (char !== "\\") {
+    return { char, nextIndex: index, unknown: false };
+  }
+
+  const escaped = pattern.charAt(index + 1);
+  const literal = readEscapedLiteral(pattern, index + 1);
+  if (literal) {
+    return { char: literal.char, nextIndex: literal.nextIndex, unknown: false };
+  }
+  if ("dDsSwWpP".includes(escaped)) {
+    return { char: "", nextIndex: index + 1, unknown: true };
+  }
+  return { char: escaped, nextIndex: index + 1, unknown: false };
+}
+
 function readEscapedLiteral(
   pattern: string,
   index: number
@@ -91,10 +111,16 @@ function addCharacterClassHints(
       index + 1 < pattern.length &&
       pattern.charAt(index + 1) !== "]"
     ) {
-      const end = pattern.charAt(index + 1);
-      if (isComparableKeyChar(end)) {
-        pushCharacterClassRange(hints.ranges, previous, end);
-        index += 1;
+      const end = readCharacterClassRangeEnd(pattern, index + 1);
+      if (end?.unknown) {
+        hints.hasUnknownMatcher = true;
+        index = end.nextIndex;
+        previous = undefined;
+        continue;
+      }
+      if (end && isComparableKeyChar(end.char)) {
+        pushCharacterClassRange(hints.ranges, previous, end.char);
+        index = end.nextIndex;
         previous = undefined;
         continue;
       }

--- a/src/core/protocols/hermes-unsafe-pattern.ts
+++ b/src/core/protocols/hermes-unsafe-pattern.ts
@@ -227,12 +227,19 @@ export function unsafeDeniedPatternMayMatchKey(
 
   let comparable = 0;
   let matching = 0;
+  let firstComparableMatches = false;
+  let lastComparableMatches = false;
   for (const char of key) {
     if (!isComparableKeyChar(char)) {
       continue;
     }
     comparable += 1;
-    if (characterMayBeMatched(char, hints)) {
+    const matches = characterMayBeMatched(char, hints);
+    if (comparable === 1) {
+      firstComparableMatches = matches;
+    }
+    lastComparableMatches = matches;
+    if (matches) {
       matching += 1;
     }
   }
@@ -248,6 +255,17 @@ export function unsafeDeniedPatternMayMatchKey(
   }
   if (hints.literalRuns.some((run) => run.length >= 2 && key.includes(run))) {
     return true;
+  }
+  const startsAtBoundary = pattern.trimStart().startsWith("^");
+  const endsAtBoundary = pattern.trimEnd().endsWith("$");
+  if (!(startsAtBoundary || endsAtBoundary)) {
+    return true;
+  }
+  if (!startsAtBoundary) {
+    return lastComparableMatches;
+  }
+  if (!endsAtBoundary) {
+    return firstComparableMatches;
   }
   return (
     matching === comparable ||

--- a/src/core/protocols/hermes-unsafe-pattern.ts
+++ b/src/core/protocols/hermes-unsafe-pattern.ts
@@ -1,0 +1,164 @@
+interface CharacterClassRange {
+  end: string;
+  start: string;
+}
+
+interface PatternCharacterHints {
+  hasUnknownMatcher: boolean;
+  literals: Set<string>;
+  ranges: CharacterClassRange[];
+}
+
+function isComparableKeyChar(char: string): boolean {
+  return /^[A-Za-z0-9_-]$/.test(char);
+}
+
+function pushCharacterClassRange(
+  ranges: CharacterClassRange[],
+  start: string,
+  end: string
+) {
+  if (start.length === 1 && end.length === 1) {
+    ranges.push({ start, end });
+  }
+}
+
+function addCharacterClassHints(
+  pattern: string,
+  classStart: number,
+  hints: PatternCharacterHints
+): number {
+  let previous: string | undefined;
+  let escaped = false;
+  for (let index = classStart + 1; index < pattern.length; index += 1) {
+    const char = pattern.charAt(index);
+    if (escaped) {
+      if ("dDsSwWpP".includes(char)) {
+        hints.hasUnknownMatcher = true;
+      } else if (isComparableKeyChar(char)) {
+        hints.literals.add(char);
+        previous = char;
+      }
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === "]") {
+      return index;
+    }
+    if (char === "^" && index === classStart + 1) {
+      hints.hasUnknownMatcher = true;
+      previous = undefined;
+      continue;
+    }
+    if (
+      char === "-" &&
+      previous !== undefined &&
+      index + 1 < pattern.length &&
+      pattern.charAt(index + 1) !== "]"
+    ) {
+      const end = pattern.charAt(index + 1);
+      if (isComparableKeyChar(end)) {
+        pushCharacterClassRange(hints.ranges, previous, end);
+        index += 1;
+        previous = undefined;
+        continue;
+      }
+    }
+    if (isComparableKeyChar(char)) {
+      hints.literals.add(char);
+      previous = char;
+    } else {
+      previous = undefined;
+    }
+  }
+  hints.hasUnknownMatcher = true;
+  return pattern.length;
+}
+
+function collectPatternCharacterHints(pattern: string): PatternCharacterHints {
+  const hints: PatternCharacterHints = {
+    hasUnknownMatcher: false,
+    literals: new Set<string>(),
+    ranges: [],
+  };
+  let escaped = false;
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern.charAt(index);
+    if (escaped) {
+      if ("dDsSwWpP".includes(char)) {
+        hints.hasUnknownMatcher = true;
+      } else if (isComparableKeyChar(char)) {
+        hints.literals.add(char);
+      }
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === "[") {
+      index = addCharacterClassHints(pattern, index, hints);
+      continue;
+    }
+    if (char === ".") {
+      hints.hasUnknownMatcher = true;
+      continue;
+    }
+    if (isComparableKeyChar(char)) {
+      hints.literals.add(char);
+    }
+  }
+  return hints;
+}
+
+function charInRange(char: string, range: CharacterClassRange): boolean {
+  return char >= range.start && char <= range.end;
+}
+
+function characterMayBeMatched(
+  char: string,
+  hints: PatternCharacterHints
+): boolean {
+  return (
+    hints.literals.has(char) ||
+    hints.ranges.some((range) => charInRange(char, range))
+  );
+}
+
+export function unsafeDeniedPatternMayMatchKey(
+  pattern: string,
+  key: string
+): boolean {
+  const hints = collectPatternCharacterHints(pattern);
+  if (hints.literals.size === 0 && hints.ranges.length === 0) {
+    return true;
+  }
+
+  let comparable = 0;
+  let matching = 0;
+  for (const char of key) {
+    if (!isComparableKeyChar(char)) {
+      continue;
+    }
+    comparable += 1;
+    if (characterMayBeMatched(char, hints)) {
+      matching += 1;
+    }
+  }
+
+  if (comparable === 0) {
+    return true;
+  }
+  if (matching === 0 && !hints.hasUnknownMatcher) {
+    return false;
+  }
+  return (
+    matching === comparable ||
+    (key.length >= 16 && matching / comparable >= 0.75)
+  );
+}

--- a/src/core/protocols/hermes-unsafe-pattern.ts
+++ b/src/core/protocols/hermes-unsafe-pattern.ts
@@ -23,6 +23,30 @@ function pushCharacterClassRange(
   }
 }
 
+function readEscapedLiteral(
+  pattern: string,
+  index: number
+): { char: string; nextIndex: number } | null {
+  const escape = pattern.charAt(index);
+  if (escape === "x" && /^[\da-fA-F]{2}$/.test(pattern.slice(index + 1, index + 3))) {
+    return {
+      char: String.fromCharCode(
+        Number.parseInt(pattern.slice(index + 1, index + 3), 16)
+      ),
+      nextIndex: index + 2,
+    };
+  }
+  if (escape === "u" && /^[\da-fA-F]{4}$/.test(pattern.slice(index + 1, index + 5))) {
+    return {
+      char: String.fromCharCode(
+        Number.parseInt(pattern.slice(index + 1, index + 5), 16)
+      ),
+      nextIndex: index + 4,
+    };
+  }
+  return null;
+}
+
 function addCharacterClassHints(
   pattern: string,
   classStart: number,
@@ -33,7 +57,14 @@ function addCharacterClassHints(
   for (let index = classStart + 1; index < pattern.length; index += 1) {
     const char = pattern.charAt(index);
     if (escaped) {
-      if ("dDsSwWpP".includes(char)) {
+      const literal = readEscapedLiteral(pattern, index);
+      if (literal) {
+        if (isComparableKeyChar(literal.char)) {
+          hints.literals.add(literal.char);
+          previous = literal.char;
+        }
+        index = literal.nextIndex;
+      } else if ("dDsSwWpP".includes(char)) {
         hints.hasUnknownMatcher = true;
       } else if (isComparableKeyChar(char)) {
         hints.literals.add(char);
@@ -89,7 +120,13 @@ function collectPatternCharacterHints(pattern: string): PatternCharacterHints {
   for (let index = 0; index < pattern.length; index += 1) {
     const char = pattern.charAt(index);
     if (escaped) {
-      if ("dDsSwWpP".includes(char)) {
+      const literal = readEscapedLiteral(pattern, index);
+      if (literal) {
+        if (isComparableKeyChar(literal.char)) {
+          hints.literals.add(literal.char);
+        }
+        index = literal.nextIndex;
+      } else if ("dDsSwWpP".includes(char)) {
         hints.hasUnknownMatcher = true;
       } else if (isComparableKeyChar(char)) {
         hints.literals.add(char);
@@ -154,7 +191,10 @@ export function unsafeDeniedPatternMayMatchKey(
   if (comparable === 0) {
     return true;
   }
-  if (matching === 0 && !hints.hasUnknownMatcher) {
+  if (hints.hasUnknownMatcher) {
+    return true;
+  }
+  if (matching === 0) {
     return false;
   }
   return (

--- a/src/core/protocols/hermes-unsafe-pattern.ts
+++ b/src/core/protocols/hermes-unsafe-pattern.ts
@@ -5,6 +5,7 @@ interface CharacterClassRange {
 
 interface PatternCharacterHints {
   hasUnknownMatcher: boolean;
+  literalRuns: string[];
   literals: Set<string>;
   ranges: CharacterClassRange[];
 }
@@ -21,6 +22,13 @@ function pushCharacterClassRange(
   if (start.length === 1 && end.length === 1) {
     ranges.push({ start, end });
   }
+}
+
+function pushLiteralRun(hints: PatternCharacterHints, run: string): string {
+  if (run.length > 0) {
+    hints.literalRuns.push(run);
+  }
+  return "";
 }
 
 function readCharacterClassRangeEnd(
@@ -139,10 +147,12 @@ function addCharacterClassHints(
 function collectPatternCharacterHints(pattern: string): PatternCharacterHints {
   const hints: PatternCharacterHints = {
     hasUnknownMatcher: false,
+    literalRuns: [],
     literals: new Set<string>(),
     ranges: [],
   };
   let escaped = false;
+  let literalRun = "";
   for (let index = 0; index < pattern.length; index += 1) {
     const char = pattern.charAt(index);
     if (escaped) {
@@ -150,12 +160,19 @@ function collectPatternCharacterHints(pattern: string): PatternCharacterHints {
       if (literal) {
         if (isComparableKeyChar(literal.char)) {
           hints.literals.add(literal.char);
+          literalRun += literal.char;
+        } else {
+          literalRun = pushLiteralRun(hints, literalRun);
         }
         index = literal.nextIndex;
       } else if ("dDsSwWpP".includes(char)) {
+        literalRun = pushLiteralRun(hints, literalRun);
         hints.hasUnknownMatcher = true;
       } else if (isComparableKeyChar(char)) {
         hints.literals.add(char);
+        literalRun += char;
+      } else {
+        literalRun = pushLiteralRun(hints, literalRun);
       }
       escaped = false;
       continue;
@@ -165,17 +182,23 @@ function collectPatternCharacterHints(pattern: string): PatternCharacterHints {
       continue;
     }
     if (char === "[") {
+      literalRun = pushLiteralRun(hints, literalRun);
       index = addCharacterClassHints(pattern, index, hints);
       continue;
     }
     if (char === ".") {
+      literalRun = pushLiteralRun(hints, literalRun);
       hints.hasUnknownMatcher = true;
       continue;
     }
     if (isComparableKeyChar(char)) {
       hints.literals.add(char);
+      literalRun += char;
+    } else {
+      literalRun = pushLiteralRun(hints, literalRun);
     }
   }
+  pushLiteralRun(hints, literalRun);
   return hints;
 }
 
@@ -222,6 +245,9 @@ export function unsafeDeniedPatternMayMatchKey(
   }
   if (matching === 0) {
     return false;
+  }
+  if (hints.literalRuns.some((run) => run.length >= 2 && key.includes(run))) {
+    return true;
   }
   return (
     matching === comparable ||

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -262,10 +262,37 @@ function schemaIsUnconstrained(schema: unknown): boolean {
   return Object.keys(unwrapped).length === 0;
 }
 
-function hasRegexGroup(pattern: string): boolean {
+interface RegexGroupState {
+  hasAlternation: boolean;
+  hasQuantifier: boolean;
+}
+
+function regexQuantifierEnd(pattern: string, index: number): number | null {
+  const char = pattern.charAt(index);
+  if (char === "*" || char === "+" || char === "?") {
+    return index;
+  }
+  if (char !== "{") {
+    return null;
+  }
+  let cursor = index + 1;
+  while (cursor < pattern.length && pattern.charAt(cursor) !== "}") {
+    const part = pattern.charAt(cursor);
+    if (!(part === "," || (part >= "0" && part <= "9"))) {
+      return null;
+    }
+    cursor += 1;
+  }
+  return cursor < pattern.length ? cursor : null;
+}
+
+function hasNestedQuantifierRisk(pattern: string): boolean {
   let escaped = false;
   let inCharClass = false;
-  for (const ch of pattern) {
+  const groups: RegexGroupState[] = [];
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const ch = pattern.charAt(index);
     if (escaped) {
       escaped = false;
       continue;
@@ -282,17 +309,67 @@ function hasRegexGroup(pattern: string): boolean {
       inCharClass = false;
       continue;
     }
-    if (!inCharClass && ch === "(") {
-      return true;
+    if (inCharClass) {
+      continue;
+    }
+    if (ch === "(") {
+      groups.push({ hasAlternation: false, hasQuantifier: false });
+      continue;
+    }
+    if (ch === ")" && groups.length > 0) {
+      const group = groups.pop();
+      const quantifierEnd = regexQuantifierEnd(pattern, index + 1);
+      if (group && quantifierEnd != null) {
+        if (group.hasAlternation || group.hasQuantifier) {
+          return true;
+        }
+        if (groups.length > 0) {
+          groups[groups.length - 1].hasQuantifier = true;
+        }
+        index = quantifierEnd;
+      }
+      continue;
+    }
+    if (ch === "|" && groups.length > 0) {
+      groups[groups.length - 1].hasAlternation = true;
+      continue;
+    }
+    const quantifierEnd = regexQuantifierEnd(pattern, index);
+    if (quantifierEnd != null) {
+      if (groups.length > 0) {
+        groups[groups.length - 1].hasQuantifier = true;
+      }
+      index = quantifierEnd;
     }
   }
   return false;
 }
 
-function hasUnsafeRegexToken(pattern: string): boolean {
+function findCharClassEnd(pattern: string, start: number): number | null {
+  let escaped = false;
+  for (let index = start + 1; index < pattern.length; index += 1) {
+    const ch = pattern.charAt(index);
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === "]") {
+      return index;
+    }
+  }
+  return null;
+}
+
+function findGroupEnd(pattern: string, start: number): number | null {
   let escaped = false;
   let inCharClass = false;
-  for (const ch of pattern) {
+  let depth = 0;
+  for (let index = start; index < pattern.length; index += 1) {
+    const ch = pattern.charAt(index);
     if (escaped) {
       escaped = false;
       continue;
@@ -309,13 +386,71 @@ function hasUnsafeRegexToken(pattern: string): boolean {
       inCharClass = false;
       continue;
     }
-    if (
-      !inCharClass &&
-      (ch === "|" || ch === "*" || ch === "+" || ch === "?" || ch === "{")
-    ) {
-      return true;
+    if (inCharClass) {
+      continue;
+    }
+    if (ch === "(") {
+      depth += 1;
+      continue;
+    }
+    if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
     }
   }
+  return null;
+}
+
+function hasAdjacentRepeatedQuantifiedAtoms(pattern: string): boolean {
+  let previousQuantifiedAtom: string | null = null;
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const ch = pattern.charAt(index);
+    let atom: string | null = null;
+    let atomEnd = index;
+
+    if (ch === "\\") {
+      atom = pattern.slice(index, Math.min(index + 2, pattern.length));
+      atomEnd = index + 1;
+    } else if (ch === "[") {
+      const classEnd = findCharClassEnd(pattern, index);
+      if (classEnd == null) {
+        return false;
+      }
+      atom = pattern.slice(index, classEnd + 1);
+      atomEnd = classEnd;
+    } else if (ch === "(") {
+      const groupEnd = findGroupEnd(pattern, index);
+      if (groupEnd == null) {
+        return false;
+      }
+      const quantifierEnd = regexQuantifierEnd(pattern, groupEnd + 1);
+      index = quantifierEnd ?? groupEnd;
+      previousQuantifiedAtom = null;
+      continue;
+    } else if (ch === "." || /^[A-Za-z0-9_$-]$/.test(ch)) {
+      atom = ch;
+    } else {
+      previousQuantifiedAtom = null;
+      continue;
+    }
+
+    const quantifierEnd = regexQuantifierEnd(pattern, atomEnd + 1);
+    if (atom && quantifierEnd != null) {
+      if (previousQuantifiedAtom === atom) {
+        return true;
+      }
+      previousQuantifiedAtom = atom;
+      index = quantifierEnd;
+      continue;
+    }
+
+    previousQuantifiedAtom = null;
+    index = atomEnd;
+  }
+
   return false;
 }
 
@@ -325,8 +460,8 @@ export function compileSafePatternPropertyRegex(
   if (
     pattern.length > MAX_PATTERN_PROPERTY_REGEX_LENGTH ||
     REGEX_BACKREFERENCE_REGEX.test(pattern) ||
-    hasRegexGroup(pattern) ||
-    hasUnsafeRegexToken(pattern)
+    hasNestedQuantifierRisk(pattern) ||
+    hasAdjacentRepeatedQuantifiedAtoms(pattern)
   ) {
     return null;
   }

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -286,6 +286,25 @@ function regexQuantifierEnd(pattern: string, index: number): number | null {
   return cursor < pattern.length ? cursor : null;
 }
 
+function regexGroupPrefixEnd(pattern: string, groupStart: number): number | null {
+  if (pattern.charAt(groupStart + 1) !== "?") {
+    return null;
+  }
+  const prefix = pattern.charAt(groupStart + 2);
+  if (prefix === ":" || prefix === "=" || prefix === "!") {
+    return groupStart + 2;
+  }
+  if (prefix !== "<") {
+    return null;
+  }
+  const lookbehindPrefix = pattern.charAt(groupStart + 3);
+  if (lookbehindPrefix === "=" || lookbehindPrefix === "!") {
+    return groupStart + 3;
+  }
+  const nameEnd = pattern.indexOf(">", groupStart + 3);
+  return nameEnd === -1 ? null : nameEnd;
+}
+
 function hasNestedQuantifierRisk(pattern: string): boolean {
   let escaped = false;
   let inCharClass = false;
@@ -314,6 +333,10 @@ function hasNestedQuantifierRisk(pattern: string): boolean {
     }
     if (ch === "(") {
       groups.push({ hasAlternation: false, hasQuantifier: false });
+      const prefixEnd = regexGroupPrefixEnd(pattern, index);
+      if (prefixEnd != null) {
+        index = prefixEnd;
+      }
       continue;
     }
     if (ch === ")" && groups.length > 0) {

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -1389,6 +1389,9 @@ export function coerceBySchema(value: unknown, schema?: unknown): unknown {
 
   const schemaType = getSchemaType(unwrapped);
   const u = unwrapped as Record<string, unknown>;
+  if (value === null && Array.isArray(u.type) && u.type.includes("null")) {
+    return value;
+  }
 
   // Handle string values
   if (typeof value === "string") {

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -289,13 +289,44 @@ function hasRegexGroup(pattern: string): boolean {
   return false;
 }
 
+function hasUnsafeRegexToken(pattern: string): boolean {
+  let escaped = false;
+  let inCharClass = false;
+  for (const ch of pattern) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === "[" && !inCharClass) {
+      inCharClass = true;
+      continue;
+    }
+    if (ch === "]" && inCharClass) {
+      inCharClass = false;
+      continue;
+    }
+    if (
+      !inCharClass &&
+      (ch === "|" || ch === "*" || ch === "+" || ch === "?" || ch === "{")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function compileSafePatternPropertyRegex(
   pattern: string
 ): RegExp | null {
   if (
     pattern.length > MAX_PATTERN_PROPERTY_REGEX_LENGTH ||
     REGEX_BACKREFERENCE_REGEX.test(pattern) ||
-    hasRegexGroup(pattern)
+    hasRegexGroup(pattern) ||
+    hasUnsafeRegexToken(pattern)
   ) {
     return null;
   }

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -11,6 +11,8 @@ const DOUBLE_QUOTE = '"';
 const SNAKE_SEGMENT_REGEX = /_([a-zA-Z0-9])/g;
 const CAMEL_BOUNDARY_REGEX = /([a-z0-9])([A-Z])/g;
 const LEADING_UNDERSCORES_REGEX = /^_+/;
+const REGEX_BACKREFERENCE_REGEX = /\\(?:[1-9]|k<)/;
+const MAX_PATTERN_PROPERTY_REGEX_LENGTH = 128;
 
 export function unwrapJsonSchema(schema: unknown): unknown {
   if (!schema || typeof schema !== "object") {
@@ -260,6 +262,50 @@ function schemaIsUnconstrained(schema: unknown): boolean {
   return Object.keys(unwrapped).length === 0;
 }
 
+function hasRegexGroup(pattern: string): boolean {
+  let escaped = false;
+  let inCharClass = false;
+  for (const ch of pattern) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === "[" && !inCharClass) {
+      inCharClass = true;
+      continue;
+    }
+    if (ch === "]" && inCharClass) {
+      inCharClass = false;
+      continue;
+    }
+    if (!inCharClass && ch === "(") {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function compileSafePatternPropertyRegex(
+  pattern: string
+): RegExp | null {
+  if (
+    pattern.length > MAX_PATTERN_PROPERTY_REGEX_LENGTH ||
+    REGEX_BACKREFERENCE_REGEX.test(pattern) ||
+    hasRegexGroup(pattern)
+  ) {
+    return null;
+  }
+  try {
+    return new RegExp(pattern);
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Gets all schemas from patternProperties that match the given key.
  *
@@ -289,13 +335,9 @@ function getPatternSchemasForKey(
   for (const [pattern, schema] of Object.entries(
     patternProperties as Record<string, unknown>
   )) {
-    try {
-      const regex = new RegExp(pattern);
-      if (regex.test(key)) {
-        schemas.push(schema);
-      }
-    } catch {
-      // Ignore invalid regex patterns.
+    const regex = compileSafePatternPropertyRegex(pattern);
+    if (regex?.test(key)) {
+      schemas.push(schema);
     }
   }
   return schemas;

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -1378,6 +1378,28 @@ function coerceArrayValue(
   return [value];
 }
 
+function coerceByStrictAllOfObjectSchemas(
+  value: unknown,
+  allOf: unknown
+): unknown {
+  if (!Array.isArray(allOf)) {
+    return value;
+  }
+  let output = value;
+  for (const subSchema of allOf) {
+    const unwrapped = unwrapJsonSchema(subSchema);
+    if (
+      unwrapped &&
+      typeof unwrapped === "object" &&
+      !Array.isArray(unwrapped) &&
+      getStrictObjectSchemaInfo(unwrapped as Record<string, unknown>)
+    ) {
+      output = coerceBySchema(output, subSchema);
+    }
+  }
+  return output;
+}
+
 export function coerceBySchema(value: unknown, schema?: unknown): unknown {
   const unwrapped = unwrapJsonSchema(schema);
   if (!unwrapped || typeof unwrapped !== "object") {
@@ -1389,17 +1411,22 @@ export function coerceBySchema(value: unknown, schema?: unknown): unknown {
 
   const schemaType = getSchemaType(unwrapped);
   const u = unwrapped as Record<string, unknown>;
-  if (value === null && Array.isArray(u.type) && u.type.includes("null")) {
-    return value;
+  const valueAfterAllOf = coerceByStrictAllOfObjectSchemas(value, u.allOf);
+  if (
+    valueAfterAllOf === null &&
+    Array.isArray(u.type) &&
+    u.type.includes("null")
+  ) {
+    return valueAfterAllOf;
   }
 
   // Handle string values
-  if (typeof value === "string") {
-    return coerceStringValue(value, schemaType, u);
+  if (typeof valueAfterAllOf === "string") {
+    return coerceStringValue(valueAfterAllOf, schemaType, u);
   }
 
   // Coerce primitive scalars to string when schema explicitly expects a string.
-  const primitiveString = coercePrimitiveToString(value, schemaType);
+  const primitiveString = coercePrimitiveToString(valueAfterAllOf, schemaType);
   if (primitiveString !== null) {
     return primitiveString;
   }
@@ -1407,22 +1434,22 @@ export function coerceBySchema(value: unknown, schema?: unknown): unknown {
   // Handle object to object coercion
   if (
     schemaType === "object" &&
-    value &&
-    typeof value === "object" &&
-    !Array.isArray(value)
+    valueAfterAllOf &&
+    typeof valueAfterAllOf === "object" &&
+    !Array.isArray(valueAfterAllOf)
   ) {
-    return coerceObjectToObject(value as Record<string, unknown>, u);
+    return coerceObjectToObject(valueAfterAllOf as Record<string, unknown>, u);
   }
 
   // Handle object wrappers when schema expects a primitive value.
   if (
-    value &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
+    valueAfterAllOf &&
+    typeof valueAfterAllOf === "object" &&
+    !Array.isArray(valueAfterAllOf) &&
     isPrimitiveSchemaType(schemaType)
   ) {
     const primitiveResult = coerceObjectToPrimitive(
-      value as Record<string, unknown>,
+      valueAfterAllOf as Record<string, unknown>,
       schemaType,
       u
     );
@@ -1438,8 +1465,8 @@ export function coerceBySchema(value: unknown, schema?: unknown): unknown {
       : undefined;
     const itemsSchema = u.items as unknown;
 
-    return coerceArrayValue(value, prefixItems, itemsSchema);
+    return coerceArrayValue(valueAfterAllOf, prefixItems, itemsSchema);
   }
 
-  return value;
+  return valueAfterAllOf;
 }

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -19,7 +19,7 @@ export function unwrapJsonSchema(schema: unknown): unknown {
     return schema;
   }
   const s = schema as Record<string, unknown>;
-  if (s.jsonSchema && typeof s.jsonSchema === "object") {
+  if ("jsonSchema" in s) {
     return unwrapJsonSchema(s.jsonSchema);
   }
   return schema;


### PR DESCRIPTION
## Summary
- close review-work schema blockers on top of #301 without modifying the original PR branch
- reject non-record arguments for object-shaped Hermes schemas, including open object schemas and wrapped `allOf` strict object schemas
- preserve explicit nullable object/array `null` values while rejecting non-nullable typed-property `null`
- avoid counting finite numeric strings as numeric/integer `oneOf` branch matches while still preserving out-of-range numeric strings
- enforce draft-07 tuple `items: [...]`, nested `enum`/`const` oneOf branch selection, strict primitive value validation after coercion, and unsafe constrained `patternProperties`
- stop emitting stale speculative streaming `tool-call` events after later invalid chunks

## Stack Context
This PR is intentionally stacked on #301 via base `fix/repair-malformed-json` and head `codex/pr301-review-fixes`.

Issue #306 and merged PR #307 record that unescaped-quote repair was previously `not planned`. This stacked PR does not decide whether #301 should merge; it only contains the review-work remediation branch requested for #301. The owner should make that product-policy decision before merging the stack.

## Verification
- `pnpm exec vitest run src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts` - 137 passed after final cleanup
- `pnpm exec vitest run src/__tests__/schema-coerce/pattern-property-regex.unit.test.ts src/__tests__/protocols/hermes-protocol/parse-generated-text/json-repair.test.ts src/__tests__/protocols/hermes-protocol/stream/json-repair.test.ts src/__tests__/protocols/cross-protocol/tool-input/streaming-events.hermes-json.test.ts src/__tests__/stream-handler/coercion.test.ts` - 146 passed before final edge-case expansion
- `pnpm check`
- `pnpm test` - 187 files / 1889 tests passed
- `pnpm build`
- `git diff --check`
- LSP diagnostics clean on changed implementation and test files
- built package smoke probes for nullable object/array `null`, numeric-string oneOf branch selection, unsafe constrained patterns, stale speculative stream invalidation, non-nullable `null` rejection, explicit nullable acceptance, open object schema non-record rejection, wrapped strict object schemas, invalid primitive values, unsafe deny substrings, draft-07 tuple items, and oneOf enum/const branches
- GitHub checks on `68fd6a9b2755f36a0764b95e0d3f50e92ce602e6`: TypeScript, Biome, Test Coverage, CodeRabbit, GitGuardian all passed

Stacked on #301 via upstream mirror branch `fix/repair-malformed-json`.