### PR TITLE
refactor: unify Hermes streaming & non-streaming tool-call resolution

### DIFF
--- a/src/__tests__/protocols/hermes-protocol/cross-path-resolve-equivalence.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/cross-path-resolve-equivalence.test.ts
@@ -1,0 +1,175 @@
+import type {
+  LanguageModelV3FunctionTool,
+  LanguageModelV3StreamPart,
+} from "@ai-sdk/provider";
+import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
+import { describe, expect, it, vi } from "vitest";
+import { hermesProtocol } from "../../../core/protocols/hermes-protocol";
+import {
+  pipeWithTransformer,
+  stopFinishReason,
+  zeroUsage,
+} from "../../test-helpers";
+
+vi.mock("@ai-sdk/provider-utils", () => ({
+  generateId: vi.fn(() => "mock-id"),
+}));
+
+// Regression guard for #336: the non-streaming (`parseGeneratedText`) and
+// streaming (`createStreamParser`) Hermes paths now share a single tool-call
+// resolver (`resolveToolCall`). For any input the two paths must agree on the
+// tool calls they ultimately produce. These tests feed identical text to both
+// paths (the whole string at once to streaming) and assert the emitted tool
+// calls — normalized to `{ toolName, input }` with the input re-parsed so the
+// random tool-call ids do not matter — are equal.
+
+function makeTool(
+  name: string,
+  properties: Record<string, { type: string }>,
+  additionalProperties?: boolean
+): LanguageModelV3FunctionTool {
+  return {
+    type: "function",
+    name,
+    inputSchema: {
+      type: "object",
+      properties,
+      ...(additionalProperties === undefined ? {} : { additionalProperties }),
+    },
+  };
+}
+
+interface NormalizedToolCall {
+  input: unknown;
+  toolName: string;
+}
+
+function normalize(input: string, toolName: string): NormalizedToolCall {
+  let parsed: unknown = input;
+  try {
+    parsed = JSON.parse(input);
+  } catch {
+    parsed = input;
+  }
+  return { toolName, input: parsed };
+}
+
+function nonStreamingToolCalls(
+  text: string,
+  tools: LanguageModelV3FunctionTool[]
+): NormalizedToolCall[] {
+  const protocol = hermesProtocol();
+  return protocol
+    .parseGeneratedText({ text, tools })
+    .filter((c) => c.type === "tool-call")
+    .map((c) => normalize((c as { input: string }).input, c.toolName));
+}
+
+async function streamingToolCalls(
+  text: string,
+  tools: LanguageModelV3FunctionTool[]
+): Promise<NormalizedToolCall[]> {
+  const protocol = hermesProtocol();
+  const transformer = protocol.createStreamParser({ tools });
+  const rs = new ReadableStream<LanguageModelV3StreamPart>({
+    start(ctrl) {
+      ctrl.enqueue({ type: "text-delta", id: "1", delta: text });
+      ctrl.enqueue({
+        type: "finish",
+        finishReason: stopFinishReason,
+        usage: zeroUsage,
+      });
+      ctrl.close();
+    },
+  });
+  const out = await convertReadableStreamToArray(
+    pipeWithTransformer(rs, transformer)
+  );
+  return out
+    .filter((c) => c.type === "tool-call")
+    .map((c) => normalize((c as { input: string }).input, c.toolName));
+}
+
+const writeTool = makeTool("write", {
+  path: { type: "string" },
+  content: { type: "string" },
+});
+
+const strictTool = makeTool("search", { query: { type: "string" } }, false);
+
+const cases: Array<{
+  name: string;
+  text: string;
+  tools: LanguageModelV3FunctionTool[];
+}> = [
+  {
+    name: "single valid tool call",
+    text: '<tool_call>{"name":"bash","arguments":{"cmd":"ls"}}</tool_call>',
+    tools: [],
+  },
+  {
+    name: "end tag inside a JSON string value",
+    text: '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}}</tool_call>',
+    tools: [],
+  },
+  {
+    name: "two adjacent calls; first holds an inner end tag in a string",
+    text:
+      '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}}</tool_call>' +
+      '<tool_call>{"name":"ok","arguments":{}}</tool_call>',
+    tools: [],
+  },
+  {
+    name: "valid call recovered after an unclosed/malformed first call",
+    text:
+      '<tool_call>{"name":"bash","arguments":{"cmd":"x </tool_call> y"}} ' +
+      '<tool_call>{"name":"ok","arguments":{}}</tool_call>',
+    tools: [],
+  },
+  {
+    name: "surrounding text with two well-formed calls",
+    text:
+      "before " +
+      '<tool_call>{"name":"a","arguments":{}}</tool_call>' +
+      " middle " +
+      '<tool_call>{"name":"b","arguments":{"n":1}}</tool_call>' +
+      " after",
+    tools: [],
+  },
+  {
+    name: "unescaped quotes repaired via shared resolver",
+    text: '<tool_call>{"name":"write","arguments":{"path":"/tmp/a.txt","content":"use "strict"; var x = 1;"}}</tool_call>',
+    tools: [writeTool],
+  },
+  {
+    name: "schema-aware coercion of a stringified number",
+    text: '<tool_call>{"name":"search","arguments":{"query":"hello"}}</tool_call>',
+    tools: [strictTool],
+  },
+  {
+    name: "schema-unknown key dropped under strict additionalProperties:false",
+    text: '<tool_call>{"name":"search","arguments":{"query":"hi","extra":"nope"}}</tool_call>',
+    tools: [strictTool],
+  },
+  {
+    name: "prototype-sensitive key dropped",
+    text: '<tool_call>{"name":"bash","arguments":{"__proto__":{"polluted":true}}}</tool_call>',
+    tools: [],
+  },
+  {
+    name: "malformed body dropped",
+    text: "<tool_call>{not valid json at all</tool_call>",
+    tools: [],
+  },
+];
+
+describe("hermesProtocol – streaming/non-streaming tool-call resolution parity", () => {
+  it.each(cases)("produces identical tool calls for both paths: $name", async ({
+    text,
+    tools,
+  }) => {
+    const nonStreaming = nonStreamingToolCalls(text, tools);
+    const streaming = await streamingToolCalls(text, tools);
+    expect(streaming).toEqual(nonStreaming);
+  });
+});

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -1691,13 +1691,37 @@ function repairToolCallJsonForTools(
   }
 }
 
-function processToolCallJson(
+/**
+ * Discriminated result of resolving a raw `<tool_call>` JSON body into a final,
+ * emittable tool call. Shared by the non-streaming (`parseGeneratedText` ->
+ * `processToolCallJson`) and streaming (`createStreamParser` -> `emitToolCall`)
+ * paths so both apply identical parse -> validate -> repair semantics. Only the
+ * emission of the success / failure result differs between the two paths.
+ */
+type ResolvedToolCall =
+  | { ok: true; toolName: string; input: string }
+  | { ok: false; error: unknown };
+
+/**
+ * Single source of truth for turning a raw `<tool_call>` JSON body into a
+ * canonical `{ toolName, input }` pair (or a failure). Performs, in order:
+ *
+ *   1. relaxed-JSON parse (with raw control-character normalization)
+ *   2. shape validation (must be an object with a string `name`)
+ *   3. prototype-pollution guard
+ *   4. argument key-policy enforcement
+ *   5. final input stringification (schema-aware)
+ *
+ * On any failure it makes one best-effort repair attempt (e.g. unescaped quotes)
+ * and, if that also fails, reports the originating error. The stringification is
+ * performed inside the same `try` as parsing so that a stringify failure falls
+ * through to the repair path exactly as it did when this logic was inlined in
+ * each caller — the two paths must stay byte-for-byte equivalent here.
+ */
+function resolveToolCall(
   toolCallJson: string,
-  fullMatch: string,
-  processedElements: LanguageModelV3Content[],
-  tools: LanguageModelV3FunctionTool[],
-  options?: ParserOptions
-) {
+  tools: LanguageModelV3FunctionTool[]
+): ResolvedToolCall {
   try {
     const parsedToolCall = parseRJSON(normalizeJsonStringCtrl(toolCallJson));
     if (!isParsedToolCallRecord(parsedToolCall)) {
@@ -1714,58 +1738,75 @@ function processToolCallJson(
     if (policyArguments === null) {
       throw new Error("Tool call arguments contain schema-unknown keys");
     }
-    processedElements.push({
-      type: "tool-call",
-      toolCallId: generateToolCallId(),
+    return {
+      ok: true,
       toolName: parsedToolCall.name,
       input: stringifyParsedToolInput(
         parsedToolCall.name,
         policyArguments.args,
         tools
       ),
-    });
+    };
   } catch (error) {
-    let finalError: unknown = error;
-    // Attempt repair for unescaped quotes
+    // Attempt repair for unescaped quotes (best-effort).
     const repaired = repairToolCallJsonForTools(toolCallJson, tools);
     if (repaired) {
       try {
-        processedElements.push({
-          type: "tool-call",
-          toolCallId: generateToolCallId(),
+        return {
+          ok: true,
           toolName: repaired.name,
           input: stringifyParsedToolInput(
             repaired.name,
             repaired.arguments,
             tools
           ),
-        });
-        return;
+        };
       } catch (repairError) {
-        finalError = repairError;
+        return { ok: false, error: repairError };
       }
     }
-    const salvagedToolName =
-      extractStreamingToolCallProgress(toolCallJson).toolName;
-    const salvagedToolCallId = generateToolCallId();
-    logParseFailure({
-      phase: "generated-text",
-      reason: "Failed to parse tool call JSON segment",
-      snippet: fullMatch,
-      error: finalError,
-    });
-    options?.onError?.(
-      "Could not process JSON tool call, keeping original text.",
-      {
-        toolCall: fullMatch,
-        error: finalError,
-        toolName: salvagedToolName,
-        toolCallId: salvagedToolCallId,
-        dropReason: "malformed-tool-call-body",
-      }
-    );
-    processedElements.push({ type: "text", text: fullMatch });
+    return { ok: false, error };
   }
+}
+
+function processToolCallJson(
+  toolCallJson: string,
+  fullMatch: string,
+  processedElements: LanguageModelV3Content[],
+  tools: LanguageModelV3FunctionTool[],
+  options?: ParserOptions
+) {
+  const resolved = resolveToolCall(toolCallJson, tools);
+  if (resolved.ok) {
+    processedElements.push({
+      type: "tool-call",
+      toolCallId: generateToolCallId(),
+      toolName: resolved.toolName,
+      input: resolved.input,
+    });
+    return;
+  }
+
+  const salvagedToolName =
+    extractStreamingToolCallProgress(toolCallJson).toolName;
+  const salvagedToolCallId = generateToolCallId();
+  logParseFailure({
+    phase: "generated-text",
+    reason: "Failed to parse tool call JSON segment",
+    snippet: fullMatch,
+    error: resolved.error,
+  });
+  options?.onError?.(
+    "Could not process JSON tool call, keeping original text.",
+    {
+      toolCall: fullMatch,
+      error: resolved.error,
+      toolName: salvagedToolName,
+      toolCallId: salvagedToolCallId,
+      dropReason: "malformed-tool-call-body",
+    }
+  );
+  processedElements.push({ type: "text", text: fullMatch });
 }
 
 interface StreamState {
@@ -2247,6 +2288,32 @@ function closeToolInput(state: StreamState, controller: StreamController) {
   state.activeToolInput = null;
 }
 
+/**
+ * Emit a fully-resolved streaming tool call (`toolName` plus an
+ * already-stringified `input`) onto the stream, reconciling any tool-input
+ * deltas already streamed for the in-progress call. Callers are responsible for
+ * closing any open text block first. Shared by `emitToolCallFromParsed` and the
+ * `resolveToolCall`-driven success path in `emitToolCall`.
+ */
+function emitResolvedToolCall(
+  state: StreamState,
+  controller: StreamController,
+  toolName: string,
+  input: string
+) {
+  ensureToolInputStart(state, controller, toolName);
+  emitToolInputDelta(state, controller, input);
+  const toolCallId = state.activeToolInput?.id ?? generateToolCallId();
+  closeToolInput(state, controller);
+  state.speculativeToolCall = null;
+  controller.enqueue({
+    type: "tool-call",
+    toolCallId,
+    toolName,
+    input,
+  } as LanguageModelV3StreamPart);
+}
+
 function emitToolCallFromParsed(
   state: StreamState,
   controller: StreamController,
@@ -2264,17 +2331,7 @@ function emitToolCallFromParsed(
     tools,
     fallback: canonicalizeToolInput,
   });
-  ensureToolInputStart(state, controller, toolName);
-  emitToolInputDelta(state, controller, input);
-  const toolCallId = state.activeToolInput?.id ?? generateToolCallId();
-  closeToolInput(state, controller);
-  state.speculativeToolCall = null;
-  controller.enqueue({
-    type: "tool-call",
-    toolCallId,
-    toolName,
-    input,
-  } as LanguageModelV3StreamPart);
+  emitResolvedToolCall(state, controller, toolName, input);
 }
 
 function flushBuffer(
@@ -2476,92 +2533,62 @@ function publishText(
 function emitToolCall(context: TagProcessingContext) {
   const { state, controller, toolCallStart, toolCallEnd, options, tools } =
     context;
-  try {
-    const parsedToolCall = parseRJSON(
-      normalizeJsonStringCtrl(state.currentToolCallJson)
-    );
-    if (!isParsedToolCallRecord(parsedToolCall)) {
-      throw new Error("Tool call object is missing own name or arguments");
-    }
-    if (hasPrototypeSensitiveKeyInJsonLikeObject(state.currentToolCallJson)) {
-      throw new Error("Tool call arguments contain prototype-sensitive keys");
-    }
-    const policyArguments = applyToolArgumentKeyPolicy(
-      parsedToolCall.name,
-      parsedToolCall.arguments,
-      tools
-    );
-    if (policyArguments === null) {
-      throw new Error("Tool call arguments contain schema-unknown keys");
-    }
-    emitToolCallFromParsed(
-      state,
-      controller,
-      { ...parsedToolCall, arguments: policyArguments.args },
-      tools
-    );
-  } catch (error) {
-    let finalError: unknown = error;
-    // Attempt repair for unescaped quotes
-    const repaired = repairToolCallJsonForTools(
-      state.currentToolCallJson,
-      tools
-    );
-    if (repaired) {
-      try {
-        emitToolCallFromParsed(state, controller, repaired, tools);
-        return;
-      } catch (repairError) {
-        finalError = repairError;
-      }
-    }
-    const activeToolCallId = state.activeToolInput?.id;
-    const activeToolName = state.activeToolInput?.toolName;
-    state.speculativeToolCall = null;
-
-    const errorContent = `${toolCallStart}${state.currentToolCallJson}${toolCallEnd}`;
-    const shouldEmitRawFallback = shouldEmitRawToolCallTextOnError(options);
-    const streamingToolCallId = activeToolCallId ?? generateToolCallId();
-    const streamingToolName =
-      activeToolName ??
-      extractStreamingToolCallProgress(state.currentToolCallJson).toolName;
-
-    logParseFailure({
-      phase: "stream",
-      reason: "Failed to parse streaming tool call JSON segment",
-      snippet: errorContent,
-      error: finalError,
-    });
-    if (shouldEmitRawFallback) {
-      const errorId = generateId();
-      controller.enqueue({
-        type: "text-start",
-        id: errorId,
-      } as LanguageModelV3StreamPart);
-      controller.enqueue({
-        type: "text-delta",
-        id: errorId,
-        delta: errorContent,
-      } as LanguageModelV3StreamPart);
-      controller.enqueue({
-        type: "text-end",
-        id: errorId,
-      } as LanguageModelV3StreamPart);
-    }
-    closeToolInput(state, controller);
-    options?.onError?.(
-      shouldEmitRawFallback
-        ? "Could not process streaming JSON tool call; emitting original text."
-        : "Could not process streaming JSON tool call.",
-      {
-        toolCall: errorContent,
-        error: finalError,
-        toolCallId: streamingToolCallId,
-        toolName: streamingToolName,
-        dropReason: "malformed-tool-call-body",
-      }
-    );
+  const resolved = resolveToolCall(state.currentToolCallJson, tools);
+  if (resolved.ok) {
+    // Mirror the original emit order: close any open text block before
+    // streaming the tool-input lifecycle (was inside emitToolCallFromParsed).
+    closeTextBlock(state, controller);
+    emitResolvedToolCall(state, controller, resolved.toolName, resolved.input);
+    return;
   }
+
+  const finalError = resolved.error;
+  const activeToolCallId = state.activeToolInput?.id;
+  const activeToolName = state.activeToolInput?.toolName;
+  state.speculativeToolCall = null;
+
+  const errorContent = `${toolCallStart}${state.currentToolCallJson}${toolCallEnd}`;
+  const shouldEmitRawFallback = shouldEmitRawToolCallTextOnError(options);
+  const streamingToolCallId = activeToolCallId ?? generateToolCallId();
+  const streamingToolName =
+    activeToolName ??
+    extractStreamingToolCallProgress(state.currentToolCallJson).toolName;
+
+  logParseFailure({
+    phase: "stream",
+    reason: "Failed to parse streaming tool call JSON segment",
+    snippet: errorContent,
+    error: finalError,
+  });
+  if (shouldEmitRawFallback) {
+    const errorId = generateId();
+    controller.enqueue({
+      type: "text-start",
+      id: errorId,
+    } as LanguageModelV3StreamPart);
+    controller.enqueue({
+      type: "text-delta",
+      id: errorId,
+      delta: errorContent,
+    } as LanguageModelV3StreamPart);
+    controller.enqueue({
+      type: "text-end",
+      id: errorId,
+    } as LanguageModelV3StreamPart);
+  }
+  closeToolInput(state, controller);
+  options?.onError?.(
+    shouldEmitRawFallback
+      ? "Could not process streaming JSON tool call; emitting original text."
+      : "Could not process streaming JSON tool call.",
+    {
+      toolCall: errorContent,
+      error: finalError,
+      toolCallId: streamingToolCallId,
+      toolName: streamingToolName,
+      dropReason: "malformed-tool-call-body",
+    }
+  );
 }
 
 function processTagMatch(context: TagProcessingContext) {


### PR DESCRIPTION
Closes #336.

## What

Unifies the **non-streaming** (`parseGeneratedText` → `processToolCallJson`) and **streaming** (`createStreamParser` → `emitToolCall`) Hermes paths onto a single tool-call resolver, removing the last piece of duplicated parser logic that @cubic-dev-ai flagged on #299.

- **New `resolveToolCall(json, tools)`** — the single source of truth for turning a raw `<tool_call>` body into a final `{ toolName, input }` (or a failure). It performs, in order: relaxed-JSON parse (with control-char normalization) → shape validation → prototype-pollution guard → argument key-policy → schema-aware stringify, with one best-effort repair attempt on any failure. Both paths now call it; only the *emission* of the result (push to a content array vs. drive the streaming lifecycle / `onError`) stays path-specific.
- **`emitResolvedToolCall`** — extracted from `emitToolCallFromParsed`'s emit tail so the streaming success path can emit an already-resolved call. The head of `emitToolCallFromParsed` (still used by `emitIncompleteToolCall`) is otherwise unchanged.

The lower-level boundary scanner (`findToolCallBoundaryOutsideRjsonSyntax`) was **already** shared by both paths — that part of the asymmetry was resolved in #299/#307. This PR removes the remaining duplication: the ~40-line parse → validate → repair block that was copy-pasted between the two callers.

## No behavioral change

This is a pure refactor. Verification:

- **Full suite green**: 1926 tests (1916 existing + 10 new), `tsc` clean, `biome` clean, build OK.
- **New cross-path equivalence test** (`cross-path-resolve-equivalence.test.ts`): feeds an identical corpus (valid calls, end-tags inside strings, adjacent/recovered calls, unescaped-quote repair, schema coercion, dropped schema-unknown / prototype-sensitive keys, malformed bodies) to **both** paths and asserts they emit identical tool calls. This locks in the unification and guards against future drift — the root cause of #303/#336.
- **Adversarial differential review**: confirmed byte-for-byte equivalence of the parse/validate/repair control flow, streaming emission ordering/side-effects, and the full `onError` metadata (`toolCall`, `toolName`, `toolCallId`, `dropReason`, `error`, messages, raw-text fallback) across both paths — including a 60-case runtime differential harness (whole-text / single-chunk / char-by-char streaming) that found no divergence.

### A note on `closeTextBlock` ordering

The original streaming path called `closeTextBlock` *inside* `emitToolCallFromParsed` before stringifying; the new path stringifies in the pure `resolveToolCall` and calls `closeTextBlock` only on the success branch of `emitToolCall`. This is **not observable**: every `emitToolCall` entry is reached via `publishText(..., isInsideToolCall=true)`, which has already closed any open text block, so `state.currentTextId` is `null` on entry and `closeTextBlock` is a no-op there in both versions.

## Out of scope (intentionally)

The two top-level *iteration* loops (`parseGeneratedText`'s `findNextToolCallSpan` walk vs. the streaming `processBufferTags`/`getPotentialStartIndex` machinery) are **not** merged. Streaming is inherently incremental — partial delimiters at chunk boundaries, progressive `tool-input-start`/`tool-input-delta` emission, cross-chunk state — so a forced merge would add risk without removing real duplication. The scanning *rules* they apply are already shared via `findToolCallBoundaryOutsideRjsonSyntax`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Hermes tool-call resolution for streaming and non-streaming into a single resolver to remove duplicated logic and keep behavior consistent. No behavior change.

- **Refactors**
  - Added `resolveToolCall(json, tools)` as the single source of truth; used by non-streaming `parseGeneratedText` and streaming `emitToolCall`.
  - Extracted `emitResolvedToolCall` to emit pre-resolved calls in streaming.
  - Added cross-path equivalence test `cross-path-resolve-equivalence.test.ts` to lock parity between both paths.

<sup>Written for commit 3297a81963fbb35239929ed8c17a5fdfb74561e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

