### PR TITLE
[codex] add stable dependency refresh changeset

### DIFF
--- a/.changeset/stable-dependency-refresh.md
+++ b/.changeset/stable-dependency-refresh.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+Refresh the AI SDK v6 dependency stack and development tooling, including
+provider-utils security hardening.


### PR DESCRIPTION
## Summary

- adds the missing patch changeset for the dependency refresh merged in #338
- lets the stable AI SDK v6 line publish a patch release instead of silently carrying dependency updates without a package version

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check:types`
- `pnpm test` (191 files, 1926 tests)
- `pnpm check:biome`
- `pnpm build`

## Release impact

Targets `main`; after merge, Release Changeset should open a Version Packages PR for the next stable patch (`4.1.26`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a missing patch changeset so the stable v6 dependency refresh ships as a proper release. This publishes a patch for `@ai-sdk-tool/parser` with the recent dependency and tooling updates.

- **Dependencies**
  - Adds `.changeset/stable-dependency-refresh.md` to capture the v6 dependency stack refresh and dev tooling updates, including provider-utils security hardening.
  - Triggers the next stable patch release (`4.1.26`) via Changesets.

<sup>Written for commit b09ffc6c7634a3822724f805b94deac7453089b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

