### PR TITLE
chore: pin npm registry for types packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+@types:registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
- add a repo-root .npmrc that keeps the default registry on npmjs.org
- explicitly resolve the @types scope through npmjs.org so Dependabot does not ask GitHub Packages for @types/node

## Validation
- pnpm config get registry
- pnpm config get @types:registry
- pnpm install --frozen-lockfile
- pnpm check
- pnpm build
- pnpm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a root `.npmrc` to pin the default registry to npmjs.org. Force the `@types` scope to resolve from npmjs.org so Dependabot stops querying GitHub Packages for `@types/node`.

<sup>Written for commit 4d8bb5813b4b65c5d5b04505398df8954f872d3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

