### PR TITLE
fix: close v7 generate/stream parity gaps and harden parsing against live model quirks

### DIFF
--- a/.changeset/violet-donuts-repair.md
+++ b/.changeset/violet-donuts-repair.md
@@ -21,4 +21,12 @@ Fixes:
 - YAML-XML streaming no longer withholds a fixed `maxTagLen - 1` tail on every chunk; only genuine partial tool-tag suffixes are held back.
 - JSON-candidate recovery now rejects prototype-sensitive keys (`__proto__`, `constructor`, `prototype`) textually, closing a gap where relaxed-JSON parsing could absorb them past the post-parse guard.
 
+Additional hardening from a second live matrix over 12 more models (DeepSeek V3.2, GLM-5, MiniMax M2.5, Ministral 8B, Nemotron Nano 9B, Granite 4.0, Nova 2 Lite, Seed 2.0 Mini, Solar Pro 3, Llama 3.3 70B, Qwen3 30B-A3B, Step 3.5 Flash):
+
+- Hermes accepts double-encoded `arguments` (a JSON string containing the object — the OpenAI native wire habit, observed live on IBM Granite 4.0) in both parse paths, still subject to the argument key policy.
+- Array-wrapped call lists (`<tool_call>[{...}, {...}]</tool_call>`, observed live on ByteDance Seed 2.0) are salvaged into individual tool calls in both parse paths.
+- The generic JSON recovery accepts `tool`/`parameters` envelope key aliases (observed live on NVIDIA Nemotron Nano) and unwraps double-encoded arguments.
+- YAML-XML falls back to parsing `<key>value</key>` child tags when the tool body is XML instead of YAML (observed live on Amazon Nova 2 Lite).
+- The streaming recovery stage also holds blocks that start with a JSON array or a literal `<tool_call>` tag leaking through a foreign protocol.
+
 Internal: dead `speculativeToolCall` state and an unreachable `flushBuffer` branch were removed from the Hermes stream parser.

--- a/.changeset/violet-donuts-repair.md
+++ b/.changeset/violet-donuts-repair.md
@@ -1,0 +1,24 @@
+---
+"@ai-sdk-tool/parser": minor
+---
+
+Close generate/stream behavior gaps found by auditing the AI SDK v7 (provider v4) spec surface and by live-testing every protocol against current open models (GLM-4.7, Qwen2.5, Kimi K2.5, gpt-oss, Llama 3.1).
+
+Features:
+
+- `toolChoice: { type: "none" }` is now supported instead of throwing. Tool definitions are not injected, tool-call history is still serialized, and both wrap handlers pass the model output through without tool parsing.
+- Streaming bare-JSON tool-call recovery: text blocks that consist of a bare `{"name": ..., "arguments": ...}` payload (or a fenced ```json block) are now recovered into proper tool calls in `streamText`, matching the long-standing generate-path recovery. Observed live on GLM-4.7 with the Hermes protocol, which previously leaked the JSON as visible text.
+- JSON-candidate recovery is now multi-call: consecutive payloads separated by newlines or orphan `<tool_call>` tags (GLM-4.7's parallel-call shape, previously 0 recovered calls) are all recovered, in both generate and stream paths.
+- Forced-tool-choice streams now emit the full spec lifecycle: `stream-start` (with the underlying model's warnings), `tool-input-start`/`tool-input-delta`/`tool-input-end` reconciled to the final `tool-call` id, and `finish` carrying the model's `providerMetadata`.
+
+Fixes:
+
+- `wrapGenerate` now rewrites `finishReason` to `tool-calls` when tool calls were parsed from text (parity with the stream path and native providers); meaningful reasons like `length` are preserved. The stream-path rewrite now also covers `unified: "other"`.
+- Canonical v4 `type: "file"` tool-result content parts (tagged `data`/`url`/`reference`/`text` file data) are now normalized properly instead of degrading to `[Unknown content]`.
+- Hermes: tool calls closed with a mismatched tag (e.g. `<tool_call>{...}</think>`, observed live on GLM-4.7) are salvaged in both parse paths, with the same argument key policy and prototype-pollution guards as the primary parser. Orphan `<tool_call>` fragments no longer leak into recovered text.
+- Qwen3-Coder: the nameless `<parameter>city</parameter>Seoul` variant (observed live on Qwen2.5-7B, which previously produced empty `{}` inputs) is now parsed in both generate and stream paths.
+- Qwen3-Coder streaming no longer freezes text delivery until finish when prose contains tag-like substrings such as `<callback>` or `<toolbar>`.
+- YAML-XML streaming no longer withholds a fixed `maxTagLen - 1` tail on every chunk; only genuine partial tool-tag suffixes are held back.
+- JSON-candidate recovery now rejects prototype-sensitive keys (`__proto__`, `constructor`, `prototype`) textually, closing a gap where relaxed-JSON parsing could absorb them past the post-parse guard.
+
+Internal: dead `speculativeToolCall` state and an unreachable `flushBuffer` branch were removed from the Hermes stream parser.

--- a/.changeset/violet-donuts-repair.md
+++ b/.changeset/violet-donuts-repair.md
@@ -29,4 +29,11 @@ Additional hardening from a second live matrix over 12 more models (DeepSeek V3.
 - YAML-XML falls back to parsing `<key>value</key>` child tags when the tool body is XML instead of YAML (observed live on Amazon Nova 2 Lite).
 - The streaming recovery stage also holds blocks that start with a JSON array or a literal `<tool_call>` tag leaking through a foreign protocol.
 
+A third pass with schema-diversity scenarios (nested objects, arrays, code content with quotes/newlines, no-arg tools, multi-tool selection, unicode values) across 14 more models (Kimi K2.6, Cohere Command R+, AI21 Jamba, LiquidAI LFM2, LG EXAONE, Longcat, Xiaomi MiMo, Tencent HY3, KAT Coder, Gemma 4, Mistral Small, Cogito 671B + controls) hardened:
+
+- schema coercion: object/array-typed parameters delivered as strings now parse through strict JSON → relaxed JSON → Python-literal normalization (`True`/`False`/`None`, observed on KAT Coder) → line-oriented XML children (observed on Cohere Command R+), with prototype-key guards.
+- cross-format recovery: the shared recovery layer now also resolves Qwen-style `<function=name><parameter=key>value` blocks (Step 3.5 Flash emits these under every prompt) and `<tool_call>` blocks with YAML mapping bodies closed by arbitrary tags (IBM Granite 4.0's native shape), in every middleware.
+- hermes: invalid JSON escapes inside string values (e.g. `\$` from template literals in generated code, observed on Command R+) are normalized before parsing.
+- qwen3coder: Hermes-style JSON payloads inside `<tool_call>` tags (observed on LiquidAI LFM2) are salvaged at stream finish instead of dropped.
+
 Internal: dead `speculativeToolCall` state and an unreachable `flushBuffer` branch were removed from the Hermes stream parser.

--- a/README.md
+++ b/README.md
@@ -119,11 +119,18 @@ export const myToolMiddleware = createToolMiddleware({
 });
 ```
 
+## Tool choice
+
+- `toolChoice: "auto"` (default) parses tool calls out of the model text.
+- `toolChoice: "required"` and `toolChoice: { type: "tool", toolName }` are emulated through JSON `responseFormat` constraints.
+- `toolChoice: "none"` skips tool prompt injection and tool-call parsing entirely; tool-call history in the conversation is still serialized to text.
+
 ## Streaming semantics
 
 - Stream parsers emit `tool-input-start`, `tool-input-delta`, and `tool-input-end` when a tool input can be incrementally reconstructed.
 - `tool-input-start.id`, `tool-input-end.id`, and final `tool-call.toolCallId` are reconciled to the same ID.
 - `emitRawToolCallTextOnError` defaults to `false`; malformed tool-call markup is suppressed from `text-delta` unless explicitly enabled.
+- Text blocks that consist of a bare `{"name": ..., "arguments": ...}` payload (or a fenced ```json block) for a known tool are recovered into tool calls in both generate and stream paths, and `finishReason` is normalized to `tool-calls` whenever tool calls were parsed.
 
 Configure parser error behavior through `providerOptions.toolCallMiddleware`:
 

--- a/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
+++ b/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
@@ -504,3 +504,115 @@ describe("normalizeToolResultForUserContent", () => {
     ]);
   });
 });
+
+describe("canonical v4 file content parts", () => {
+  const contentWith = (part: unknown) =>
+    ({ type: "content", value: [part] }) as Parameters<
+      typeof unwrapToolResult
+    >[0];
+
+  it("renders a placeholder for inline file data", () => {
+    expect(
+      unwrapToolResult(
+        contentWith({
+          type: "file",
+          data: { type: "data", data: "aGVsbG8=" },
+          mediaType: "application/pdf",
+          filename: "report.pdf",
+        })
+      )
+    ).toBe("[File: report.pdf (application/pdf)]");
+  });
+
+  it("renders an image placeholder for image media types", () => {
+    expect(
+      unwrapToolResult(
+        contentWith({
+          type: "file",
+          data: { type: "data", data: "aGVsbG8=" },
+          mediaType: "image/png",
+        })
+      )
+    ).toBe("[Image: image/png]");
+  });
+
+  it("renders url-backed file parts as URL placeholders", () => {
+    expect(
+      unwrapToolResult(
+        contentWith({
+          type: "file",
+          data: { type: "url", url: "https://example.com/doc.pdf" },
+          mediaType: "application/pdf",
+        })
+      )
+    ).toBe("[File URL: https://example.com/doc.pdf]");
+
+    expect(
+      unwrapToolResult(
+        contentWith({
+          type: "file",
+          data: { type: "url", url: "https://example.com/cat.png" },
+          mediaType: "image/png",
+        })
+      )
+    ).toBe("[Image URL: https://example.com/cat.png]");
+  });
+
+  it("renders provider references as ID placeholders", () => {
+    expect(
+      unwrapToolResult(
+        contentWith({
+          type: "file",
+          data: { type: "reference", reference: { openai: "file-123" } },
+          mediaType: "application/pdf",
+        })
+      )
+    ).toBe('[File ID: {"openai":"file-123"}]');
+  });
+
+  it("surfaces inline text documents as their text", () => {
+    expect(
+      unwrapToolResult(
+        contentWith({
+          type: "file",
+          data: { type: "text", text: "inline document body" },
+          mediaType: "text/plain",
+        })
+      )
+    ).toBe("inline document body");
+  });
+
+  it("mixes file placeholders with text parts", () => {
+    expect(
+      unwrapToolResult({
+        type: "content",
+        value: [
+          { type: "text", text: "see attachment" },
+          {
+            type: "file",
+            data: { type: "data", data: "aGVsbG8=" },
+            mediaType: "image/jpeg",
+          },
+        ],
+      } as Parameters<typeof unwrapToolResult>[0])
+    ).toBe("see attachment\n[Image: image/jpeg]");
+  });
+
+  it("passes canonical file parts through unchanged in model mode", () => {
+    const filePart = {
+      type: "file",
+      data: { type: "data", data: "aGVsbG8=" },
+      mediaType: "image/png",
+      filename: "cat.png",
+    };
+    const out = normalizeToolResultForUserContent(
+      {
+        type: "content",
+        value: [filePart],
+      } as Parameters<typeof normalizeToolResultForUserContent>[0],
+      { mode: "model" }
+    );
+
+    expect(out).toEqual([filePart]);
+  });
+});

--- a/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
+++ b/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
@@ -27,7 +27,7 @@ const tools: LanguageModelV4FunctionTool[] = [
 ];
 
 describe("recoverToolCallFromJsonCandidates", () => {
-  it("prefers earliest JSON candidate when multiple are present", () => {
+  it("recovers every resolvable JSON candidate in order", () => {
     const text =
       'before {"name":"calc","arguments":{"a":1}} middle\n' +
       "```json\n" +
@@ -37,10 +37,14 @@ describe("recoverToolCallFromJsonCandidates", () => {
     const recovered = recoverToolCallFromJsonCandidates(text, tools);
 
     expect(recovered).not.toBeNull();
-    const tool = recovered?.find((part) => part.type === "tool-call") as any;
+    const calls = recovered?.filter(
+      (part) => part.type === "tool-call"
+    ) as any[];
 
-    expect(tool.toolName).toBe("calc");
-    expect(JSON.parse(tool.input)).toEqual({ a: 1 });
+    expect(calls).toHaveLength(2);
+    expect(calls[0].toolName).toBe("calc");
+    expect(JSON.parse(calls[0].input)).toEqual({ a: 1 });
+    expect(JSON.parse(calls[1].input)).toEqual({ a: 2 });
 
     const textOut = recovered
       ?.filter((part) => part.type === "text")
@@ -48,8 +52,43 @@ describe("recoverToolCallFromJsonCandidates", () => {
       .join("");
     expect(textOut).toContain("before ");
     expect(textOut).toContain(" middle");
-    expect(textOut).toContain("```json");
-    expect(textOut).toContain("``` after");
+    expect(textOut).toContain(" after");
+  });
+
+  it("recovers consecutive bare JSON tool payloads as multiple calls", () => {
+    // Real-world shape observed from GLM-4.7: parallel calls emitted as
+    // newline-separated bare JSON objects, or separated by orphan
+    // <tool_call> tags.
+    const text =
+      '{"name":"get_weather","arguments":{"city":"Seoul"}}\n' +
+      '{"name":"get_weather","arguments":{"city":"Tokyo"}}\n' +
+      '{"name":"get_weather","arguments":{"city":"Paris"}}';
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const calls = recovered?.filter(
+      (part) => part.type === "tool-call"
+    ) as any[];
+    expect(calls).toHaveLength(3);
+    expect(calls.map((c) => JSON.parse(c.input).city)).toEqual([
+      "Seoul",
+      "Tokyo",
+      "Paris",
+    ]);
+    expect(recovered?.some((part) => part.type === "text")).toBe(false);
+  });
+
+  it("treats orphan tool_call separators between payloads as markup", () => {
+    const text =
+      '{"name":"get_weather","arguments":{"city":"Seoul"}}<tool_call>{"name":"get_weather","arguments":{"city":"Tokyo"}}';
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const calls = recovered?.filter(
+      (part) => part.type === "tool-call"
+    ) as any[];
+    expect(calls).toHaveLength(2);
+    expect(recovered?.some((part) => part.type === "text")).toBe(false);
   });
 
   it("does not recover nested tool payload objects", () => {
@@ -97,5 +136,72 @@ describe("recoverToolCallFromJsonCandidates", () => {
     const recovered = recoverToolCallFromJsonCandidates(text, tools);
 
     expect(recovered).toBeNull();
+  });
+});
+
+describe("recoverToolCallFromJsonCandidates orphan markup trim", () => {
+  it("strips dangling tool_call tags around the recovered payload", () => {
+    const text =
+      '<tool_call>{"name":"get_weather","arguments":{"city":"Seoul"}}</think>';
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    expect(recovered).not.toBeNull();
+    const tool = recovered?.find((part) => part.type === "tool-call") as any;
+    expect(tool.toolName).toBe("get_weather");
+
+    const textOut = recovered
+      ?.filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("");
+    expect(textOut).not.toContain("<tool_call>");
+  });
+
+  it("strips a dangling close tag after the recovered payload", () => {
+    const text = '{"name":"calc","arguments":{"a":1}}</tool_call>';
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    expect(recovered).not.toBeNull();
+    const textOut = recovered
+      ?.filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("");
+    expect(textOut ?? "").not.toContain("</tool_call>");
+  });
+
+  it("keeps surrounding prose intact while trimming orphan tags", () => {
+    const text = 'Sure thing:\n<tool_call>{"name":"calc","arguments":{"a":2}}';
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    expect(recovered).not.toBeNull();
+    const textOut = recovered
+      ?.filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("");
+    expect(textOut).toContain("Sure thing:");
+    expect(textOut).not.toContain("<tool_call>");
+  });
+});
+
+describe("recoverToolCallFromJsonCandidates prototype-sensitive keys", () => {
+  it("rejects payloads whose arguments contain __proto__", () => {
+    const text = '{"name":"calc","arguments":{"__proto__":{"x":1}}}';
+
+    expect(recoverToolCallFromJsonCandidates(text, tools)).toBeNull();
+  });
+
+  it("rejects arguments-only payloads containing constructor keys", () => {
+    const text = '{"city":"Seoul","constructor":{"bad":true}}';
+
+    expect(recoverToolCallFromJsonCandidates(text, [tools[1]])).toBeNull();
+  });
+
+  it("rejects nested prototype-sensitive keys", () => {
+    const text =
+      '{"name":"calc","arguments":{"a":1,"nested":{"prototype":{}}}}';
+
+    expect(recoverToolCallFromJsonCandidates(text, tools)).toBeNull();
   });
 });

--- a/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
+++ b/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
@@ -249,3 +249,75 @@ describe("recoverToolCallFromJsonCandidates envelope variants", () => {
     expect(recoverToolCallFromJsonCandidates(text, tools)).toBeNull();
   });
 });
+
+describe("recoverToolCallFromJsonCandidates cross-format blocks", () => {
+  it("recovers Qwen-style function blocks (Step 3.5 shape)", () => {
+    const text =
+      "<tool_call>\n<function=get_weather>\n<parameter=city>\nSeoul\n</parameter>\n</function>\n</tool_call>";
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const call = recovered?.find((part) => part.type === "tool-call") as any;
+    expect(call).toBeDefined();
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({ city: "Seoul" });
+  });
+
+  it("recovers YAML-bodied tool_call blocks with envelope (Granite shape)", () => {
+    const text =
+      "<tool_call>\nname: get_weather\narguments:\n  city: Seoul\n  unit: celsius\n</weather>";
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const call = recovered?.find((part) => part.type === "tool-call") as any;
+    expect(call).toBeDefined();
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({ city: "Seoul", unit: "celsius" });
+  });
+
+  it("recovers bare-args YAML blocks closed with the tool name", () => {
+    const text =
+      "<tool_call>\ncity: Seoul\nunit: celsius\n</get_weather>\n<tool_call>\ncity: Tokyo\nunit: celsius\n</get_weather>";
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const calls = recovered?.filter(
+      (part) => part.type === "tool-call"
+    ) as any[];
+    expect(calls).toHaveLength(2);
+    expect(calls.map((c) => JSON.parse(c.input).city)).toEqual([
+      "Seoul",
+      "Tokyo",
+    ]);
+  });
+
+  it("does not misread prose inside a tool_call block as YAML args", () => {
+    const text = "<tool_call>\njust some prose here\n</tool_call>";
+
+    expect(recoverToolCallFromJsonCandidates(text, tools)).toBeNull();
+  });
+});
+
+describe("recoverToolCallFromJsonCandidates namespaced close tags", () => {
+  it("trims namespaced garbage close tags and matches the tool name", () => {
+    const text =
+      "<tool_call>\nname: get_weather\narguments:\n  city: Seoul\n</functions:get_weather>";
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const call = recovered?.find((part) => part.type === "tool-call") as any;
+    expect(call).toBeDefined();
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({ city: "Seoul" });
+  });
+
+  it("matches the tool from the namespaced close tag in bare-args form", () => {
+    const text = "<tool_call>\ncity: Seoul\n</functions:get_weather>";
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const call = recovered?.find((part) => part.type === "tool-call") as any;
+    expect(call).toBeDefined();
+    expect(call.toolName).toBe("get_weather");
+  });
+});

--- a/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
+++ b/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
@@ -205,3 +205,47 @@ describe("recoverToolCallFromJsonCandidates prototype-sensitive keys", () => {
     expect(recoverToolCallFromJsonCandidates(text, tools)).toBeNull();
   });
 });
+
+describe("recoverToolCallFromJsonCandidates envelope variants", () => {
+  it("accepts tool/parameters key aliases", () => {
+    const text = '{"tool": "get_weather", "parameters": {"city": "Seoul"}}';
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const call = recovered?.find((part) => part.type === "tool-call") as any;
+    expect(call).toBeDefined();
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({ city: "Seoul" });
+  });
+
+  it("unwraps string-typed arguments", () => {
+    const text =
+      '{"name": "get_weather", "arguments": "{\\"city\\": \\"Seoul\\"}"}';
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const call = recovered?.find((part) => part.type === "tool-call") as any;
+    expect(call).toBeDefined();
+    expect(JSON.parse(call.input)).toEqual({ city: "Seoul" });
+  });
+
+  it("recovers array-wrapped call lists without leaking punctuation", () => {
+    const text =
+      '[{"name":"get_weather","arguments":{"city":"Seoul"}}, {"name":"get_weather","arguments":{"city":"Tokyo"}}]';
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const calls = recovered?.filter(
+      (part) => part.type === "tool-call"
+    ) as any[];
+    expect(calls).toHaveLength(2);
+    expect(recovered?.some((part) => part.type === "text")).toBe(false);
+  });
+
+  it("rejects prototype-sensitive keys in string-typed arguments", () => {
+    const text =
+      '{"name": "get_weather", "arguments": "{\\"__proto__\\": {}}"}';
+
+    expect(recoverToolCallFromJsonCandidates(text, tools)).toBeNull();
+  });
+});

--- a/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
+++ b/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
@@ -329,6 +329,53 @@ describe("recoverToolCallFromJsonCandidates cross-format blocks", () => {
     expect(textOut).toContain(" done");
   });
 
+  it("uses a malformed close inside an unclosed parameter when no later call close exists", () => {
+    const text =
+      "<function=get_weather><parameter=city>Seoul </function garbage> done </parameter> tail";
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const call = recovered?.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected a recovered tool call");
+    }
+    expect(JSON.parse(call.input)).toEqual({ city: "Seoul" });
+
+    const textOut = recovered
+      ?.filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("");
+    expect(textOut).toContain(" done </parameter> tail");
+    expect(textOut).not.toContain("</function garbage>");
+  });
+
+  it("handles many close-like parameter fragments without quadratic scanning", () => {
+    const fragments = Array.from(
+      { length: 8000 },
+      (_, index) => `literal ${index} </function garbage>`
+    ).join(" ");
+    const text = `<function=get_weather><parameter=city>${fragments}</parameter></function> done`;
+
+    const startedAt = performance.now();
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+    const elapsedMs = performance.now() - startedAt;
+
+    const call = recovered?.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected a recovered tool call");
+    }
+    const input = JSON.parse(call.input);
+    expect(input.city).toContain("literal 0 </function garbage>");
+    expect(input.city).toContain("literal 7999 </function garbage>");
+
+    const textOut = recovered
+      ?.filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("");
+    expect(textOut).toContain(" done");
+    expect(elapsedMs).toBeLessThan(1000);
+  });
+
   it("recovers YAML-bodied tool_call blocks with envelope (Granite shape)", () => {
     const text =
       "<tool_call>\nname: get_weather\narguments:\n  city: Seoul\n  unit: celsius\n</weather>";

--- a/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
+++ b/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
@@ -263,6 +263,30 @@ describe("recoverToolCallFromJsonCandidates cross-format blocks", () => {
     expect(JSON.parse(call.input)).toEqual({ city: "Seoul" });
   });
 
+  it("recovers Qwen-style call blocks with name attributes", () => {
+    const text =
+      '<tool_call>\n<call name="get_weather">\n<parameter=city>Seoul</parameter>\n</call>\n</tool_call>';
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const call = recovered?.find((part) => part.type === "tool-call") as any;
+    expect(call).toBeDefined();
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({ city: "Seoul" });
+  });
+
+  it("recovers Qwen-style tool blocks with child tool_name tags", () => {
+    const text =
+      "<tool_call>\n<tool>\n<tool_name>get_weather</tool_name>\n<parameter=city>Seoul</parameter>\n</tool>\n</tool_call>";
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const call = recovered?.find((part) => part.type === "tool-call") as any;
+    expect(call).toBeDefined();
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({ city: "Seoul" });
+  });
+
   it("recovers YAML-bodied tool_call blocks with envelope (Granite shape)", () => {
     const text =
       "<tool_call>\nname: get_weather\narguments:\n  city: Seoul\n  unit: celsius\n</weather>";

--- a/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
+++ b/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
@@ -287,6 +287,48 @@ describe("recoverToolCallFromJsonCandidates cross-format blocks", () => {
     expect(JSON.parse(call.input)).toEqual({ city: "Seoul" });
   });
 
+  it("terminates Qwen-style blocks at malformed close tags without swallowing trailing text", () => {
+    const text =
+      "<function=get_weather><parameter=city>Seoul</parameter></function garbage> done";
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const call = recovered?.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected a recovered tool call");
+    }
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({ city: "Seoul" });
+
+    const textOut = recovered
+      ?.filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("");
+    expect(textOut).toContain(" done");
+    expect(textOut).not.toContain("</function garbage>");
+  });
+
+  it("does not treat malformed close-like text inside a parameter as the block close", () => {
+    const text =
+      "<function=get_weather><parameter=city>literal </function garbage> text</parameter></function> done";
+
+    const recovered = recoverToolCallFromJsonCandidates(text, tools);
+
+    const call = recovered?.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected a recovered tool call");
+    }
+    expect(JSON.parse(call.input)).toEqual({
+      city: "literal </function garbage> text",
+    });
+
+    const textOut = recovered
+      ?.filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("");
+    expect(textOut).toContain(" done");
+  });
+
   it("recovers YAML-bodied tool_call blocks with envelope (Granite shape)", () => {
     const text =
       "<tool_call>\nname: get_weather\narguments:\n  city: Seoul\n  unit: celsius\n</weather>";

--- a/src/__tests__/core/utils/stream-json-recovery.unit.test.ts
+++ b/src/__tests__/core/utils/stream-json-recovery.unit.test.ts
@@ -210,6 +210,22 @@ describe("createStreamJsonRecoveryTransform", () => {
     expect(out.some((p) => p.type === "tool-call")).toBe(true);
   });
 
+  it("keeps spaced Qwen function tags eligible for recovery", async () => {
+    const out = await run([
+      ...textBlock(
+        '<function = "get_weather"><parameter=city>Seoul</parameter></function>'
+      ),
+      finishPart,
+    ]);
+
+    const toolCall = out.find((p) => p.type === "tool-call") as Extract<
+      LanguageModelV4StreamPart,
+      { type: "tool-call" }
+    >;
+    expect(toolCall).toBeDefined();
+    expect(JSON.parse(toolCall.input)).toEqual({ city: "Seoul" });
+  });
+
   it("passes everything through when no tools are configured", async () => {
     const parts = [
       ...textBlock('{"name":"get_weather","arguments":{"city":"Seoul"}}'),

--- a/src/__tests__/core/utils/stream-json-recovery.unit.test.ts
+++ b/src/__tests__/core/utils/stream-json-recovery.unit.test.ts
@@ -186,26 +186,6 @@ describe("createStreamJsonRecoveryTransform", () => {
     await writer.close();
   });
 
-  it("stops recovering after the protocol parser already emitted a tool call", async () => {
-    const protocolToolCall: LanguageModelV4StreamPart = {
-      type: "tool-call",
-      toolCallId: "call_protocol",
-      toolName: "get_weather",
-      input: '{"city":"Paris"}',
-    };
-    const out = await run([
-      protocolToolCall,
-      ...textBlock('{"name":"get_weather","arguments":{"city":"Seoul"}}'),
-      finishPart,
-    ]);
-
-    const toolCalls = out.filter((p) => p.type === "tool-call");
-    expect(toolCalls).toHaveLength(1);
-    expect(toolCalls[0]).toBe(protocolToolCall);
-    // The JSON block stays plain text.
-    expect(out.some((p) => p.type === "text-delta")).toBe(true);
-  });
-
   it("resolves a held block when the stream finishes without text-end", async () => {
     const out = await run([
       { type: "text-start", id: "t1" },
@@ -332,6 +312,87 @@ describe("createStreamJsonRecoveryTransform extended hold shapes", () => {
 
   it("flushes tag-like prose that is not a tool_call tag", async () => {
     const payload = "<toolbox> content here";
+    const out = await run([...textBlock(payload), finish]);
+
+    expect(out.some((p) => p.type === "tool-call")).toBe(false);
+    const text = out
+      .filter((p) => p.type === "text-delta")
+      .map((p) => (p as { delta: string }).delta)
+      .join("");
+    expect(text).toBe(payload);
+  });
+});
+
+describe("createStreamJsonRecoveryTransform per-block independence (review fixes)", () => {
+  const finish: LanguageModelV4StreamPart = {
+    type: "finish",
+    finishReason: stopFinishReason,
+    usage: zeroUsage,
+  };
+
+  it("recovers a second bare-JSON block after a successful recovery", async () => {
+    const out = await run([
+      ...textBlock('{"name":"get_weather","arguments":{"city":"Seoul"}}', "t1"),
+      ...textBlock('{"name":"get_weather","arguments":{"city":"Tokyo"}}', "t2"),
+      finish,
+    ]);
+
+    const calls = out.filter((p) => p.type === "tool-call") as Extract<
+      LanguageModelV4StreamPart,
+      { type: "tool-call" }
+    >[];
+    expect(calls).toHaveLength(2);
+    expect(calls.map((c) => JSON.parse(c.input).city)).toEqual([
+      "Seoul",
+      "Tokyo",
+    ]);
+    expect(out.some((p) => p.type === "text-delta")).toBe(false);
+  });
+
+  it("recovers a bare-JSON block even after a protocol tool call", async () => {
+    const protocolToolCall: LanguageModelV4StreamPart = {
+      type: "tool-call",
+      toolCallId: "call_protocol",
+      toolName: "get_weather",
+      input: '{"city":"Paris"}',
+    };
+    const out = await run([
+      protocolToolCall,
+      ...textBlock('{"name":"get_weather","arguments":{"city":"Seoul"}}'),
+      finish,
+    ]);
+
+    const calls = out.filter((p) => p.type === "tool-call");
+    expect(calls).toHaveLength(2);
+  });
+
+  it("streams non-recoverable fenced blocks through without holding", async () => {
+    const transformer = createStreamJsonRecoveryTransform({ tools });
+    const writer = transformer.writable.getWriter();
+    const reader = transformer.readable.getReader();
+
+    // No close(): parts must arrive while the block is still open.
+    const writes = (async () => {
+      await writer.write({ type: "text-start", id: "t1" });
+      await writer.write({
+        type: "text-delta",
+        id: "t1",
+        delta: "```python\nprint('hi')\n",
+      });
+    })();
+
+    expect((await reader.read()).value).toMatchObject({ type: "text-start" });
+    expect((await reader.read()).value).toMatchObject({
+      type: "text-delta",
+      delta: "```python\nprint('hi')\n",
+    });
+
+    await writes;
+    await writer.close();
+  });
+
+  it("flushes bracketed prose that is not an array of calls", async () => {
+    const payload = "[1] First citation in the list.";
     const out = await run([...textBlock(payload), finish]);
 
     expect(out.some((p) => p.type === "tool-call")).toBe(false);

--- a/src/__tests__/core/utils/stream-json-recovery.unit.test.ts
+++ b/src/__tests__/core/utils/stream-json-recovery.unit.test.ts
@@ -1,0 +1,298 @@
+import type {
+  LanguageModelV4FunctionTool,
+  LanguageModelV4StreamPart,
+} from "@ai-sdk/provider";
+import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
+import { describe, expect, it } from "vitest";
+
+import { createStreamJsonRecoveryTransform } from "../../../core/utils/stream-json-recovery";
+import {
+  pipeWithTransformer,
+  stopFinishReason,
+  zeroUsage,
+} from "../../test-helpers";
+
+const tools: LanguageModelV4FunctionTool[] = [
+  {
+    type: "function",
+    name: "get_weather",
+    inputSchema: {
+      type: "object",
+      properties: { city: { type: "string" } },
+    },
+  },
+];
+
+const finishPart: LanguageModelV4StreamPart = {
+  type: "finish",
+  finishReason: stopFinishReason,
+  usage: zeroUsage,
+};
+
+function streamOf(
+  parts: LanguageModelV4StreamPart[]
+): ReadableStream<LanguageModelV4StreamPart> {
+  return new ReadableStream<LanguageModelV4StreamPart>({
+    start(controller) {
+      for (const part of parts) {
+        controller.enqueue(part);
+      }
+      controller.close();
+    },
+  });
+}
+
+function textBlock(text: string, id = "t1"): LanguageModelV4StreamPart[] {
+  return [
+    { type: "text-start", id },
+    { type: "text-delta", id, delta: text },
+    { type: "text-end", id },
+  ];
+}
+
+async function run(
+  parts: LanguageModelV4StreamPart[]
+): Promise<LanguageModelV4StreamPart[]> {
+  return await convertReadableStreamToArray(
+    pipeWithTransformer(
+      streamOf(parts),
+      createStreamJsonRecoveryTransform({ tools })
+    )
+  );
+}
+
+describe("createStreamJsonRecoveryTransform", () => {
+  it("recovers a bare JSON tool-call text block as a tool call", async () => {
+    const out = await run([
+      ...textBlock('{"name":"get_weather","arguments":{"city":"Seoul"}}'),
+      finishPart,
+    ]);
+
+    const types = out.map((p) => p.type);
+    expect(types).toEqual([
+      "tool-input-start",
+      "tool-input-delta",
+      "tool-input-end",
+      "tool-call",
+      "finish",
+    ]);
+
+    const toolCall = out.find((p) => p.type === "tool-call") as Extract<
+      LanguageModelV4StreamPart,
+      { type: "tool-call" }
+    >;
+    expect(toolCall.toolName).toBe("get_weather");
+    expect(JSON.parse(toolCall.input)).toEqual({ city: "Seoul" });
+
+    // tool-input lifecycle ids reconcile with the final toolCallId
+    for (const part of out) {
+      if ("id" in part && part.type.startsWith("tool-input")) {
+        expect(part.id).toBe(toolCall.toolCallId);
+      }
+    }
+  });
+
+  it("recovers a bare JSON block split across many deltas", async () => {
+    const payload = '{"name":"get_weather","arguments":{"city":"Seoul"}}';
+    const deltas: LanguageModelV4StreamPart[] = payload
+      .split("")
+      .map((ch) => ({ type: "text-delta", id: "t1", delta: ch }));
+
+    const out = await run([
+      { type: "text-start", id: "t1" },
+      ...deltas,
+      { type: "text-end", id: "t1" },
+      finishPart,
+    ]);
+
+    expect(out.some((p) => p.type === "tool-call")).toBe(true);
+    expect(out.some((p) => p.type === "text-delta")).toBe(false);
+  });
+
+  it("recovers multiple newline-separated bare JSON payloads", async () => {
+    const out = await run([
+      ...textBlock(
+        '{"name":"get_weather","arguments":{"city":"Seoul"}}\n{"name":"get_weather","arguments":{"city":"Tokyo"}}\n{"name":"get_weather","arguments":{"city":"Paris"}}'
+      ),
+      finishPart,
+    ]);
+
+    const calls = out.filter((p) => p.type === "tool-call") as Extract<
+      LanguageModelV4StreamPart,
+      { type: "tool-call" }
+    >[];
+    expect(calls).toHaveLength(3);
+    expect(calls.map((c) => JSON.parse(c.input).city)).toEqual([
+      "Seoul",
+      "Tokyo",
+      "Paris",
+    ]);
+    expect(out.some((p) => p.type === "text-delta")).toBe(false);
+  });
+
+  it("recovers an arguments-only object when a single tool is available", async () => {
+    const out = await run([...textBlock('{"city":"Seoul"}'), finishPart]);
+
+    const toolCall = out.find((p) => p.type === "tool-call") as Extract<
+      LanguageModelV4StreamPart,
+      { type: "tool-call" }
+    >;
+    expect(toolCall).toBeDefined();
+    expect(toolCall.toolName).toBe("get_weather");
+    expect(JSON.parse(toolCall.input)).toEqual({ city: "Seoul" });
+  });
+
+  it("flushes an unknown-tool JSON block as plain text", async () => {
+    const payload = '{"name":"unknown_tool","arguments":{"a":1}}';
+    const out = await run([...textBlock(payload), finishPart]);
+
+    expect(out.some((p) => p.type === "tool-call")).toBe(false);
+    const deltas = out.filter((p) => p.type === "text-delta");
+    expect(deltas.map((d) => (d as { delta: string }).delta).join("")).toBe(
+      payload
+    );
+    expect(out.map((p) => p.type)).toEqual([
+      "text-start",
+      "text-delta",
+      "text-end",
+      "finish",
+    ]);
+  });
+
+  it("does not delay blocks that start with prose", async () => {
+    const transformer = createStreamJsonRecoveryTransform({ tools });
+    const writer = transformer.writable.getWriter();
+    const reader = transformer.readable.getReader();
+
+    // Deliberately no close(): the parts must be readable while the stream
+    // is still open, otherwise prose would be buffered until flush.
+    const writes = (async () => {
+      await writer.write({ type: "text-start", id: "t1" });
+      await writer.write({ type: "text-delta", id: "t1", delta: "Hello " });
+      await writer.write({ type: "text-delta", id: "t1", delta: "world" });
+    })();
+
+    expect((await reader.read()).value).toMatchObject({ type: "text-start" });
+    expect((await reader.read()).value).toMatchObject({
+      type: "text-delta",
+      delta: "Hello ",
+    });
+    expect((await reader.read()).value).toMatchObject({
+      type: "text-delta",
+      delta: "world",
+    });
+
+    await writes;
+    await writer.close();
+  });
+
+  it("stops recovering after the protocol parser already emitted a tool call", async () => {
+    const protocolToolCall: LanguageModelV4StreamPart = {
+      type: "tool-call",
+      toolCallId: "call_protocol",
+      toolName: "get_weather",
+      input: '{"city":"Paris"}',
+    };
+    const out = await run([
+      protocolToolCall,
+      ...textBlock('{"name":"get_weather","arguments":{"city":"Seoul"}}'),
+      finishPart,
+    ]);
+
+    const toolCalls = out.filter((p) => p.type === "tool-call");
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]).toBe(protocolToolCall);
+    // The JSON block stays plain text.
+    expect(out.some((p) => p.type === "text-delta")).toBe(true);
+  });
+
+  it("resolves a held block when the stream finishes without text-end", async () => {
+    const out = await run([
+      { type: "text-start", id: "t1" },
+      {
+        type: "text-delta",
+        id: "t1",
+        delta: '{"name":"get_weather","arguments":{"city":"Seoul"}}',
+      },
+      finishPart,
+    ]);
+
+    expect(out.some((p) => p.type === "tool-call")).toBe(true);
+    expect(out.at(-1)).toMatchObject({ type: "finish" });
+  });
+
+  it("keeps leading whitespace blocks eligible for recovery", async () => {
+    const out = await run([
+      ...textBlock('\n  {"name":"get_weather","arguments":{"city":"Seoul"}}\n'),
+      finishPart,
+    ]);
+
+    expect(out.some((p) => p.type === "tool-call")).toBe(true);
+  });
+
+  it("passes everything through when no tools are configured", async () => {
+    const parts = [
+      ...textBlock('{"name":"get_weather","arguments":{"city":"Seoul"}}'),
+      finishPart,
+    ];
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(
+        streamOf(parts),
+        createStreamJsonRecoveryTransform({ tools: [] })
+      )
+    );
+    expect(out).toEqual(parts);
+  });
+});
+
+describe("createStreamJsonRecoveryTransform fenced blocks", () => {
+  const finish: LanguageModelV4StreamPart = {
+    type: "finish",
+    finishReason: stopFinishReason,
+    usage: zeroUsage,
+  };
+
+  it("recovers a tool call from a fenced json block", async () => {
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(
+        streamOf([
+          { type: "text-start", id: "t1" },
+          {
+            type: "text-delta",
+            id: "t1",
+            delta:
+              '```json\n{\n  "name": "get_weather",\n  "arguments": {"city": "Seoul"}\n}\n```',
+          },
+          { type: "text-end", id: "t1" },
+          finish,
+        ]),
+        createStreamJsonRecoveryTransform({ tools })
+      )
+    );
+
+    const toolCall = out.find((p) => p.type === "tool-call") as Extract<
+      LanguageModelV4StreamPart,
+      { type: "tool-call" }
+    >;
+    expect(toolCall).toBeDefined();
+    expect(JSON.parse(toolCall.input)).toEqual({ city: "Seoul" });
+    expect(out.some((p) => p.type === "text-delta")).toBe(false);
+  });
+
+  it("flushes inline-code prose without holding it", async () => {
+    const payload = "`ls -la` lists files.";
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(
+        streamOf([...textBlock(payload), finish]),
+        createStreamJsonRecoveryTransform({ tools })
+      )
+    );
+
+    expect(out.some((p) => p.type === "tool-call")).toBe(false);
+    const text = out
+      .filter((p) => p.type === "text-delta")
+      .map((p) => (p as { delta: string }).delta)
+      .join("");
+    expect(text).toBe(payload);
+  });
+});

--- a/src/__tests__/core/utils/stream-json-recovery.unit.test.ts
+++ b/src/__tests__/core/utils/stream-json-recovery.unit.test.ts
@@ -296,3 +296,49 @@ describe("createStreamJsonRecoveryTransform fenced blocks", () => {
     expect(text).toBe(payload);
   });
 });
+
+describe("createStreamJsonRecoveryTransform extended hold shapes", () => {
+  const finish: LanguageModelV4StreamPart = {
+    type: "finish",
+    finishReason: stopFinishReason,
+    usage: zeroUsage,
+  };
+
+  it("recovers an array-wrapped call list", async () => {
+    const out = await run([
+      ...textBlock(
+        '[{"name":"get_weather","arguments":{"city":"Seoul"}}, {"name":"get_weather","arguments":{"city":"Tokyo"}}]'
+      ),
+      finish,
+    ]);
+
+    const calls = out.filter((p) => p.type === "tool-call");
+    expect(calls).toHaveLength(2);
+    expect(out.some((p) => p.type === "text-delta")).toBe(false);
+  });
+
+  it("recovers a literal tool_call tag leaking through a foreign protocol", async () => {
+    const out = await run([
+      ...textBlock(
+        '<tool_call>[{"name":"get_weather","arguments":{"city":"Seoul"}}]'
+      ),
+      finish,
+    ]);
+
+    const calls = out.filter((p) => p.type === "tool-call");
+    expect(calls).toHaveLength(1);
+    expect(out.some((p) => p.type === "text-delta")).toBe(false);
+  });
+
+  it("flushes tag-like prose that is not a tool_call tag", async () => {
+    const payload = "<toolbox> content here";
+    const out = await run([...textBlock(payload), finish]);
+
+    expect(out.some((p) => p.type === "tool-call")).toBe(false);
+    const text = out
+      .filter((p) => p.type === "text-delta")
+      .map((p) => (p as { delta: string }).delta)
+      .join("");
+    expect(text).toBe(payload);
+  });
+});

--- a/src/__tests__/generate-handler/finish-reason.test.ts
+++ b/src/__tests__/generate-handler/finish-reason.test.ts
@@ -1,0 +1,181 @@
+import type { LanguageModelV4FunctionTool } from "@ai-sdk/provider";
+import { describe, expect, it, vi } from "vitest";
+
+import type { TCMCoreProtocol } from "../../core/protocols/protocol-interface";
+import { originalToolsSchema } from "../../core/utils/provider-options";
+import { wrapGenerate } from "../../generate-handler";
+import { mockFinishReason, zeroUsage } from "../test-helpers";
+
+const tools: LanguageModelV4FunctionTool[] = [
+  {
+    type: "function",
+    name: "get_weather",
+    inputSchema: {
+      type: "object",
+      properties: { city: { type: "string" } },
+    },
+  },
+];
+
+const toolCallProtocol: TCMCoreProtocol = {
+  formatTools: ({ toolSystemPromptTemplate }) => toolSystemPromptTemplate([]),
+  formatToolCall: () => "",
+  parseGeneratedText: ({ text }) =>
+    text.includes("CALL")
+      ? [
+          {
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "get_weather",
+            input: '{"city":"Seoul"}',
+          },
+        ]
+      : [{ type: "text", text }],
+  createStreamParser: () => new TransformStream(),
+};
+
+function makeParams() {
+  return {
+    providerOptions: {
+      toolCallMiddleware: {
+        originalTools: originalToolsSchema.encode(tools),
+      },
+    },
+  };
+}
+
+function makeResult(text: string, finishReason: unknown) {
+  return {
+    content: [{ type: "text", text }],
+    finishReason,
+    usage: zeroUsage,
+    warnings: [],
+  };
+}
+
+describe("wrapGenerate finishReason parity with streaming", () => {
+  it("rewrites stop to tool-calls when a tool call was parsed", async () => {
+    const doGenerate = vi
+      .fn()
+      .mockResolvedValue(makeResult("CALL", mockFinishReason("stop")));
+
+    const result = await wrapGenerate({
+      protocol: toolCallProtocol,
+      doGenerate,
+      params: makeParams(),
+    });
+
+    expect(result.content[0]).toMatchObject({ type: "tool-call" });
+    expect(result.finishReason).toEqual({
+      unified: "tool-calls",
+      raw: "stop",
+    });
+  });
+
+  it("rewrites other to tool-calls when a tool call was parsed", async () => {
+    const doGenerate = vi
+      .fn()
+      .mockResolvedValue(makeResult("CALL", { unified: "other", raw: "eos" }));
+
+    const result = await wrapGenerate({
+      protocol: toolCallProtocol,
+      doGenerate,
+      params: makeParams(),
+    });
+
+    expect(result.finishReason).toEqual({
+      unified: "tool-calls",
+      raw: "eos",
+    });
+  });
+
+  it("preserves meaningful finish reasons such as length", async () => {
+    const doGenerate = vi
+      .fn()
+      .mockResolvedValue(makeResult("CALL", mockFinishReason("length")));
+
+    const result = await wrapGenerate({
+      protocol: toolCallProtocol,
+      doGenerate,
+      params: makeParams(),
+    });
+
+    expect(result.content[0]).toMatchObject({ type: "tool-call" });
+    expect(result.finishReason).toEqual(mockFinishReason("length"));
+  });
+
+  it("keeps the model finish reason when no tool call was parsed", async () => {
+    const doGenerate = vi
+      .fn()
+      .mockResolvedValue(makeResult("plain answer", mockFinishReason("stop")));
+
+    const result = await wrapGenerate({
+      protocol: toolCallProtocol,
+      doGenerate,
+      params: makeParams(),
+    });
+
+    expect(result.content[0]).toMatchObject({ type: "text" });
+    expect(result.finishReason).toEqual(mockFinishReason("stop"));
+  });
+
+  it("rewrites finishReason for forced tool choice results", async () => {
+    const doGenerate = vi
+      .fn()
+      .mockResolvedValue(
+        makeResult(
+          '{"name":"get_weather","arguments":{"city":"Seoul"}}',
+          mockFinishReason("stop")
+        )
+      );
+
+    const result = await wrapGenerate({
+      protocol: toolCallProtocol,
+      doGenerate,
+      params: {
+        providerOptions: {
+          toolCallMiddleware: {
+            originalTools: originalToolsSchema.encode(tools),
+            toolChoice: { type: "required" },
+          },
+        },
+      },
+    });
+
+    expect(result.content[0]).toMatchObject({
+      type: "tool-call",
+      toolName: "get_weather",
+    });
+    expect(result.finishReason).toMatchObject({ unified: "tool-calls" });
+  });
+});
+
+describe("wrapGenerate toolChoice none passthrough", () => {
+  it("returns the model result untouched without parsing", async () => {
+    const parseSpy = vi.fn(() => []);
+    const spyProtocol: TCMCoreProtocol = {
+      ...toolCallProtocol,
+      parseGeneratedText: parseSpy,
+    };
+    const modelResult = makeResult(
+      '<tool_call>{"name":"x"}</tool_call>',
+      mockFinishReason("stop")
+    );
+    const doGenerate = vi.fn().mockResolvedValue(modelResult);
+
+    const result = await wrapGenerate({
+      protocol: spyProtocol,
+      doGenerate,
+      params: {
+        providerOptions: {
+          toolCallMiddleware: {
+            toolChoice: { type: "none" },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(modelResult);
+    expect(parseSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/protocols/hermes-protocol/stream/mismatched-close-salvage.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/mismatched-close-salvage.test.ts
@@ -245,4 +245,18 @@ describe("hermes invalid JSON escape normalization", () => {
     }
     expect(JSON.parse(toolCall.input)).toEqual({ city: 'line1\nline2 "q"' });
   });
+
+  it("drops apostrophe escapes inside double-quoted JSON strings", () => {
+    const protocol = hermesProtocol();
+    const out = protocol.parseGeneratedText({
+      text: `<tool_call>{"name":"get_weather","arguments":{"city":"it\\'s Seoul"}}</tool_call>`,
+      tools,
+    });
+
+    const toolCall = out.find((p) => p.type === "tool-call");
+    if (toolCall?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(JSON.parse(toolCall.input)).toEqual({ city: "it's Seoul" });
+  });
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/mismatched-close-salvage.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/mismatched-close-salvage.test.ts
@@ -204,3 +204,45 @@ describe("hermes double-encoded and array-wrapped salvage", () => {
     expect(joinedText(out)).toBe("");
   });
 });
+
+describe("hermes invalid JSON escape normalization", () => {
+  // Real-world shape observed from Cohere Command R+: generated code inside
+  // a JSON string escapes template-literal dollars as \$ (invalid JSON).
+  it("drops invalid escapes and parses the call (generate)", () => {
+    const protocol = hermesProtocol();
+    const out = protocol.parseGeneratedText({
+      text: '<tool_call>{"name":"get_weather","arguments":{"city":"a\\$b"}}</tool_call>',
+      tools,
+    });
+
+    const toolCall = out.find((p) => p.type === "tool-call");
+    if (toolCall?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(JSON.parse(toolCall.input)).toEqual({ city: "a$b" });
+  });
+
+  it("drops invalid escapes and parses the call (stream)", async () => {
+    const out = await runStream(
+      '<tool_call>{"name":"get_weather","arguments":{"city":"a\\$b"}}</tool_call>'
+    );
+
+    const toolCall = out.find((p) => p.type === "tool-call") as ToolCallPart;
+    expect(toolCall).toBeDefined();
+    expect(JSON.parse(toolCall.input)).toEqual({ city: "a$b" });
+  });
+
+  it("keeps valid escapes intact", () => {
+    const protocol = hermesProtocol();
+    const out = protocol.parseGeneratedText({
+      text: '<tool_call>{"name":"get_weather","arguments":{"city":"line1\\nline2 \\"q\\""}}</tool_call>',
+      tools,
+    });
+
+    const toolCall = out.find((p) => p.type === "tool-call");
+    if (toolCall?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(JSON.parse(toolCall.input)).toEqual({ city: 'line1\nline2 "q"' });
+  });
+});

--- a/src/__tests__/protocols/hermes-protocol/stream/mismatched-close-salvage.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/mismatched-close-salvage.test.ts
@@ -141,3 +141,66 @@ describe("hermes parseGeneratedText mismatched-close salvage", () => {
     );
   });
 });
+
+describe("hermes double-encoded and array-wrapped salvage", () => {
+  // Real-world shape observed from IBM Granite 4.0: arguments serialized as
+  // a JSON string (the OpenAI native wire habit).
+  const doubleEncoded =
+    '<tool_call>\n{"name": "get_weather", "arguments": "{\\n  \\"city\\": \\"Seoul\\",\\n  \\"unit\\": \\"celsius\\"\\n}"}\n</tool_call>';
+
+  // Real-world shape observed from ByteDance Seed 2.0: an array of calls
+  // inside a single tool_call block.
+  const arrayWrapped =
+    '<tool_call>\n[{"name": "get_weather", "arguments": {"city": "Seoul"}},\n{"name": "get_weather", "arguments": {"city": "Tokyo"}}]\n</tool_call>';
+
+  it("parses string-typed arguments in parseGeneratedText", () => {
+    const protocol = hermesProtocol();
+    const out = protocol.parseGeneratedText({ text: doubleEncoded, tools });
+
+    const toolCall = out.find((p) => p.type === "tool-call");
+    if (toolCall?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(toolCall.toolName).toBe("get_weather");
+    expect(JSON.parse(toolCall.input)).toEqual({
+      city: "Seoul",
+      unit: "celsius",
+    });
+  });
+
+  it("parses string-typed arguments in streaming", async () => {
+    const out = await runStream(doubleEncoded);
+
+    const toolCall = out.find((p) => p.type === "tool-call") as ToolCallPart;
+    expect(toolCall).toBeDefined();
+    expect(JSON.parse(toolCall.input)).toEqual({
+      city: "Seoul",
+      unit: "celsius",
+    });
+    expect(joinedText(out)).toBe("");
+  });
+
+  it("salvages an array of calls in parseGeneratedText", () => {
+    const protocol = hermesProtocol();
+    const out = protocol.parseGeneratedText({ text: arrayWrapped, tools });
+
+    const calls = out.filter((p) => p.type === "tool-call");
+    expect(calls).toHaveLength(2);
+    expect(
+      calls.map((c) => JSON.parse((c as ToolCallPart).input).city)
+    ).toEqual(["Seoul", "Tokyo"]);
+    expect(out.some((p) => p.type === "text")).toBe(false);
+  });
+
+  it("salvages an array of calls in streaming", async () => {
+    const out = await runStream(arrayWrapped);
+
+    const calls = out.filter((p) => p.type === "tool-call") as ToolCallPart[];
+    expect(calls).toHaveLength(2);
+    expect(calls.map((c) => JSON.parse(c.input).city)).toEqual([
+      "Seoul",
+      "Tokyo",
+    ]);
+    expect(joinedText(out)).toBe("");
+  });
+});

--- a/src/__tests__/protocols/hermes-protocol/stream/mismatched-close-salvage.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/mismatched-close-salvage.test.ts
@@ -1,0 +1,143 @@
+import type {
+  LanguageModelV4FunctionTool,
+  LanguageModelV4StreamPart,
+} from "@ai-sdk/provider";
+import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
+import { describe, expect, it, vi } from "vitest";
+
+import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
+import {
+  createChunkedStream,
+  pipeWithTransformer,
+} from "../../../test-helpers";
+
+const tools: LanguageModelV4FunctionTool[] = [
+  {
+    type: "function",
+    name: "get_weather",
+    inputSchema: {
+      type: "object",
+      properties: { city: { type: "string" } },
+    },
+  },
+];
+
+type ToolCallPart = Extract<LanguageModelV4StreamPart, { type: "tool-call" }>;
+
+async function runStream(
+  text: string,
+  onError?: (message: string, metadata?: Record<string, unknown>) => void
+): Promise<LanguageModelV4StreamPart[]> {
+  const protocol = hermesProtocol();
+  return await convertReadableStreamToArray(
+    pipeWithTransformer(
+      createChunkedStream(text),
+      protocol.createStreamParser({ tools, options: { onError } })
+    )
+  );
+}
+
+function joinedText(parts: LanguageModelV4StreamPart[]): string {
+  return parts
+    .filter((p) => p.type === "text-delta")
+    .map((p) => (p as { delta: string }).delta)
+    .join("");
+}
+
+describe("hermes streaming mismatched-close salvage", () => {
+  it("salvages a call closed with a wrong tag (e.g. </think>) at finish", async () => {
+    const out = await runStream(
+      '<tool_call>{"name":"get_weather","arguments":{"city":"Seoul"}}</think>'
+    );
+
+    const toolCall = out.find((p) => p.type === "tool-call") as ToolCallPart;
+    expect(toolCall).toBeDefined();
+    expect(toolCall.toolName).toBe("get_weather");
+    expect(JSON.parse(toolCall.input)).toEqual({ city: "Seoul" });
+
+    // No protocol markup leaks into visible text.
+    expect(joinedText(out)).toBe("");
+  });
+
+  it("salvages a call missing its close tag entirely", async () => {
+    const out = await runStream(
+      '<tool_call>{"name":"get_weather","arguments":{"city":"Seoul"}}'
+    );
+
+    const toolCall = out.find((p) => p.type === "tool-call") as ToolCallPart;
+    expect(toolCall).toBeDefined();
+    expect(JSON.parse(toolCall.input)).toEqual({ city: "Seoul" });
+  });
+
+  it("salvages consecutive calls separated by orphan <tool_call> tags", async () => {
+    // Real-world GLM-4.7 parallel-call shape: no closing tags at all, the
+    // next <tool_call> acts as a separator.
+    const out = await runStream(
+      '<tool_call>{"name":"get_weather","arguments":{"city":"Seoul"}}<tool_call>{"name":"get_weather","arguments":{"city":"Tokyo"}}'
+    );
+
+    const calls = out.filter((p) => p.type === "tool-call") as ToolCallPart[];
+    expect(calls).toHaveLength(2);
+    expect(calls.map((c) => JSON.parse(c.input).city)).toEqual([
+      "Seoul",
+      "Tokyo",
+    ]);
+    expect(joinedText(out)).toBe("");
+  });
+
+  it("does not salvage genuinely truncated JSON", async () => {
+    const onError = vi.fn();
+    const out = await runStream(
+      '<tool_call>{"name":"get_weather","argu',
+      onError
+    );
+
+    expect(out.some((p) => p.type === "tool-call")).toBe(false);
+    expect(onError).toHaveBeenCalledWith(
+      expect.stringContaining("Could not complete streaming JSON tool call"),
+      expect.objectContaining({ dropReason: "unfinished-tool-call" })
+    );
+  });
+
+  it("does not salvage bodies with trailing non-markup prose", async () => {
+    const onError = vi.fn();
+    const out = await runStream(
+      '<tool_call>{"name":"get_weather","arguments":{"city":"Seoul"}} and then some prose',
+      onError
+    );
+
+    expect(out.some((p) => p.type === "tool-call")).toBe(false);
+    expect(onError).toHaveBeenCalled();
+  });
+});
+
+describe("hermes parseGeneratedText mismatched-close salvage", () => {
+  it("salvages a wrong close tag inside a well-formed tool_call span", () => {
+    const protocol = hermesProtocol();
+    const out = protocol.parseGeneratedText({
+      text: '<tool_call>{"name":"get_weather","arguments":{"city":"Seoul"}}</think></tool_call>',
+      tools,
+    });
+
+    const toolCall = out.find((p) => p.type === "tool-call");
+    expect(toolCall).toMatchObject({ toolName: "get_weather" });
+    // The stray </think> inside the span is markup, not visible text.
+    expect(out.some((p) => p.type === "text")).toBe(false);
+  });
+
+  it("keeps the text fallback for spans with trailing prose", () => {
+    const onError = vi.fn();
+    const protocol = hermesProtocol();
+    const out = protocol.parseGeneratedText({
+      text: '<tool_call>{"name":"get_weather","arguments":{"city":"Seoul"}} definitely prose</tool_call>',
+      tools,
+      options: { onError },
+    });
+
+    expect(out.some((p) => p.type === "tool-call")).toBe(false);
+    expect(onError).toHaveBeenCalledWith(
+      expect.stringContaining("Could not process JSON tool call"),
+      expect.objectContaining({ dropReason: "malformed-tool-call-body" })
+    );
+  });
+});

--- a/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/nameless-param-salvage.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/nameless-param-salvage.test.ts
@@ -1,0 +1,86 @@
+import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
+import { describe, expect, it } from "vitest";
+import { qwen3CoderProtocol } from "../../../../core/protocols/qwen3coder-protocol";
+import { emptyFunctionTools } from "../../../fixtures/function-tools";
+import {
+  createChunkedStream,
+  pipeWithTransformer,
+} from "../../../test-helpers";
+
+// Real-world shape observed from Qwen2.5-7B-Instruct: the parameter tag is
+// emitted without a name (`<parameter>NAME</parameter>` followed by the value
+// as plain text) instead of the canonical `<parameter=NAME>VALUE</parameter>`.
+const NAMELESS_OUTPUT = `<tool_call>
+<function=get_weather>
+<parameter>city</parameter>
+Seoul
+<parameter>unit</parameter>
+celsius
+</function>
+</tool_call>`;
+
+describe("qwen3CoderProtocol nameless parameter salvage", () => {
+  const tools = emptyFunctionTools;
+
+  it("recovers <parameter>name</parameter>value pairs", () => {
+    const p = qwen3CoderProtocol();
+    const out = p.parseGeneratedText({ text: NAMELESS_OUTPUT, tools });
+
+    const call = out.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({
+      city: "Seoul",
+      unit: "celsius",
+    });
+  });
+
+  it("recovers the nameless variant when streamed in small chunks", async () => {
+    const p = qwen3CoderProtocol();
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(
+        createChunkedStream(NAMELESS_OUTPUT),
+        p.createStreamParser({ tools })
+      )
+    );
+
+    const call = out.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({
+      city: "Seoul",
+      unit: "celsius",
+    });
+  });
+
+  it("ignores nameless tags whose element text is not identifier-like", () => {
+    const p = qwen3CoderProtocol();
+    const text =
+      "<tool_call><function=get_weather><parameter>not a parameter name</parameter>value</function></tool_call>";
+    const out = p.parseGeneratedText({ text, tools });
+
+    const call = out.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({});
+  });
+
+  it("terminates a nameless value at the next parameter tag", () => {
+    const p = qwen3CoderProtocol();
+    const text =
+      "<tool_call><function=alpha><parameter>a</parameter>1<parameter=b>2</parameter></function></tool_call>";
+    const out = p.parseGeneratedText({ text, tools });
+
+    const call = out.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(JSON.parse(call.input)).toEqual({ a: "1", b: "2" });
+  });
+});

--- a/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/nameless-param-salvage.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/nameless-param-salvage.test.ts
@@ -83,4 +83,23 @@ describe("qwen3CoderProtocol nameless parameter salvage", () => {
     }
     expect(JSON.parse(call.input)).toEqual({ a: "1", b: "2" });
   });
+
+  it("ignores self-closing nameless parameter tags", async () => {
+    const p = qwen3CoderProtocol();
+    const text =
+      "<tool_call><function=get_weather><parameter/></function></tool_call>";
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(
+        createChunkedStream(text),
+        p.createStreamParser({ tools })
+      )
+    );
+
+    const call = out.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({});
+  });
 });

--- a/src/__tests__/protocols/qwen3coder-protocol/stream/foreign-format-salvage.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/stream/foreign-format-salvage.test.ts
@@ -1,0 +1,73 @@
+import type { LanguageModelV4FunctionTool } from "@ai-sdk/provider";
+import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
+import { describe, expect, it } from "vitest";
+import { qwen3CoderProtocol } from "../../../../core/protocols/qwen3coder-protocol";
+import {
+  createChunkedStream,
+  pipeWithTransformer,
+} from "../../../test-helpers";
+
+const tools: LanguageModelV4FunctionTool[] = [
+  {
+    type: "function",
+    name: "book_flight",
+    inputSchema: {
+      type: "object",
+      properties: {
+        passenger: { type: "object" },
+        legs: { type: "array" },
+        cabin: { type: "string" },
+      },
+    },
+  },
+];
+
+// Real-world shape observed from LiquidAI LFM2: a Hermes-style JSON payload
+// inside <tool_call> tags while the Qwen3-Coder prompt is active.
+const HERMES_JSON_UNDER_QWEN = `<tool_call>
+{"name": "book_flight", "arguments": {"passenger": {"name": "Jane Doe", "age": 34}, "legs": [{"from": "ICN", "to": "NRT"}], "cabin": "economy"}}
+</tool_call>`;
+
+describe("qwen3CoderProtocol foreign-format salvage", () => {
+  it("salvages a Hermes-style JSON payload inside tool_call tags (stream)", async () => {
+    const p = qwen3CoderProtocol();
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(
+        createChunkedStream(HERMES_JSON_UNDER_QWEN),
+        p.createStreamParser({ tools })
+      )
+    );
+
+    const call = out.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(call.toolName).toBe("book_flight");
+    const input = JSON.parse(call.input);
+    expect(input.passenger).toEqual({ name: "Jane Doe", age: 34 });
+    expect(input.legs).toEqual([{ from: "ICN", to: "NRT" }]);
+
+    const text = out
+      .filter((part) => part.type === "text-delta")
+      .map((part) => (part as { delta: string }).delta)
+      .join("");
+    expect(text).toBe("");
+  });
+
+  it("still drops prose-only tool_call blocks with onError", async () => {
+    const errors: string[] = [];
+    const p = qwen3CoderProtocol();
+    const out = await convertReadableStreamToArray(
+      pipeWithTransformer(
+        createChunkedStream("<tool_call>\nsome prose, not a call\n"),
+        p.createStreamParser({
+          tools,
+          options: { onError: (m) => errors.push(m) },
+        })
+      )
+    );
+
+    expect(out.some((part) => part.type === "tool-call")).toBe(false);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/protocols/qwen3coder-protocol/stream/latency-flush.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/stream/latency-flush.test.ts
@@ -1,0 +1,65 @@
+import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
+import { describe, expect, it } from "vitest";
+import { qwen3CoderProtocol } from "../../../../core/protocols/qwen3coder-protocol";
+import { emptyFunctionTools } from "../../../fixtures/function-tools";
+
+// Regression tests for streaming latency: text containing tag-like substrings
+// such as `<callback>` or `<toolbar>` must not be withheld until finish.
+describe("qwen3CoderProtocol stream text flushing", () => {
+  async function collectWhileOpen(
+    deltas: string[],
+    expectedParts: number
+  ): Promise<LanguageModelV4StreamPart[]> {
+    const parser = qwen3CoderProtocol().createStreamParser({
+      tools: emptyFunctionTools,
+    });
+    const writer = parser.writable.getWriter();
+    const reader = parser.readable.getReader();
+
+    // Deliberately no close(): the parts must be readable while the stream
+    // is still open, otherwise the text was buffered until finish.
+    const writes = (async () => {
+      for (const delta of deltas) {
+        await writer.write({ type: "text-delta", id: "1", delta });
+      }
+    })();
+
+    const collected: LanguageModelV4StreamPart[] = [];
+    for (let i = 0; i < expectedParts; i += 1) {
+      const { value } = await reader.read();
+      if (value) {
+        collected.push(value);
+      }
+    }
+    await writes;
+    await writer.close();
+    return collected;
+  }
+
+  it("streams text containing <callback> without waiting for finish", async () => {
+    const out = await collectWhileOpen(
+      ["See the <callback> API here.", " More text."],
+      3
+    );
+
+    const text = out
+      .filter((p) => p.type === "text-delta")
+      .map((p) => (p as { delta: string }).delta)
+      .join("");
+    expect(text).toContain("<callback> API here.");
+    expect(text).toContain("More text.");
+  });
+
+  it("streams text containing <toolbar> and <invoker> immediately", async () => {
+    const out = await collectWhileOpen(
+      ["Use <toolbar> and <invoker> tags."],
+      2
+    );
+
+    const text = out
+      .filter((p) => p.type === "text-delta")
+      .map((p) => (p as { delta: string }).delta)
+      .join("");
+    expect(text).toBe("Use <toolbar> and <invoker> tags.");
+  });
+});

--- a/src/__tests__/protocols/qwen3coder-protocol/stream/latency-flush.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/stream/latency-flush.test.ts
@@ -63,3 +63,55 @@ describe("qwen3CoderProtocol stream text flushing", () => {
     expect(text).toBe("Use <toolbar> and <invoker> tags.");
   });
 });
+
+describe("qwen3CoderProtocol trailing partial after invalid full occurrence", () => {
+  it("holds a genuine trailing partial even when <tool_callback> appears earlier", async () => {
+    const parser = qwen3CoderProtocol().createStreamParser({
+      tools: emptyFunctionTools,
+    });
+    const writer = parser.writable.getWriter();
+    const reader = parser.readable.getReader();
+
+    const writes = (async () => {
+      await writer.write({
+        type: "text-delta",
+        id: "1",
+        delta: "docs at <tool_callback> page. <tool_ca",
+      });
+      await writer.write({
+        type: "text-delta",
+        id: "1",
+        delta:
+          "ll>\n<function=get_weather>\n<parameter=city>Seoul</parameter>\n</function>\n</tool_call>",
+      });
+    })();
+
+    const collected: LanguageModelV4StreamPart[] = [];
+    while (collected.filter((p) => p.type === "tool-call").length === 0) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        collected.push(value);
+      }
+    }
+    await writes;
+    await writer.close();
+
+    const text = collected
+      .filter((p) => p.type === "text-delta")
+      .map((p) => (p as { delta: string }).delta)
+      .join("");
+    // The prose before the call streams out; the tag itself must not leak.
+    expect(text).toContain("<tool_callback> page.");
+    expect(text).not.toContain("<tool_call>");
+
+    const call = collected.find((p) => p.type === "tool-call") as Extract<
+      LanguageModelV4StreamPart,
+      { type: "tool-call" }
+    >;
+    expect(call).toBeDefined();
+    expect(JSON.parse(call.input)).toEqual({ city: "Seoul" });
+  });
+});

--- a/src/__tests__/protocols/yaml-xml-protocol/stream/latency-flush.test.ts
+++ b/src/__tests__/protocols/yaml-xml-protocol/stream/latency-flush.test.ts
@@ -1,0 +1,98 @@
+import type {
+  LanguageModelV4FunctionTool,
+  LanguageModelV4StreamPart,
+} from "@ai-sdk/provider";
+import { describe, expect, it } from "vitest";
+import { yamlXmlProtocol } from "../../../../core/protocols/yaml-xml-protocol";
+
+const tools: LanguageModelV4FunctionTool[] = [
+  {
+    type: "function",
+    name: "get_weather",
+    inputSchema: {
+      type: "object",
+      properties: { city: { type: "string" } },
+    },
+  },
+];
+
+// Regression tests: the streaming parser previously withheld a fixed
+// `maxTagLen - 1` tail on every chunk, so short chunks never streamed until
+// finish. Only a genuine partial tool-tag suffix may be held back.
+describe("yamlXmlProtocol stream text flushing", () => {
+  function openParser() {
+    const parser = yamlXmlProtocol({}).createStreamParser({ tools });
+    return {
+      writer: parser.writable.getWriter(),
+      reader: parser.readable.getReader(),
+    };
+  }
+
+  it("streams short text chunks immediately", async () => {
+    const { writer, reader } = openParser();
+
+    // Deliberately no close(): parts must arrive while the stream is open.
+    const writes = writer.write({ type: "text-delta", id: "1", delta: "Hi!" });
+
+    const collected: LanguageModelV4StreamPart[] = [];
+    for (let i = 0; i < 2; i += 1) {
+      const { value } = await reader.read();
+      if (value) {
+        collected.push(value);
+      }
+    }
+    await writes;
+
+    const text = collected
+      .filter((p) => p.type === "text-delta")
+      .map((p) => (p as { delta: string }).delta)
+      .join("");
+    expect(text).toBe("Hi!");
+
+    await writer.close();
+  });
+
+  it("still holds back a genuine partial tool tag", async () => {
+    const { writer, reader } = openParser();
+
+    const writes = (async () => {
+      await writer.write({
+        type: "text-delta",
+        id: "1",
+        delta: "prefix <get_wea",
+      });
+      await writer.write({
+        type: "text-delta",
+        id: "1",
+        delta: "ther>\ncity: Seoul\n</get_weather>",
+      });
+    })();
+
+    const collected: LanguageModelV4StreamPart[] = [];
+    // text-start, "prefix " delta, then the tool-input lifecycle + tool-call.
+    while (collected.filter((p) => p.type === "tool-call").length === 0) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        collected.push(value);
+      }
+    }
+    await writes;
+    await writer.close();
+
+    const text = collected
+      .filter((p) => p.type === "text-delta")
+      .map((p) => (p as { delta: string }).delta)
+      .join("");
+    expect(text).toBe("prefix ");
+
+    const toolCall = collected.find((p) => p.type === "tool-call") as Extract<
+      LanguageModelV4StreamPart,
+      { type: "tool-call" }
+    >;
+    expect(toolCall.toolName).toBe("get_weather");
+    expect(JSON.parse(toolCall.input)).toEqual({ city: "Seoul" });
+  });
+});

--- a/src/__tests__/protocols/yaml-xml-protocol/stream/latency-flush.test.ts
+++ b/src/__tests__/protocols/yaml-xml-protocol/stream/latency-flush.test.ts
@@ -96,3 +96,105 @@ describe("yamlXmlProtocol stream text flushing", () => {
     expect(JSON.parse(toolCall.input)).toEqual({ city: "Seoul" });
   });
 });
+
+// Real-world shape observed from Amazon Nova 2 Lite: the model answers the
+// YAML-body prompt with XML child tags (the morph-xml body format).
+describe("yamlXmlProtocol XML-children fallback", () => {
+  it("parses <key>value</key> children when YAML parsing fails (generate)", () => {
+    const p = yamlXmlProtocol({});
+    const out = p.parseGeneratedText({
+      text: "<get_weather>\n<city> Seoul</city>\n<unit> celsius</unit>\n</get_weather>",
+      tools,
+    });
+
+    const call = out.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(call.toolName).toBe("get_weather");
+    expect(JSON.parse(call.input)).toEqual({
+      city: "Seoul",
+      unit: "celsius",
+    });
+  });
+
+  it("parses <key>value</key> children when YAML parsing fails (stream)", async () => {
+    const { writer, reader } = (() => {
+      const parser = yamlXmlProtocol({}).createStreamParser({ tools });
+      return {
+        writer: parser.writable.getWriter(),
+        reader: parser.readable.getReader(),
+      };
+    })();
+
+    const writes = (async () => {
+      await writer.write({
+        type: "text-delta",
+        id: "1",
+        delta:
+          "<get_weather>\n<city> Tokyo</city>\n<unit> celsius</unit>\n</get_weather>",
+      });
+      await writer.close();
+    })();
+
+    const collected: LanguageModelV4StreamPart[] = [];
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        collected.push(value);
+      }
+    }
+    await writes;
+
+    const call = collected.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(JSON.parse(call.input)).toEqual({
+      city: "Tokyo",
+      unit: "celsius",
+    });
+  });
+
+  it("keeps the failure path for mixed prose bodies", () => {
+    const p = yamlXmlProtocol({});
+    const out = p.parseGeneratedText({
+      text: "<get_weather>\nsome prose <city>Seoul</city>\n</get_weather>",
+      tools,
+    });
+
+    expect(out.some((part) => part.type === "tool-call")).toBe(false);
+  });
+});
+
+describe("yamlXmlProtocol XML-children fallback tolerance", () => {
+  it("tolerates lines with missing close tags", () => {
+    const p = yamlXmlProtocol({});
+    const out = p.parseGeneratedText({
+      text: "<get_weather>\n<city> Seoul</city>\n<unit>celsius\n</get_weather>",
+      tools,
+    });
+
+    const call = out.find((part) => part.type === "tool-call");
+    if (call?.type !== "tool-call") {
+      throw new Error("Expected tool-call part");
+    }
+    expect(JSON.parse(call.input)).toEqual({
+      city: "Seoul",
+      unit: "celsius",
+    });
+  });
+
+  it("declines lines containing nested markup in values", () => {
+    const p = yamlXmlProtocol({});
+    const out = p.parseGeneratedText({
+      text: "<get_weather>\n<city>Seoul</city><unit>celsius</unit>\n</get_weather>",
+      tools,
+    });
+
+    expect(out.some((part) => part.type === "tool-call")).toBe(false);
+  });
+});

--- a/src/__tests__/schema-coerce/loose-structured-strings.unit.test.ts
+++ b/src/__tests__/schema-coerce/loose-structured-strings.unit.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { coerceBySchema } from "../../schema-coerce";
+
+// Live-model variants: nested object parameters delivered as strings
+// (JSON, Python-literal dicts, XML children) instead of structured values.
+const schema = {
+  type: "object",
+  properties: {
+    passenger: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "number" },
+        frequentFlyer: { type: "boolean" },
+      },
+    },
+    legs: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          from: { type: "string" },
+          to: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+describe("coerceBySchema loose structured strings", () => {
+  it("parses single-quoted Python-literal dict strings (KAT Coder shape)", () => {
+    const out = coerceBySchema(
+      {
+        passenger: "{'name': 'Jane Doe', 'age': 34, 'frequentFlyer': True}",
+      },
+      schema
+    ) as Record<string, unknown>;
+
+    expect(out.passenger).toEqual({
+      name: "Jane Doe",
+      age: 34,
+      frequentFlyer: true,
+    });
+  });
+
+  it("parses Python-literal list strings for array-typed parameters", () => {
+    const out = coerceBySchema(
+      { legs: "[{'from': 'ICN', 'to': 'NRT'}]" },
+      schema
+    ) as Record<string, unknown>;
+
+    expect(out.legs).toEqual([{ from: "ICN", to: "NRT" }]);
+  });
+
+  it("parses XML-children strings for object-typed parameters (Command R+ shape)", () => {
+    const out = coerceBySchema(
+      { passenger: "<name>Jane Doe</name>\n<age>34</age>" },
+      schema
+    ) as Record<string, unknown>;
+
+    expect(out.passenger).toEqual({ name: "Jane Doe", age: 34 });
+  });
+
+  it("rejects prototype-sensitive keys in loose strings", () => {
+    const out = coerceBySchema(
+      { passenger: "{'__proto__': {'polluted': True}}" },
+      schema
+    ) as Record<string, unknown>;
+
+    // Not coerced into an object — the raw string is preserved.
+    expect(typeof out.passenger).toBe("string");
+  });
+
+  it("keeps CSV splitting for plain enumerations", () => {
+    const out = coerceBySchema(
+      { tags: "a, b, c" },
+      {
+        type: "object",
+        properties: {
+          tags: { type: "array", items: { type: "string" } },
+        },
+      }
+    ) as Record<string, unknown>;
+
+    expect(out.tags).toEqual(["a", "b", "c"]);
+  });
+});

--- a/src/__tests__/schema-coerce/loose-structured-strings.unit.test.ts
+++ b/src/__tests__/schema-coerce/loose-structured-strings.unit.test.ts
@@ -72,12 +72,49 @@ describe("coerceBySchema loose structured strings", () => {
     expect(typeof out.passenger).toBe("string");
   });
 
+  it("parses strict JSON string values containing prototype-like key text", () => {
+    const out = coerceBySchema(
+      {
+        passenger: `{"name":"notes mention 'constructor': and '__proto__': labels","age":34}`,
+      },
+      schema
+    ) as Record<string, unknown>;
+
+    expect(out.passenger).toEqual({
+      name: "notes mention 'constructor': and '__proto__': labels",
+      age: 34,
+    });
+  });
+
+  it("parses relaxed string values containing prototype-like key text", () => {
+    const out = coerceBySchema(
+      {
+        passenger: `{'name': "notes mention '__proto__': and 'constructor': labels", 'age': 34}`,
+      },
+      schema
+    ) as Record<string, unknown>;
+
+    expect(out.passenger).toEqual({
+      name: "notes mention '__proto__': and 'constructor': labels",
+      age: 34,
+    });
+  });
+
   it("rejects unicode-escaped prototype-sensitive keys after strict JSON parse", () => {
     const out = coerceBySchema(
       {
         passenger:
           '{"\\u005f\\u005fproto\\u005f\\u005f":{"polluted":true},"name":"Jane Doe"}',
       },
+      schema
+    ) as Record<string, unknown>;
+
+    expect(typeof out.passenger).toBe("string");
+  });
+
+  it("rejects unquoted relaxed prototype-sensitive keys", () => {
+    const out = coerceBySchema(
+      { passenger: "{constructor: {'polluted': True}, name: 'Jane Doe'}" },
       schema
     ) as Record<string, unknown>;
 

--- a/src/__tests__/schema-coerce/loose-structured-strings.unit.test.ts
+++ b/src/__tests__/schema-coerce/loose-structured-strings.unit.test.ts
@@ -86,3 +86,32 @@ describe("coerceBySchema loose structured strings", () => {
     expect(out.tags).toEqual(["a", "b", "c"]);
   });
 });
+
+describe("coerceBySchema Python literal handling (review fixes)", () => {
+  it("converts bare None to null instead of the string 'None'", () => {
+    const out = coerceBySchema(
+      { passenger: "{'name': None, 'age': 34}" },
+      schema
+    ) as Record<string, unknown>;
+
+    expect(out.passenger).toEqual({ name: null, age: 34 });
+  });
+
+  it("never rewrites Python literals inside string values", () => {
+    const out = coerceBySchema(
+      { passenger: "{'name': 'True story of None', 'age': 34}" },
+      schema
+    ) as Record<string, unknown>;
+
+    expect(out.passenger).toEqual({ name: "True story of None", age: 34 });
+  });
+
+  it("unescapes XML entities in XML-children strings", () => {
+    const out = coerceBySchema(
+      { passenger: "<name>Tom &amp; Jerry</name>\n<age>34</age>" },
+      schema
+    ) as Record<string, unknown>;
+
+    expect(out.passenger).toEqual({ name: "Tom & Jerry", age: 34 });
+  });
+});

--- a/src/__tests__/schema-coerce/loose-structured-strings.unit.test.ts
+++ b/src/__tests__/schema-coerce/loose-structured-strings.unit.test.ts
@@ -72,6 +72,18 @@ describe("coerceBySchema loose structured strings", () => {
     expect(typeof out.passenger).toBe("string");
   });
 
+  it("rejects unicode-escaped prototype-sensitive keys after strict JSON parse", () => {
+    const out = coerceBySchema(
+      {
+        passenger:
+          '{"\\u005f\\u005fproto\\u005f\\u005f":{"polluted":true},"name":"Jane Doe"}',
+      },
+      schema
+    ) as Record<string, unknown>;
+
+    expect(typeof out.passenger).toBe("string");
+  });
+
   it("keeps CSV splitting for plain enumerations", () => {
     const out = coerceBySchema(
       { tags: "a, b, c" },

--- a/src/__tests__/stream-handler/json-recovery.integration.test.ts
+++ b/src/__tests__/stream-handler/json-recovery.integration.test.ts
@@ -1,0 +1,175 @@
+import type {
+  LanguageModelV4FunctionTool,
+  LanguageModelV4StreamPart,
+} from "@ai-sdk/provider";
+import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
+import { describe, expect, it, vi } from "vitest";
+
+import { hermesProtocol } from "../../core/protocols/hermes-protocol";
+import { originalToolsSchema } from "../../core/utils/provider-options";
+import { wrapStream } from "../../stream-handler";
+import { stopFinishReason, zeroUsage } from "../test-helpers";
+
+const tools: LanguageModelV4FunctionTool[] = [
+  {
+    type: "function",
+    name: "get_weather",
+    inputSchema: {
+      type: "object",
+      properties: { city: { type: "string" } },
+    },
+  },
+];
+
+function providerStream(
+  parts: LanguageModelV4StreamPart[]
+): ReadableStream<LanguageModelV4StreamPart> {
+  return new ReadableStream<LanguageModelV4StreamPart>({
+    start(controller) {
+      for (const part of parts) {
+        controller.enqueue(part);
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("wrapStream bare-JSON tool call recovery", () => {
+  it("recovers a wrapperless JSON tool call like the generate path does", async () => {
+    // Real-world shape observed from GLM-4.7 through an OpenAI-compatible
+    // endpoint: the whole content is a bare JSON payload without any
+    // <tool_call> markup, delivered inside a normal provider text block.
+    const doStream = vi.fn().mockResolvedValue({
+      stream: providerStream([
+        { type: "stream-start", warnings: [] },
+        { type: "text-start", id: "t0" },
+        {
+          type: "text-delta",
+          id: "t0",
+          delta: '{"name": "get_weather", "arguments": {"city": "Seoul"}}',
+        },
+        { type: "text-end", id: "t0" },
+        {
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        },
+      ]),
+    });
+
+    const { stream } = await wrapStream({
+      protocol: hermesProtocol(),
+      doStream,
+      doGenerate: vi.fn(),
+      params: {
+        providerOptions: {
+          toolCallMiddleware: {
+            originalTools: originalToolsSchema.encode(tools),
+          },
+        },
+      },
+    });
+
+    const out = await convertReadableStreamToArray(stream);
+
+    const toolCall = out.find((p) => p.type === "tool-call") as Extract<
+      LanguageModelV4StreamPart,
+      { type: "tool-call" }
+    >;
+    expect(toolCall).toBeDefined();
+    expect(toolCall.toolName).toBe("get_weather");
+    expect(JSON.parse(toolCall.input)).toEqual({ city: "Seoul" });
+
+    // The JSON payload must not leak as visible text.
+    const text = out
+      .filter((p) => p.type === "text-delta")
+      .map((p) => (p as { delta: string }).delta)
+      .join("");
+    expect(text).toBe("");
+
+    // The tool-input lifecycle reconciles with the final tool call id.
+    const inputStart = out.find((p) => p.type === "tool-input-start");
+    expect((inputStart as { id?: string })?.id).toBe(toolCall.toolCallId);
+
+    // finishReason parity with native tool calling.
+    const finish = out.find((p) => p.type === "finish");
+    expect((finish as { finishReason?: unknown })?.finishReason).toMatchObject({
+      unified: "tool-calls",
+    });
+  });
+
+  it("leaves ordinary text streams untouched", async () => {
+    const doStream = vi.fn().mockResolvedValue({
+      stream: providerStream([
+        { type: "text-start", id: "t0" },
+        { type: "text-delta", id: "t0", delta: "Just a normal answer." },
+        { type: "text-end", id: "t0" },
+        {
+          type: "finish",
+          finishReason: stopFinishReason,
+          usage: zeroUsage,
+        },
+      ]),
+    });
+
+    const { stream } = await wrapStream({
+      protocol: hermesProtocol(),
+      doStream,
+      doGenerate: vi.fn(),
+      params: {
+        providerOptions: {
+          toolCallMiddleware: {
+            originalTools: originalToolsSchema.encode(tools),
+          },
+        },
+      },
+    });
+
+    const out = await convertReadableStreamToArray(stream);
+
+    expect(out.some((p) => p.type === "tool-call")).toBe(false);
+    const text = out
+      .filter((p) => p.type === "text-delta")
+      .map((p) => (p as { delta: string }).delta)
+      .join("");
+    expect(text).toBe("Just a normal answer.");
+    const finish = out.find((p) => p.type === "finish");
+    expect((finish as { finishReason?: unknown })?.finishReason).toEqual(
+      stopFinishReason
+    );
+  });
+});
+
+describe("wrapStream toolChoice none passthrough", () => {
+  it("returns the model stream untouched without parsing", async () => {
+    const parts: LanguageModelV4StreamPart[] = [
+      { type: "text-start", id: "t0" },
+      {
+        type: "text-delta",
+        id: "t0",
+        delta: '<tool_call>{"name":"get_weather"}</tool_call>',
+      },
+      { type: "text-end", id: "t0" },
+      { type: "finish", finishReason: stopFinishReason, usage: zeroUsage },
+    ];
+    const streamResult = { stream: providerStream(parts) };
+    const doStream = vi.fn().mockResolvedValue(streamResult);
+
+    const result = await wrapStream({
+      protocol: hermesProtocol(),
+      doStream,
+      doGenerate: vi.fn(),
+      params: {
+        providerOptions: {
+          toolCallMiddleware: {
+            toolChoice: { type: "none" },
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(streamResult);
+    const out = await convertReadableStreamToArray(result.stream);
+    expect(out).toEqual(parts);
+  });
+});

--- a/src/__tests__/stream-handler/toolchoice.behavior.test.ts
+++ b/src/__tests__/stream-handler/toolchoice.behavior.test.ts
@@ -7,7 +7,7 @@ import { mockUsage } from "../test-helpers";
 const TOOL_CALL_ID_RE = /^call_[A-Za-z0-9]{24}$/;
 
 describe("toolChoiceStream behavior", () => {
-  it("emits tool-call and finish chunks from valid JSON text", async () => {
+  it("emits the full tool-input lifecycle and finish from valid JSON text", async () => {
     const doGenerate = vi.fn().mockResolvedValue({
       content: [{ type: "text", text: '{"name":"do","arguments":{"x":1}}' }],
       usage: mockUsage(3, 5),
@@ -22,15 +22,44 @@ describe("toolChoiceStream behavior", () => {
 
     const chunks = await convertReadableStreamToArray(stream);
 
-    expect(chunks[0]).toMatchObject({
+    expect(chunks.map((c) => c.type)).toEqual([
+      "stream-start",
+      "tool-input-start",
+      "tool-input-delta",
+      "tool-input-end",
+      "tool-call",
+      "finish",
+    ]);
+
+    expect(chunks[0]).toMatchObject({ type: "stream-start", warnings: [] });
+    expect(chunks[1]).toMatchObject({
+      type: "tool-input-start",
+      toolName: "do",
+    });
+    expect(chunks[2]).toMatchObject({
+      type: "tool-input-delta",
+      delta: '{"x":1}',
+    });
+
+    const toolCall = chunks[4] as {
+      type: string;
+      toolCallId: string;
+      toolName: string;
+      input: string;
+    };
+    expect(toolCall).toMatchObject({
       type: "tool-call",
       toolName: "do",
       input: '{"x":1}',
     });
-    expect((chunks[0] as { toolCallId?: string }).toolCallId).toMatch(
-      TOOL_CALL_ID_RE
-    );
-    expect(chunks[1]).toMatchObject({
+    expect(toolCall.toolCallId).toMatch(TOOL_CALL_ID_RE);
+
+    // The tool-input lifecycle ids reconcile with the final toolCallId.
+    expect((chunks[1] as { id?: string }).id).toBe(toolCall.toolCallId);
+    expect((chunks[2] as { id?: string }).id).toBe(toolCall.toolCallId);
+    expect((chunks[3] as { id?: string }).id).toBe(toolCall.toolCallId);
+
+    expect(chunks[5]).toMatchObject({
       type: "finish",
       finishReason: {
         unified: "tool-calls",
@@ -41,6 +70,34 @@ describe("toolChoiceStream behavior", () => {
     expect(response).toEqual({ b: 2 });
   });
 
+  it("forwards underlying warnings on stream-start", async () => {
+    const warnings = [{ type: "unsupported", feature: "seed" }];
+    const doGenerate = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: '{"name":"do","arguments":{}}' }],
+      warnings,
+    });
+
+    const { stream } = await toolChoiceStream({ doGenerate, tools: [] });
+    const chunks = await convertReadableStreamToArray(stream);
+
+    expect(chunks[0]).toMatchObject({ type: "stream-start", warnings });
+  });
+
+  it("forwards providerMetadata on the finish part", async () => {
+    const doGenerate = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: '{"name":"do","arguments":{}}' }],
+      providerMetadata: { someProvider: { traceId: "t1" } },
+    });
+
+    const { stream } = await toolChoiceStream({ doGenerate, tools: [] });
+    const chunks = await convertReadableStreamToArray(stream);
+
+    expect(chunks.at(-1)).toMatchObject({
+      type: "finish",
+      providerMetadata: { someProvider: { traceId: "t1" } },
+    });
+  });
+
   it("falls back to unknown tool and empty args on invalid JSON", async () => {
     const doGenerate = vi.fn().mockResolvedValue({
       content: [{ type: "text", text: "not-json" }],
@@ -49,15 +106,16 @@ describe("toolChoiceStream behavior", () => {
     const { stream } = await toolChoiceStream({ doGenerate, tools: [] });
     const chunks = await convertReadableStreamToArray(stream);
 
-    expect(chunks[0]).toMatchObject({
+    const toolCall = chunks.find((c) => c.type === "tool-call");
+    expect(toolCall).toMatchObject({
       type: "tool-call",
       toolName: "unknown",
       input: "{}",
     });
-    expect((chunks[0] as { toolCallId?: string }).toolCallId).toMatch(
+    expect((toolCall as { toolCallId?: string }).toolCallId).toMatch(
       TOOL_CALL_ID_RE
     );
-    expect(chunks[1]).toMatchObject({ type: "finish" });
+    expect(chunks.at(-1)).toMatchObject({ type: "finish" });
   });
 
   it("handles empty content by emitting default unknown tool and zeroed usage", async () => {
@@ -66,12 +124,12 @@ describe("toolChoiceStream behavior", () => {
     const { stream } = await toolChoiceStream({ doGenerate, tools: [] });
     const chunks = await convertReadableStreamToArray(stream);
 
-    expect(chunks[0]).toMatchObject({
+    expect(chunks.find((c) => c.type === "tool-call")).toMatchObject({
       type: "tool-call",
       toolName: "unknown",
       input: "{}",
     });
-    expect(chunks[1]).toMatchObject({
+    expect(chunks.at(-1)).toMatchObject({
       type: "finish",
       usage: {
         inputTokens: {
@@ -98,7 +156,7 @@ describe("toolChoiceStream behavior", () => {
     const { stream } = await toolChoiceStream({ doGenerate, tools: [] });
     const chunks = await convertReadableStreamToArray(stream);
 
-    expect(chunks[1]).toMatchObject({
+    expect(chunks.at(-1)).toMatchObject({
       type: "finish",
       finishReason: {
         unified: "tool-calls",

--- a/src/__tests__/stream-handler/toolchoice.coercion.test.ts
+++ b/src/__tests__/stream-handler/toolchoice.coercion.test.ts
@@ -32,7 +32,7 @@ describe("toolChoiceStream coercion", () => {
     });
     const chunks = await convertReadableStreamToArray(stream);
 
-    expect(chunks[0]).toMatchObject({
+    expect(chunks.find((c) => c.type === "tool-call")).toMatchObject({
       type: "tool-call",
       toolName: "calc",
       input: '{"a":10,"b":false}',

--- a/src/__tests__/stream-handler/toolchoice.compat.test.ts
+++ b/src/__tests__/stream-handler/toolchoice.compat.test.ts
@@ -13,12 +13,12 @@ describe("toolChoiceStream compat", () => {
     const { stream } = await toolChoiceStream({ doGenerate });
     const chunks = await convertReadableStreamToArray(stream);
 
-    expect(chunks[0]).toMatchObject({
+    expect(chunks.find((c) => c.type === "tool-call")).toMatchObject({
       type: "tool-call",
       toolName: "do",
       input: '{"x":1}',
     });
-    expect(chunks[1]).toMatchObject({ type: "finish" });
+    expect(chunks.at(-1)).toMatchObject({ type: "finish" });
   });
 
   it("normalizes finish reason to tool-calls and preserves legacy object reason", async () => {
@@ -31,7 +31,7 @@ describe("toolChoiceStream compat", () => {
     const { stream } = await toolChoiceStream({ doGenerate, tools: [] });
     const chunks = await convertReadableStreamToArray(stream);
 
-    expect(chunks[1]).toMatchObject({
+    expect(chunks.at(-1)).toMatchObject({
       type: "finish",
       finishReason: {
         unified: "tool-calls",
@@ -49,7 +49,7 @@ describe("toolChoiceStream compat", () => {
     const { stream } = await toolChoiceStream({ doGenerate, tools: [] });
     const chunks = await convertReadableStreamToArray(stream);
 
-    expect(chunks[1]).toMatchObject({
+    expect(chunks.at(-1)).toMatchObject({
       type: "finish",
       usage: mockUsage(7, 11),
     });

--- a/src/__tests__/transform-handler/prompt-template.transform-params-toolchoice-validation.test.ts
+++ b/src/__tests__/transform-handler/prompt-template.transform-params-toolchoice-validation.test.ts
@@ -15,7 +15,7 @@ const _REGEX_GET_WEATHER = /get_weather/;
 const _REGEX_FUNCTION_CALLING_MODEL = /You are a function calling AI model/;
 const _REGEX_MAY_CALL_FUNCTIONS = /You may call one or more functions/;
 const _REGEX_TOOLS_TAG = /<tools>/;
-const REGEX_NONE = /none/;
+const _REGEX_NONE = /none/;
 const _REGEX_NOT_FOUND = /not found/;
 const _REGEX_PROVIDER_DEFINED = /Provider-defined tools/;
 const _REGEX_REQUIRED_NO_TOOLS =
@@ -27,17 +27,40 @@ const _REGEX_GET_WEATHER_TAG = /<get_weather>/;
 const _REGEX_TOOL_CALL_WORD = /tool_call/;
 
 describe("transformParams toolChoice validation", () => {
-  it("transformParams throws on toolChoice type none", async () => {
+  it("transformParams handles toolChoice type none without tool prompt injection", async () => {
     const mw = createToolMiddleware({
       protocol: hermesProtocol,
-      toolSystemPromptTemplate: () => "",
+      toolSystemPromptTemplate: () => "TOOL PROMPT",
     });
+    const tools = [
+      {
+        type: "function",
+        name: "get_weather",
+        description: "d",
+        inputSchema: { type: "object", properties: { a: { type: "string" } } },
+      },
+    ];
     const transformParams = requireTransformParams(mw.transformParams);
-    await expect(
-      transformParams({
-        params: { prompt: [], tools: [], toolChoice: { type: "none" } },
-      } as any)
-    ).rejects.toThrow(REGEX_NONE);
+    const result = await transformParams({
+      params: {
+        prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+        tools,
+        toolChoice: { type: "none" },
+      },
+    } as any);
+
+    // No tool definitions are forwarded and no tool system prompt is added.
+    expect(result.tools).toEqual([]);
+    expect(result.toolChoice).toBeUndefined();
+    expect(result.prompt).toEqual([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ]);
+    expect(
+      (result.providerOptions as any).toolCallMiddleware.toolChoice
+    ).toEqual({ type: "none" });
+    expect(
+      (result.providerOptions as any).toolCallMiddleware.originalTools
+    ).toBeUndefined();
   });
 
   it("transformParams validates specific tool selection and builds JSON schema", async () => {

--- a/src/core/prompts/shared/tool-result-normalizer.ts
+++ b/src/core/prompts/shared/tool-result-normalizer.ts
@@ -52,6 +52,7 @@ function getContentPartMediaKind(part: unknown): ToolResponseMediaType | null {
     case "image-url":
     case "image-file-id":
       return "image";
+    case "file":
     case "file-data":
     case "file-url":
     case "file-id": {
@@ -137,11 +138,63 @@ function formatIdPlaceholder(
   return `[${label}: ${displayId}]`;
 }
 
+interface TaggedFileData {
+  data?: unknown;
+  reference?: unknown;
+  text?: string;
+  type?: string;
+  url?: string;
+}
+
+/**
+ * Placeholder for the canonical v4 `type: 'file'` content part whose `data`
+ * is a tagged union (`data` / `url` / `reference` / `text`).
+ */
+function formatTaggedFilePartPlaceholder(contentPart: {
+  data?: unknown;
+  mediaType?: string;
+  filename?: string;
+}): string {
+  const fileData = isMapping(contentPart.data)
+    ? (contentPart.data as TaggedFileData)
+    : undefined;
+  const mediaType = contentPart.mediaType ?? "application/octet-stream";
+  const isImage = mediaType.startsWith("image");
+
+  switch (fileData?.type) {
+    case "url":
+      return isImage
+        ? `[Image URL: ${fileData.url}]`
+        : `[File URL: ${fileData.url}]`;
+    case "reference":
+      return formatIdPlaceholder(
+        isImage ? "Image ID" : "File ID",
+        fileData.reference
+      );
+    case "text":
+      // Inline text documents are readable content; surface the text itself.
+      return fileData.text ?? "";
+    default: {
+      if (isImage) {
+        return `[Image: ${mediaType}]`;
+      }
+      if (contentPart.filename) {
+        return `[File: ${contentPart.filename} (${mediaType})]`;
+      }
+      return `[File: ${mediaType}]`;
+    }
+  }
+}
+
 function formatContentPartPlaceholder(part: unknown): string {
   const contentPart = part as { type?: string };
   switch (contentPart.type) {
     case "text":
       return (contentPart as { text?: string }).text ?? "";
+    case "file":
+      return formatTaggedFilePartPlaceholder(
+        contentPart as { data?: unknown; mediaType?: string; filename?: string }
+      );
     case "image-data":
       return `[Image: ${(contentPart as { mediaType?: string }).mediaType}]`;
     case "image-url":
@@ -206,6 +259,10 @@ function toModelContentPart(part: unknown): ToolResponseUserContentPart {
   switch (contentPart.type) {
     case "text":
       return toTextPart(contentPart.text ?? "", contentPart.providerOptions);
+    case "file":
+      // Canonical v4 file part — already in LanguageModelV4FilePart shape
+      // (tagged `data` union, mediaType, optional filename).
+      return part as LanguageModelV4FilePart;
     case "image-data":
       return toFilePart({
         data: contentPart.data ?? "",

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -1259,6 +1259,63 @@ function collectObjectKeys(
   return null;
 }
 
+/**
+ * Unwrap the double-encoded arguments variant some models emit
+ * (`"arguments": "{\"city\": \"Seoul\"}"` — the OpenAI native wire shape,
+ * observed live on IBM Granite 4.0). Returns the parsed record, or null when
+ * the string is not a safe JSON object.
+ */
+function tryParseDoubleEncodedArguments(
+  args: string
+): Record<string, unknown> | null {
+  if (!args.trimStart().startsWith("{")) {
+    return null;
+  }
+  if (hasPrototypeSensitiveKeyInJsonLikeObject(args)) {
+    return null;
+  }
+  try {
+    const parsed = parseRJSON(normalizeJsonStringCtrl(args));
+    return isRecord(parsed) && !containsPrototypeSensitiveArgumentKey(parsed)
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function applyNonRecordArgumentPolicy(
+  toolName: string,
+  args: Exclude<unknown, Record<string, unknown>>,
+  tools: LanguageModelV4FunctionTool[],
+  keyPolicy: ArgumentKeyPolicy | undefined
+): { args: unknown } | null {
+  if (args === null) {
+    return topLevelNullArgumentMatchesToolSchema(toolName, tools)
+      ? { args }
+      : null;
+  }
+  if (
+    keyPolicy &&
+    argumentValueMatchesSchemaKeyShape(args, keyPolicy.schema, new Set(), true)
+  ) {
+    return { args };
+  }
+  if (typeof args === "string") {
+    const unwrapped = tryParseDoubleEncodedArguments(args);
+    if (unwrapped) {
+      const unwrappedPolicyArgs = applyArgumentKeyPolicy(unwrapped, keyPolicy);
+      if (unwrappedPolicyArgs !== null) {
+        return { args: unwrappedPolicyArgs };
+      }
+    }
+  }
+  if (keyPolicy?.rejectNonRecordArguments) {
+    return null;
+  }
+  return { args };
+}
+
 function applyToolArgumentKeyPolicy(
   toolName: string,
   args: unknown,
@@ -1270,26 +1327,12 @@ function applyToolArgumentKeyPolicy(
   }
   const normalizedArgs = args === undefined ? {} : args;
   if (!isRecord(normalizedArgs)) {
-    if (normalizedArgs === null) {
-      return topLevelNullArgumentMatchesToolSchema(toolName, tools)
-        ? { args: normalizedArgs }
-        : null;
-    }
-    if (
-      keyPolicy &&
-      argumentValueMatchesSchemaKeyShape(
-        normalizedArgs,
-        keyPolicy.schema,
-        new Set(),
-        true
-      )
-    ) {
-      return { args: normalizedArgs };
-    }
-    if (keyPolicy?.rejectNonRecordArguments) {
-      return null;
-    }
-    return { args: normalizedArgs };
+    return applyNonRecordArgumentPolicy(
+      toolName,
+      normalizedArgs,
+      tools,
+      keyPolicy
+    );
   }
   const policyArgs = applyArgumentKeyPolicy(normalizedArgs, keyPolicy);
   return policyArgs === null ? null : { args: policyArgs };
@@ -1766,16 +1809,22 @@ function resolveToolCall(
         return { ok: false, error: repairError };
       }
     }
-    // Last resort: salvage a balanced `{"name": ..., "arguments": ...}`
-    // payload for a known tool from a body with trailing garbage (e.g. a
-    // mismatched close tag such as `{...}</think>`). This path resolves a
-    // single call, so multi-call bodies stay with the caller's fallback.
-    const recoveredCalls = recoverKnownToolCallsFromText(toolCallJson, tools);
-    if (recoveredCalls?.length === 1) {
-      return recoveredCalls[0];
-    }
     return { ok: false, error };
   }
+}
+
+/**
+ * Salvage layer shared by the closed-body emission paths: when the strict
+ * parse/repair pipeline fails, recover one or more balanced
+ * `{"name": ..., "arguments": ...}` payloads for known tools from bodies
+ * with markup garbage (mismatched `</think>` close tags, `<tool_call>`
+ * separators, array-wrapped call lists).
+ */
+function salvageResolvedToolCalls(
+  toolCallJson: string,
+  tools: LanguageModelV4FunctionTool[]
+): Extract<ResolvedToolCall, { ok: true }>[] | null {
+  return recoverKnownToolCallsFromText(toolCallJson, tools);
 }
 
 /** Whitespace and complete tag-like tokens only (e.g. a stray `</think>`). */
@@ -1868,6 +1917,19 @@ function processToolCallJson(
       toolName: resolved.toolName,
       input: resolved.input,
     });
+    return;
+  }
+
+  const salvagedCalls = salvageResolvedToolCalls(toolCallJson, tools);
+  if (salvagedCalls && salvagedCalls.length > 0) {
+    for (const salvagedCall of salvagedCalls) {
+      processedElements.push({
+        type: "tool-call",
+        toolCallId: generateToolCallId(),
+        toolName: salvagedCall.toolName,
+        input: salvagedCall.input,
+      });
+    }
     return;
   }
 
@@ -2648,6 +2710,23 @@ function emitToolCall(context: TagProcessingContext) {
     // streaming the tool-input lifecycle (was inside emitToolCallFromParsed).
     closeTextBlock(state, controller);
     emitResolvedToolCall(state, controller, resolved.toolName, resolved.input);
+    return;
+  }
+
+  const salvagedCalls = salvageResolvedToolCalls(
+    state.currentToolCallJson,
+    tools
+  );
+  if (salvagedCalls && salvagedCalls.length > 0) {
+    closeTextBlock(state, controller);
+    for (const salvagedCall of salvagedCalls) {
+      emitResolvedToolCall(
+        state,
+        controller,
+        salvagedCall.toolName,
+        salvagedCall.input
+      );
+    }
     return;
   }
 

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -1738,8 +1738,6 @@ function repairToolCallJsonForTools(
 }
 
 const VALID_JSON_ESCAPE_CHARS = new Set([
-  '"',
-  "'",
   "\\",
   "/",
   "b",
@@ -1749,6 +1747,16 @@ const VALID_JSON_ESCAPE_CHARS = new Set([
   "t",
   "u",
 ]);
+
+function isValidJsonEscape(
+  next: string | undefined,
+  quote: '"' | "'"
+): boolean {
+  if (next === undefined) {
+    return true;
+  }
+  return next === quote || VALID_JSON_ESCAPE_CHARS.has(next);
+}
 
 /**
  * Drop the backslash from invalid JSON escape sequences inside string values
@@ -1776,7 +1784,7 @@ function normalizeInvalidJsonEscapes(json: string): string {
       continue;
     }
     const next = json[i + 1];
-    if (next !== undefined && !VALID_JSON_ESCAPE_CHARS.has(next)) {
+    if (!isValidJsonEscape(next, quote)) {
       parts ??= [];
       parts.push(json.slice(chunkStart, i));
       chunkStart = i + 1;

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -1275,7 +1275,9 @@ function tryParseDoubleEncodedArguments(
     return null;
   }
   try {
-    const parsed = parseRJSON(normalizeJsonStringCtrl(args));
+    const parsed = parseRJSON(
+      normalizeInvalidJsonEscapes(normalizeJsonStringCtrl(args))
+    );
     return isRecord(parsed) && !containsPrototypeSensitiveArgumentKey(parsed)
       ? parsed
       : null;
@@ -1869,20 +1871,6 @@ function resolveToolCall(
   }
 }
 
-/**
- * Salvage layer shared by the closed-body emission paths: when the strict
- * parse/repair pipeline fails, recover one or more balanced
- * `{"name": ..., "arguments": ...}` payloads for known tools from bodies
- * with markup garbage (mismatched `</think>` close tags, `<tool_call>`
- * separators, array-wrapped call lists).
- */
-function salvageResolvedToolCalls(
-  toolCallJson: string,
-  tools: LanguageModelV4FunctionTool[]
-): Extract<ResolvedToolCall, { ok: true }>[] | null {
-  return recoverKnownToolCallsFromText(toolCallJson, tools);
-}
-
 /** Whitespace and complete tag-like tokens only (e.g. a stray `</think>`). */
 const MARKUP_ONLY_TEXT_REGEX = /^\s*(?:<[^<>\n]*>\s*)*$/;
 
@@ -1976,7 +1964,7 @@ function processToolCallJson(
     return;
   }
 
-  const salvagedCalls = salvageResolvedToolCalls(toolCallJson, tools);
+  const salvagedCalls = recoverKnownToolCallsFromText(toolCallJson, tools);
   if (salvagedCalls && salvagedCalls.length > 0) {
     for (const salvagedCall of salvagedCalls) {
       processedElements.push({
@@ -2773,7 +2761,7 @@ function emitToolCall(context: TagProcessingContext) {
     return;
   }
 
-  const salvagedCalls = salvageResolvedToolCalls(
+  const salvagedCalls = recoverKnownToolCallsFromText(
     state.currentToolCallJson,
     tools
   );

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -1735,6 +1735,60 @@ function repairToolCallJsonForTools(
   }
 }
 
+const VALID_JSON_ESCAPE_CHARS = new Set([
+  '"',
+  "'",
+  "\\",
+  "/",
+  "b",
+  "f",
+  "n",
+  "r",
+  "t",
+  "u",
+]);
+
+/**
+ * Drop the backslash from invalid JSON escape sequences inside string values
+ * (e.g. `\$` from a template literal in generated code — observed live on
+ * Cohere Command R+). Valid escapes and structural characters are untouched.
+ */
+function normalizeInvalidJsonEscapes(json: string): string {
+  let quote: '"' | "'" | null = null;
+  let parts: string[] | null = null;
+  let chunkStart = 0;
+
+  for (let i = 0; i < json.length; i += 1) {
+    const ch = json[i];
+    if (quote === null) {
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+      }
+      continue;
+    }
+    if (ch === quote) {
+      quote = null;
+      continue;
+    }
+    if (ch !== "\\") {
+      continue;
+    }
+    const next = json[i + 1];
+    if (next !== undefined && !VALID_JSON_ESCAPE_CHARS.has(next)) {
+      parts ??= [];
+      parts.push(json.slice(chunkStart, i));
+      chunkStart = i + 1;
+    }
+    i += 1;
+  }
+
+  if (parts === null) {
+    return json;
+  }
+  parts.push(json.slice(chunkStart));
+  return parts.join("");
+}
+
 /**
  * Discriminated result of resolving a raw `<tool_call>` JSON body into a final,
  * emittable tool call. Shared by the non-streaming (`parseGeneratedText` ->
@@ -1767,7 +1821,9 @@ function resolveToolCall(
   tools: LanguageModelV4FunctionTool[]
 ): ResolvedToolCall {
   try {
-    const parsedToolCall = parseRJSON(normalizeJsonStringCtrl(toolCallJson));
+    const parsedToolCall = parseRJSON(
+      normalizeInvalidJsonEscapes(normalizeJsonStringCtrl(toolCallJson))
+    );
     if (!isParsedToolCallRecord(parsedToolCall)) {
       throw new Error("Tool call object is missing own name or arguments");
     }
@@ -2360,7 +2416,9 @@ function emitStreamingToolInputProgress(options: {
     return false;
   }
   try {
-    const parsedToolCall = parseRJSON(normalizeJsonStringCtrl(toolCallJson));
+    const parsedToolCall = parseRJSON(
+      normalizeInvalidJsonEscapes(normalizeJsonStringCtrl(toolCallJson))
+    );
     if (!isParsedToolCallRecord(parsedToolCall)) {
       return false;
     }
@@ -2555,7 +2613,9 @@ function emitIncompleteToolCall(
   if (state.currentToolCallJson) {
     try {
       const parsedToolCall = parseRJSON(
-        normalizeJsonStringCtrl(state.currentToolCallJson)
+        normalizeInvalidJsonEscapes(
+          normalizeJsonStringCtrl(state.currentToolCallJson)
+        )
       );
       if (!isParsedToolCallRecord(parsedToolCall)) {
         throw new Error("Tool call object is missing own name or arguments");

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -13,6 +13,7 @@ import {
   unwrapJsonSchema,
 } from "../../schema-coerce";
 import { logParseFailure } from "../utils/debug";
+import { recoverToolCallFromJsonCandidates } from "../utils/generated-text-json-recovery";
 import { getPotentialStartIndex } from "../utils/get-potential-start-index";
 import { generateId, generateToolCallId } from "../utils/id";
 import {
@@ -1765,8 +1766,91 @@ function resolveToolCall(
         return { ok: false, error: repairError };
       }
     }
+    // Last resort: salvage a balanced `{"name": ..., "arguments": ...}`
+    // payload for a known tool from a body with trailing garbage (e.g. a
+    // mismatched close tag such as `{...}</think>`). This path resolves a
+    // single call, so multi-call bodies stay with the caller's fallback.
+    const recoveredCalls = recoverKnownToolCallsFromText(toolCallJson, tools);
+    if (recoveredCalls?.length === 1) {
+      return recoveredCalls[0];
+    }
     return { ok: false, error };
   }
+}
+
+/** Whitespace and complete tag-like tokens only (e.g. a stray `</think>`). */
+const MARKUP_ONLY_TEXT_REGEX = /^\s*(?:<[^<>\n]*>\s*)*$/;
+
+/**
+ * Run the shared JSON-candidate recovery over `text` and return every
+ * recovered call for known tools, in `ResolvedToolCall` success shape.
+ *
+ * The salvage is deliberately narrow so it cannot override the primary
+ * parser's intentional fallbacks:
+ *   - the body must consist solely of tool payloads plus markup remnants
+ *     (whitespace or complete tag-like tokens such as a mismatched
+ *     `</think>` close tag or `<tool_call>` separators). Bodies whose parse
+ *     failed mid-object (e.g. unescaped quotes, trailing top-level fields)
+ *     keep falling back to text.
+ *   - prototype-sensitive keys are re-checked on the raw text, and recovered
+ *     arguments go through the same argument key policy as the primary path.
+ */
+function recoverKnownToolCallsFromText(
+  text: string,
+  tools: LanguageModelV4FunctionTool[]
+): Extract<ResolvedToolCall, { ok: true }>[] | null {
+  if (hasPrototypeSensitiveKeyInJsonLikeObject(text)) {
+    return null;
+  }
+
+  const recoveredParts = recoverToolCallFromJsonCandidates(text, tools);
+  if (!recoveredParts) {
+    return null;
+  }
+
+  const calls: Extract<ResolvedToolCall, { ok: true }>[] = [];
+  for (const part of recoveredParts) {
+    if (part.type === "text") {
+      if (!MARKUP_ONLY_TEXT_REGEX.test(part.text)) {
+        return null;
+      }
+      continue;
+    }
+    if (part.type !== "tool-call") {
+      return null;
+    }
+
+    let parsedArgs: unknown;
+    try {
+      parsedArgs = JSON.parse(part.input);
+    } catch {
+      return null;
+    }
+    const policyArguments = applyToolArgumentKeyPolicy(
+      part.toolName,
+      parsedArgs,
+      tools
+    );
+    if (policyArguments === null) {
+      return null;
+    }
+
+    try {
+      calls.push({
+        ok: true,
+        toolName: part.toolName,
+        input: stringifyParsedToolInput(
+          part.toolName,
+          policyArguments.args,
+          tools
+        ),
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  return calls.length > 0 ? calls : null;
 }
 
 function processToolCallJson(
@@ -1821,10 +1905,6 @@ interface StreamState {
   hasEmittedTextStart: boolean;
   isInsideToolCall: boolean;
   pendingToolInputProgressVersion: number;
-  speculativeToolCall: {
-    input: string;
-    toolName: string;
-  } | null;
 }
 
 type StreamController =
@@ -2241,10 +2321,6 @@ function emitStreamingToolInputProgress(options: {
     });
     ensureToolInputStart(state, controller, parsedToolCall.name);
     emitToolInputDelta(state, controller, input);
-    state.speculativeToolCall = {
-      input,
-      toolName: parsedToolCall.name,
-    };
     return true;
   } catch {
     return false;
@@ -2305,7 +2381,6 @@ function emitResolvedToolCall(
   emitToolInputDelta(state, controller, input);
   const toolCallId = state.activeToolInput?.id ?? generateToolCallId();
   closeToolInput(state, controller);
-  state.speculativeToolCall = null;
   controller.enqueue({
     type: "tool-call",
     toolCallId,
@@ -2334,11 +2409,7 @@ function emitToolCallFromParsed(
   emitResolvedToolCall(state, controller, toolName, input);
 }
 
-function flushBuffer(
-  state: StreamState,
-  controller: StreamController,
-  toolCallStart: string
-) {
+function flushBuffer(state: StreamState, controller: StreamController) {
   if (state.buffer.length === 0) {
     return;
   }
@@ -2352,14 +2423,10 @@ function flushBuffer(
     state.hasEmittedTextStart = true;
   }
 
-  const deltaContent = state.isInsideToolCall
-    ? `${toolCallStart}${state.buffer}`
-    : state.buffer;
-
   controller.enqueue({
     type: "text-delta",
     id: state.currentTextId,
-    delta: deltaContent,
+    delta: state.buffer,
   } as LanguageModelV4StreamPart);
   state.buffer = "";
 }
@@ -2373,6 +2440,41 @@ function closeTextBlock(state: StreamState, controller: StreamController) {
     state.currentTextId = null;
     state.hasEmittedTextStart = false;
   }
+}
+
+/**
+ * Salvage tool calls from an unterminated streaming tool-call body. A call
+ * closed with the wrong tag (e.g. `<tool_call>{...}</think>`) or a run of
+ * calls separated by bare `<tool_call>` tags never sees an end tag, but the
+ * JSON bodies themselves are complete. Genuinely truncated JSON stays
+ * unbalanced, fails recovery, and the caller falls through to the error
+ * fallback. Returns true when at least one call was emitted.
+ */
+function salvageIncompleteToolCalls(
+  state: StreamState,
+  controller: StreamController,
+  rawToolCallContent: string,
+  tools: LanguageModelV4FunctionTool[]
+): boolean {
+  const recoveredCalls = recoverKnownToolCallsFromText(
+    rawToolCallContent,
+    tools
+  );
+  if (!recoveredCalls || recoveredCalls.length === 0) {
+    return false;
+  }
+  closeTextBlock(state, controller);
+  for (const recoveredCall of recoveredCalls) {
+    emitResolvedToolCall(
+      state,
+      controller,
+      recoveredCall.toolName,
+      recoveredCall.input
+    );
+  }
+  state.currentToolCallJson = "";
+  state.isInsideToolCall = false;
+  return true;
 }
 
 function emitIncompleteToolCall(
@@ -2418,12 +2520,19 @@ function emitIncompleteToolCall(
       return;
     } catch {
       // Incomplete tool calls (no closing </tool_call>) are not candidates
-      // for repair — the JSON may be genuinely truncated.
-      // Fall through to text/error fallback.
+      // for quote repair — the JSON may be genuinely truncated.
+      // Fall through to balanced-JSON salvage, then text/error fallback.
     }
   }
 
   const rawToolCallContent = `${state.currentToolCallJson}${trailingBuffer}`;
+
+  if (
+    salvageIncompleteToolCalls(state, controller, rawToolCallContent, tools)
+  ) {
+    return;
+  }
+
   const errorContent = `${toolCallStart}${rawToolCallContent}`;
   const shouldEmitRawFallback = shouldEmitRawToolCallTextOnError(options);
 
@@ -2499,7 +2608,7 @@ function handleFinishChunk(
       options
     );
   } else if (state.buffer.length > 0) {
-    flushBuffer(state, controller, toolCallStart);
+    flushBuffer(state, controller);
   }
   closeTextBlock(state, controller);
   controller.enqueue(chunk);
@@ -2545,7 +2654,6 @@ function emitToolCall(context: TagProcessingContext) {
   const finalError = resolved.error;
   const activeToolCallId = state.activeToolInput?.id;
   const activeToolName = state.activeToolInput?.toolName;
-  state.speculativeToolCall = null;
 
   const errorContent = `${toolCallStart}${state.currentToolCallJson}${toolCallEnd}`;
   const shouldEmitRawFallback = shouldEmitRawToolCallTextOnError(options);
@@ -2842,7 +2950,9 @@ export const hermesProtocol = ({
 
       if (!span.found) {
         // Orphan start tag — emit everything up to and including it as text,
-        // then continue searching for subsequent tool calls.
+        // then continue searching for subsequent tool calls. The original
+        // text is preserved verbatim here: the parser cannot be sure this is
+        // protocol markup, and dropped-call salvage happens downstream.
         const skipTo = span.startIdx + toolCallStart.length;
         if (skipTo > currentIndex) {
           addTextSegment(text.slice(currentIndex, skipTo), processedElements);
@@ -2899,7 +3009,6 @@ export const hermesProtocol = ({
       hasEmittedTextStart: false,
       activeToolInput: null,
       pendingToolInputProgressVersion: 0,
-      speculativeToolCall: null,
     };
 
     return new TransformStream<

--- a/src/core/protocols/qwen3coder-protocol.ts
+++ b/src/core/protocols/qwen3coder-protocol.ts
@@ -431,6 +431,11 @@ type Qwen3CoderToolParserParamTagParseResult =
       openEnd: number | null;
       name?: string;
       value?: string;
+    }
+  | {
+      kind: "skip";
+      start: number;
+      end: number;
     };
 
 function parseQwen3CoderToolParserParamTagNameLower(
@@ -542,6 +547,14 @@ function parseQwen3CoderToolParserParamTagAt(
     tagNameLower
   );
   const paramName = paramNameRaw?.trim() ?? "";
+  const selfClosing = openTag.trimEnd().endsWith("/>");
+  if (selfClosing && paramName.length === 0) {
+    return {
+      kind: "skip",
+      start: startIndex,
+      end: openEnd + 1,
+    };
+  }
   if (paramName.length === 0) {
     return parseQwen3CoderNamelessParamTag({
       text,
@@ -554,7 +567,6 @@ function parseQwen3CoderToolParserParamTagAt(
     });
   }
 
-  const selfClosing = openTag.trimEnd().endsWith("/>");
   if (selfClosing) {
     return {
       kind: "match",
@@ -865,6 +877,11 @@ function extractParameters(
 
     if (parsed.kind === "match") {
       mergeParamValue(args, parsed.name, parsed.value);
+      index = parsed.end;
+      continue;
+    }
+
+    if (parsed.kind === "skip") {
       index = parsed.end;
       continue;
     }

--- a/src/core/protocols/qwen3coder-protocol.ts
+++ b/src/core/protocols/qwen3coder-protocol.ts
@@ -108,6 +108,46 @@ function isTagBoundaryChar(ch: string): boolean {
   return ch === "" || isAsciiWhitespace(ch) || ch === ">" || ch === "/";
 }
 
+function isTagNameBoundaryChar(ch: string | undefined): boolean {
+  return (
+    ch === undefined ||
+    isAsciiWhitespace(ch) ||
+    ch === ">" ||
+    ch === "/" ||
+    ch === "="
+  );
+}
+
+/**
+ * Like `getPotentialStartIndex`, but tag-shape aware: a complete occurrence
+ * of the prefix counts only when followed by a valid tag-name boundary, so
+ * ordinary text such as `<callback>` or `<toolbar>` does not pin the stream
+ * buffer until finish. A trailing partial occurrence is still reported so a
+ * real tag split across chunks is never flushed as text prematurely.
+ */
+function getPotentialTagStartIndex(
+  lower: string,
+  prefixLower: string
+): number | null {
+  let from = 0;
+  while (true) {
+    const index = lower.indexOf(prefixLower, from);
+    if (index === -1) {
+      break;
+    }
+    if (isTagNameBoundaryChar(lower[index + prefixLower.length])) {
+      return index;
+    }
+    from = index + 1;
+  }
+
+  const partialIndex = getPotentialStartIndex(lower, prefixLower);
+  return partialIndex != null &&
+    partialIndex + prefixLower.length > lower.length
+    ? partialIndex
+    : null;
+}
+
 function findTagEndIndex(text: string, startIndex: number): number | null {
   let quote: '"' | "'" | null = null;
   for (let i = startIndex; i < text.length; i += 1) {
@@ -494,7 +534,15 @@ function parseQwen3CoderToolParserParamTagAt(
   );
   const paramName = paramNameRaw?.trim() ?? "";
   if (paramName.length === 0) {
-    return null;
+    return parseQwen3CoderNamelessParamTag({
+      text,
+      lowerText,
+      startIndex,
+      openEnd,
+      tagNameLower,
+      allowEndOfString: options?.allowEndOfString === true,
+      callEndTagNameLower: options?.callEndTagNameLower,
+    });
   }
 
   const selfClosing = openTag.trimEnd().endsWith("/>");
@@ -538,6 +586,84 @@ function normalizeXmlTextValue(raw: string): string {
     out = out.slice("<![CDATA[".length, -"]]>".length).trim();
   }
   return unescapeXml(out);
+}
+
+const NAMELESS_PARAM_IDENTIFIER_RE = /^[A-Za-z_][\w.-]{0,255}$/;
+
+/**
+ * Salvage the nameless-tag variant some models (e.g. Qwen2.5) emit when they
+ * half-follow the format:
+ *
+ *   <parameter>city</parameter>
+ *   Seoul
+ *
+ * The element text is the parameter NAME and the plain text after the closing
+ * tag (up to the next parameter tag or call close boundary) is the VALUE.
+ * Only identifier-like element text qualifies, so ordinary tagged content is
+ * not misread as a parameter.
+ */
+function parseQwen3CoderNamelessParamTag(options: {
+  text: string;
+  lowerText: string;
+  startIndex: number;
+  openEnd: number;
+  tagNameLower: string;
+  allowEndOfString: boolean;
+  callEndTagNameLower?: string | null;
+}): Qwen3CoderToolParserParamTagParseResult | null {
+  const { text, lowerText, startIndex, openEnd, tagNameLower } = options;
+
+  const nameStart = openEnd + 1;
+  const close = findClosingTagEnd(lowerText, nameStart, tagNameLower);
+  if (!close) {
+    // The closing tag may still be streaming in.
+    return options.allowEndOfString
+      ? null
+      : { kind: "partial", start: startIndex, openEnd };
+  }
+
+  const paramName = normalizeXmlTextValue(text.slice(nameStart, close.start));
+  if (!NAMELESS_PARAM_IDENTIFIER_RE.test(paramName)) {
+    return null;
+  }
+
+  const valueStart = close.end;
+  const boundaryIndex = findUnclosedParamBoundaryIndex(
+    lowerText,
+    valueStart,
+    options.callEndTagNameLower ?? null,
+    options.allowEndOfString
+  );
+  if (boundaryIndex == null) {
+    if (!options.allowEndOfString) {
+      const rawProgressValue = text.slice(valueStart);
+      return {
+        kind: "partial",
+        start: startIndex,
+        openEnd,
+        name: paramName,
+        value: rawProgressValue ? normalizeXmlTextValue(rawProgressValue) : "",
+      };
+    }
+
+    const rawValue = text.slice(valueStart);
+    return {
+      kind: "match",
+      start: startIndex,
+      end: text.length,
+      name: paramName,
+      value: rawValue ? normalizeXmlTextValue(rawValue) : "",
+    };
+  }
+
+  const rawValue = text.slice(valueStart, boundaryIndex);
+  return {
+    kind: "match",
+    start: startIndex,
+    end: boundaryIndex,
+    name: paramName,
+    value: rawValue ? normalizeXmlTextValue(rawValue) : "",
+  };
 }
 
 function getOpeningTag(xml: string): string | null {
@@ -1763,9 +1889,9 @@ export const qwen3CoderProtocol = (): TCMProtocol => ({
       const lower = buffer.toLowerCase();
 
       const potentialIndices = [
-        getPotentialStartIndex(lower, toolCallStartPrefixLower),
+        getPotentialTagStartIndex(lower, toolCallStartPrefixLower),
         ...implicitCallPrefixesLower.map((prefix) =>
-          getPotentialStartIndex(lower, prefix)
+          getPotentialTagStartIndex(lower, prefix)
         ),
       ].filter((value): value is number => value != null);
 

--- a/src/core/protocols/qwen3coder-protocol.ts
+++ b/src/core/protocols/qwen3coder-protocol.ts
@@ -144,11 +144,17 @@ function getPotentialTagStartIndex(
     from = index + 1;
   }
 
-  const partialIndex = getPotentialStartIndex(lower, prefixLower);
-  return partialIndex != null &&
-    partialIndex + prefixLower.length > lower.length
-    ? partialIndex
-    : null;
+  // Genuine trailing partial: the buffer tail is a proper prefix of the tag.
+  // Scanned directly (longest first) because an earlier boundary-invalid full
+  // occurrence (e.g. `<tool_callback>`) must not mask a real partial at the
+  // end of the buffer.
+  const maxLen = Math.min(prefixLower.length - 1, lower.length);
+  for (let len = maxLen; len > 0; len -= 1) {
+    if (lower.endsWith(prefixLower.slice(0, len))) {
+      return lower.length - len;
+    }
+  }
+  return null;
 }
 
 function findTagEndIndex(text: string, startIndex: number): number | null {

--- a/src/core/protocols/qwen3coder-protocol.ts
+++ b/src/core/protocols/qwen3coder-protocol.ts
@@ -8,6 +8,7 @@ import {
   escapeXmlMinimalText,
   unescapeXml,
 } from "../../rxml/utils/helpers";
+import { recoverToolCallFromJsonCandidates } from "../utils/generated-text-json-recovery";
 import { getPotentialStartIndex } from "../utils/get-potential-start-index";
 import { generateToolCallId } from "../utils/id";
 import {
@@ -67,6 +68,8 @@ const QWEN3CODER_TOOL_PARSER_STREAM_NAME_OR_PARAM_SIGNAL_RE =
 const QWEN3CODER_TOOL_PARSER_STREAM_NAME_TAG_RE =
   /<\s*(name|tool_name)\b[^>]*>([\s\S]*?)<\s*\/\s*\1\s*>/i;
 const QWEN3CODER_TOOL_PARSER_STREAM_SELF_CLOSING_TAG_RE = /\/\s*>$/;
+/** Whitespace and complete tag-like tokens only (salvage strictness gate). */
+const SALVAGE_MARKUP_ONLY_TEXT_REGEX = /^\s*(?:<[^<>\n]*>\s*)*$/;
 
 function isAsciiWhitespace(ch: string): boolean {
   return ch === " " || ch === "\n" || ch === "\r" || ch === "\t" || ch === "\f";
@@ -2256,11 +2259,60 @@ export const qwen3CoderProtocol = (): TCMProtocol => ({
       }
     };
 
+    /**
+     * Cross-format salvage before dropping an unfinished tool_call block:
+     * some models emit Hermes-style JSON payloads inside `<tool_call>` tags
+     * regardless of the Qwen prompt (observed live on LiquidAI LFM2). The
+     * shared recovery only fires when the block is nothing but resolvable
+     * payloads plus markup remnants.
+     */
+    const trySalvageForeignFormatCalls = (
+      controller: StreamController,
+      rawToolCall: string
+    ): boolean => {
+      const recovered = recoverToolCallFromJsonCandidates(rawToolCall, tools);
+      if (!recovered) {
+        return false;
+      }
+      const calls = recovered.filter(
+        (part): part is Extract<typeof part, { type: "tool-call" }> =>
+          part.type === "tool-call"
+      );
+      const hasProse = recovered.some(
+        (part) =>
+          part.type === "text" &&
+          !SALVAGE_MARKUP_ONLY_TEXT_REGEX.test(part.text)
+      );
+      if (calls.length === 0 || hasProse) {
+        return false;
+      }
+      for (const call of calls) {
+        controller.enqueue({
+          type: "tool-input-start",
+          id: call.toolCallId,
+          toolName: call.toolName,
+        });
+        if (call.input.length > 0) {
+          controller.enqueue({
+            type: "tool-input-delta",
+            id: call.toolCallId,
+            delta: call.input,
+          });
+        }
+        controller.enqueue({ type: "tool-input-end", id: call.toolCallId });
+        controller.enqueue(call);
+      }
+      return true;
+    };
+
     const reportUnfinishedToolCallAtFinish = (
       controller: StreamController,
       rawToolCall: string,
       metadata: { toolCallId?: string; toolName?: string | null } = {}
     ) => {
+      if (trySalvageForeignFormatCalls(controller, rawToolCall)) {
+        return;
+      }
       const shouldEmitRaw = shouldEmitRawToolCallTextOnError(options);
       const toolName =
         metadata.toolName ?? extractShorthandToolNameFromRaw(rawToolCall);

--- a/src/core/protocols/qwen3coder-stream-call-content.ts
+++ b/src/core/protocols/qwen3coder-stream-call-content.ts
@@ -24,6 +24,11 @@ type QwenParamTagParseResult =
       openEnd: number | null;
       name?: string;
       value?: string;
+    }
+  | {
+      kind: "skip";
+      start: number;
+      end: number;
     };
 
 function consumeToolNameTag(options: {
@@ -112,6 +117,16 @@ function consumeSingleParamTag(options: {
       nextIndex: options.lt + 1,
       nextLastKept: options.lastKept,
       shouldStop: true,
+    };
+  }
+
+  if (parsed.kind === "skip") {
+    options.callState.partialParam = null;
+    return {
+      keepSlice: options.work.slice(options.lastKept, parsed.start),
+      nextIndex: parsed.end,
+      nextLastKept: parsed.end,
+      shouldStop: false,
     };
   }
 

--- a/src/core/protocols/yaml-xml-protocol.ts
+++ b/src/core/protocols/yaml-xml-protocol.ts
@@ -24,6 +24,7 @@ import { tryRepairXmlSelfClosingRootWithBody } from "../utils/xml-root-repair";
 import {
   findEarliestToolTag,
   findNextToolTag,
+  findPotentialPartialToolTagStart,
 } from "../utils/xml-tool-tag-scanner";
 import type { ParserOptions, TCMCoreProtocol } from "./protocol-interface";
 
@@ -815,14 +816,20 @@ export const yamlXmlProtocol = (
     const flushSafeText = (
       controller: TransformStreamDefaultController<LanguageModelV4StreamPart>
     ): void => {
-      const maxTagLen = toolNames.length
-        ? Math.max(...toolNames.map((n) => `<${n} />`.length))
-        : 0;
-      const tail = Math.max(0, maxTagLen - 1);
-      const safeLen = Math.max(0, buffer.length - tail);
-      if (safeLen > 0) {
-        flushText(controller, buffer.slice(0, safeLen));
-        buffer = buffer.slice(safeLen);
+      if (buffer.length === 0) {
+        return;
+      }
+      // Hold back only a genuine partial tool-tag suffix; everything else is
+      // provably plain text and streams out immediately.
+      const holdFrom = findPotentialPartialToolTagStart(buffer, toolNames);
+      if (holdFrom == null) {
+        flushText(controller, buffer);
+        buffer = "";
+        return;
+      }
+      if (holdFrom > 0) {
+        flushText(controller, buffer.slice(0, holdFrom));
+        buffer = buffer.slice(holdFrom);
       }
     };
 

--- a/src/core/protocols/yaml-xml-protocol.ts
+++ b/src/core/protocols/yaml-xml-protocol.ts
@@ -448,7 +448,9 @@ function yamlFailureCause(failure: YamlParseFailure): Record<string, unknown> {
  * helper cause attached as context.
  */
 const XML_CHILD_CLOSED_LINE_REGEX = /^<([A-Za-z_][\w.-]*)\s*>([^<]*)<\/\1\s*>$/;
-const XML_CHILD_OPEN_LINE_REGEX = /^<([A-Za-z_][\w.-]*)\s*>([^<]*)$/;
+// The open form requires a non-empty value so that a lone nesting tag like
+// `<passenger>` never gets misread as an empty flat parameter.
+const XML_CHILD_OPEN_LINE_REGEX = /^<([A-Za-z_][\w.-]*)\s*>([^<]*\S[^<]*|\S)$/;
 const PROTOTYPE_SENSITIVE_PARAM_KEYS = new Set([
   "__proto__",
   "constructor",

--- a/src/core/protocols/yaml-xml-protocol.ts
+++ b/src/core/protocols/yaml-xml-protocol.ts
@@ -4,6 +4,7 @@ import type {
   LanguageModelV4ToolCall,
 } from "@ai-sdk/provider";
 import YAML from "yaml";
+import { unescapeXml } from "../../rxml/utils/helpers";
 import { generateToolCallId } from "../utils/id";
 import {
   addTextSegment,
@@ -446,6 +447,66 @@ function yamlFailureCause(failure: YamlParseFailure): Record<string, unknown> {
  * (`toolCall`, `toolName`, `toolCallId`, `dropReason`) with the underlying
  * helper cause attached as context.
  */
+const XML_CHILD_CLOSED_LINE_REGEX = /^<([A-Za-z_][\w.-]*)\s*>([^<]*)<\/\1\s*>$/;
+const XML_CHILD_OPEN_LINE_REGEX = /^<([A-Za-z_][\w.-]*)\s*>([^<]*)$/;
+const PROTOTYPE_SENSITIVE_PARAM_KEYS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+function mergeXmlChildArg(
+  args: Record<string, unknown>,
+  key: string,
+  value: string
+): void {
+  const existing = args[key];
+  if (existing === undefined) {
+    args[key] = value;
+  } else if (Array.isArray(existing)) {
+    existing.push(value);
+  } else {
+    args[key] = [existing, value];
+  }
+}
+
+/**
+ * Fallback for models that answer the YAML-body prompt with XML child tags
+ * instead (`<city>Seoul</city>`, observed live on Amazon Nova 2 Lite —
+ * effectively the morph-xml body format). Parses line-oriented
+ * `<key>value</key>` pairs, tolerating a missing close tag on a line
+ * (`<unit>celsius`), and declines on anything else so genuine YAML failures
+ * keep their normal error handling.
+ */
+function parseXmlChildrenAsArgs(
+  content: string
+): Record<string, unknown> | null {
+  const lines = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0 || !lines[0].startsWith("<")) {
+    return null;
+  }
+
+  const args: Record<string, unknown> = {};
+  for (const line of lines) {
+    const match =
+      XML_CHILD_CLOSED_LINE_REGEX.exec(line) ??
+      XML_CHILD_OPEN_LINE_REGEX.exec(line);
+    if (!match) {
+      return null;
+    }
+    const key = match[1];
+    if (PROTOTYPE_SENSITIVE_PARAM_KEYS.has(key)) {
+      return null;
+    }
+    mergeXmlChildArg(args, key, unescapeXml((match[2] ?? "").trim()));
+  }
+
+  return args;
+}
+
 function parseYamlContent(yamlContent: string): YamlParseResult {
   const { normalized, nonEmptyLines } = normalizeYamlContent(yamlContent);
   if (nonEmptyLines.length === 0) {
@@ -454,6 +515,10 @@ function parseYamlContent(yamlContent: string): YamlParseResult {
 
   const parsed = parseYamlDocumentAsMapping(normalized);
   if (parsed.errors.length > 0) {
+    const xmlArgs = parseXmlChildrenAsArgs(yamlContent);
+    if (xmlArgs) {
+      return { ok: true, value: xmlArgs };
+    }
     return {
       ok: false,
       failure: { kind: "yaml-parse-error", errors: parsed.errors },
@@ -461,6 +526,10 @@ function parseYamlContent(yamlContent: string): YamlParseResult {
   }
 
   if (parsed.value === null) {
+    const xmlArgs = parseXmlChildrenAsArgs(yamlContent);
+    if (xmlArgs) {
+      return { ok: true, value: xmlArgs };
+    }
     return { ok: false, failure: { kind: "yaml-non-mapping" } };
   }
 

--- a/src/core/utils/finish-reason.ts
+++ b/src/core/utils/finish-reason.ts
@@ -1,0 +1,51 @@
+import type { LanguageModelV4FinishReason } from "@ai-sdk/provider";
+
+/**
+ * Build a `tool-calls` finish reason while preserving the provider's raw
+ * value. Accepts the loose shapes seen across providers (plain string,
+ * `{ raw }`, `{ unified }`) so both wrap handlers can share one normalizer.
+ */
+export function normalizeToolCallsFinishReason(
+  finishReason: unknown
+): LanguageModelV4FinishReason {
+  let raw = "tool-calls";
+  if (typeof finishReason === "string") {
+    raw = finishReason;
+  } else if (
+    finishReason &&
+    typeof finishReason === "object" &&
+    "raw" in finishReason &&
+    typeof (finishReason as { raw?: unknown }).raw === "string"
+  ) {
+    raw = (finishReason as { raw: string }).raw;
+  } else if (
+    finishReason &&
+    typeof finishReason === "object" &&
+    "unified" in finishReason &&
+    typeof (finishReason as { unified?: unknown }).unified === "string"
+  ) {
+    raw = (finishReason as { unified: string }).unified;
+  }
+
+  return {
+    unified: "tool-calls",
+    raw,
+  };
+}
+
+/**
+ * Whether a finish reason should be rewritten to `tool-calls` once the
+ * middleware has parsed tool calls out of the model text. `stop` is the
+ * common case; `other` covers providers that report an unmapped raw finish
+ * reason for plain end-of-turn. Meaningful reasons (`length`,
+ * `content-filter`, `error`) are preserved.
+ */
+export function shouldRewriteFinishReasonToToolCalls(
+  finishReason: unknown
+): boolean {
+  if (!finishReason || typeof finishReason !== "object") {
+    return false;
+  }
+  const unified = (finishReason as { unified?: unknown }).unified;
+  return unified === "stop" || unified === "other";
+}

--- a/src/core/utils/generated-text-json-recovery.ts
+++ b/src/core/utils/generated-text-json-recovery.ts
@@ -4,6 +4,7 @@ import type {
 } from "@ai-sdk/provider";
 import YAML from "yaml";
 import { parse as parseRJSON } from "../../rjson";
+import { unescapeXml } from "../../rxml/utils/helpers";
 import { getSchemaType, unwrapJsonSchema } from "../../schema-coerce";
 import { generateToolCallId } from "./id";
 
@@ -430,30 +431,93 @@ function resolveCandidatePayload(
   );
 }
 
-const FUNCTION_BLOCK_OPEN_REGEX =
-  /<function\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>/]+))\s*>/gi;
-const FUNCTION_PARAM_OPEN_REGEX =
-  /<parameter\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>/]+))\s*>/gi;
-const PARAM_BOUNDARY_REGEX = /<parameter\b|<\/parameter|<\/function/i;
+const QWEN_CALL_BLOCK_OPEN_REGEX = /<\s*(call|function|tool|invoke)\b[^>]*>/gi;
+const QWEN_PARAM_OPEN_REGEX = /<\s*(?:parameter|param|argument|arg)\b[^>]*>/gi;
+const QWEN_PARAM_BOUNDARY_REGEX =
+  /<\s*(?:parameter|param|argument|arg)\b|<\s*\/\s*(?:parameter|param|argument|arg|call|function|tool|invoke)\s*>/i;
+const QWEN_NAME_CHILD_REGEX =
+  /<\s*(?:name|tool_name)\b[^>]*>([\s\S]*?)<\s*\/\s*(?:name|tool_name)\s*>/i;
+const SELF_CLOSING_TAG_REGEX = /\/\s*>$/;
+const QWEN_TAG_SHORTHAND_VALUE_REGEX =
+  /^<\s*[A-Za-z_][\w.-]*\b\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>/<]+))/i;
+const QWEN_NAME_ATTR_REGEX = /\bname\s*=\s*(?:"([^"]*)"|'([^']*)')/i;
+
+function isSelfClosingTag(openTag: string): boolean {
+  return SELF_CLOSING_TAG_REGEX.test(openTag);
+}
+
+function readQwenTagValue(openTag: string): string | null {
+  const shorthand = QWEN_TAG_SHORTHAND_VALUE_REGEX.exec(openTag);
+  const value = shorthand?.[1] ?? shorthand?.[2] ?? shorthand?.[3];
+  if (value != null) {
+    return unescapeXml(value);
+  }
+
+  const nameAttr = QWEN_NAME_ATTR_REGEX.exec(openTag);
+  return nameAttr ? unescapeXml(nameAttr[1] ?? nameAttr[2] ?? "") : null;
+}
+
+function readQwenCallToolName(openTag: string, body: string): string | null {
+  const tagValue = readQwenTagValue(openTag);
+  if (tagValue?.trim()) {
+    return tagValue.trim();
+  }
+
+  const nameChild = QWEN_NAME_CHILD_REGEX.exec(body);
+  const childValue = nameChild?.[1];
+  return childValue?.trim() ? unescapeXml(childValue).trim() : null;
+}
 
 function readFunctionBlockParams(body: string): Record<string, unknown> | null {
   const params: Record<string, unknown> = {};
-  FUNCTION_PARAM_OPEN_REGEX.lastIndex = 0;
-  let match = FUNCTION_PARAM_OPEN_REGEX.exec(body);
+  QWEN_PARAM_OPEN_REGEX.lastIndex = 0;
+  let match = QWEN_PARAM_OPEN_REGEX.exec(body);
   while (match) {
-    const key = (match[1] ?? match[2] ?? match[3] ?? "").trim();
-    if (key.length === 0 || PROTOTYPE_SENSITIVE_KEYS.has(key)) {
+    const openTag = match[0] ?? "";
+    const key = readQwenTagValue(openTag)?.trim() ?? "";
+    if (key.length === 0) {
+      if (isSelfClosingTag(openTag)) {
+        QWEN_PARAM_OPEN_REGEX.lastIndex = match.index + openTag.length;
+        match = QWEN_PARAM_OPEN_REGEX.exec(body);
+        continue;
+      }
+      return null;
+    }
+    if (PROTOTYPE_SENSITIVE_KEYS.has(key)) {
       return null;
     }
     const valueStart = match.index + match[0].length;
-    const boundaryMatch = PARAM_BOUNDARY_REGEX.exec(body.slice(valueStart));
+    if (isSelfClosingTag(openTag)) {
+      params[key] = "";
+      QWEN_PARAM_OPEN_REGEX.lastIndex = valueStart;
+      match = QWEN_PARAM_OPEN_REGEX.exec(body);
+      continue;
+    }
+    const boundaryMatch = QWEN_PARAM_BOUNDARY_REGEX.exec(
+      body.slice(valueStart)
+    );
     const valueEnd =
       boundaryMatch == null ? body.length : valueStart + boundaryMatch.index;
     params[key] = body.slice(valueStart, valueEnd).trim();
-    FUNCTION_PARAM_OPEN_REGEX.lastIndex = valueEnd;
-    match = FUNCTION_PARAM_OPEN_REGEX.exec(body);
+    QWEN_PARAM_OPEN_REGEX.lastIndex = valueEnd;
+    match = QWEN_PARAM_OPEN_REGEX.exec(body);
   }
   return params;
+}
+
+function findQwenCallCloseTag(
+  text: string,
+  startIndex: number,
+  tagName: string,
+  beforeIndex: number
+): { start: number; end: number } | null {
+  const closeRegex = new RegExp(`<\\s*\\/\\s*${tagName}\\s*>`, "i");
+  const match = closeRegex.exec(text.slice(startIndex, beforeIndex));
+  if (!match) {
+    return null;
+  }
+  const start = startIndex + match.index;
+  return { start, end: start + match[0].length };
 }
 
 /**
@@ -467,32 +531,33 @@ function extractFunctionBlockCallSpans(
   tools: LanguageModelV4FunctionTool[]
 ): RecoveredCallSpan[] {
   const spans: RecoveredCallSpan[] = [];
-  const lower = text.toLowerCase();
-  const opens = [...text.matchAll(FUNCTION_BLOCK_OPEN_REGEX)];
+  const opens = [...text.matchAll(QWEN_CALL_BLOCK_OPEN_REGEX)];
 
   for (let index = 0; index < opens.length; index += 1) {
     const open = opens[index];
-    const toolName = (open[1] ?? open[2] ?? open[3] ?? "").trim();
-    if (!tools.some((tool) => tool.name === toolName)) {
+    const tagName = (open[1] ?? "").toLowerCase();
+    const openTag = open[0] ?? "";
+    const bodyStart = open.index + open[0].length;
+    const nextOpenIndex = opens[index + 1]?.index ?? text.length;
+    const selfClosing = isSelfClosingTag(openTag);
+    const close = selfClosing
+      ? null
+      : findQwenCallCloseTag(text, bodyStart, tagName, nextOpenIndex);
+    const bodyEnd = close?.start ?? nextOpenIndex;
+    const body = selfClosing ? "" : text.slice(bodyStart, bodyEnd);
+    const toolName = readQwenCallToolName(openTag, body);
+    if (!(toolName && tools.some((tool) => tool.name === toolName))) {
       continue;
     }
 
-    const bodyStart = open.index + open[0].length;
-    const nextOpenIndex = opens[index + 1]?.index ?? text.length;
-    const closeIndex = lower.indexOf("</function", bodyStart);
-    const hasClose = closeIndex !== -1 && closeIndex < nextOpenIndex;
-    const bodyEnd = hasClose ? closeIndex : nextOpenIndex;
-
-    const params = readFunctionBlockParams(text.slice(bodyStart, bodyEnd));
+    const params = readFunctionBlockParams(body);
     if (!params) {
       continue;
     }
 
-    let endIndex = bodyEnd;
-    if (hasClose) {
-      const closeGt = text.indexOf(">", closeIndex);
-      endIndex = closeGt === -1 ? text.length : closeGt + 1;
-    }
+    const endIndex = selfClosing
+      ? open.index + openTag.length
+      : (close?.end ?? nextOpenIndex);
     spans.push({
       startIndex: open.index,
       endIndex,

--- a/src/core/utils/generated-text-json-recovery.ts
+++ b/src/core/utils/generated-text-json-recovery.ts
@@ -433,6 +433,10 @@ function resolveCandidatePayload(
 
 const QWEN_CALL_BLOCK_OPEN_REGEX = /<\s*(call|function|tool|invoke)\b[^>]*>/gi;
 const QWEN_PARAM_OPEN_REGEX = /<\s*(?:parameter|param|argument|arg)\b[^>]*>/gi;
+const QWEN_PARAM_TAG_REGEX =
+  /<\s*(\/?)\s*(parameter|param|argument|arg)\b[^>]*>/gi;
+const QWEN_PARAM_CLOSE_TAG_REGEX =
+  /<\s*\/\s*(?:parameter|param|argument|arg)\b[^>]*>/i;
 const QWEN_PARAM_BOUNDARY_REGEX =
   /<\s*(?:parameter|param|argument|arg)\b|<\s*\/\s*(?:parameter|param|argument|arg|call|function|tool|invoke)\s*>/i;
 const QWEN_NAME_CHILD_REGEX =
@@ -505,19 +509,58 @@ function readFunctionBlockParams(body: string): Record<string, unknown> | null {
   return params;
 }
 
+function hasUnclosedQwenParamTag(text: string): boolean {
+  let depth = 0;
+  QWEN_PARAM_TAG_REGEX.lastIndex = 0;
+  let match = QWEN_PARAM_TAG_REGEX.exec(text);
+  while (match) {
+    const isClosingTag = (match[1] ?? "").length > 0;
+    if (isClosingTag) {
+      depth = Math.max(0, depth - 1);
+    } else if (!isSelfClosingTag(match[0] ?? "")) {
+      depth += 1;
+    }
+    match = QWEN_PARAM_TAG_REGEX.exec(text);
+  }
+  return depth > 0;
+}
+
+function hasQwenParamCloseBeforeNextCallClose(
+  text: string,
+  tagName: string
+): boolean {
+  const paramClose = QWEN_PARAM_CLOSE_TAG_REGEX.exec(text);
+  if (!paramClose) {
+    return false;
+  }
+
+  const nextCallCloseRegex = new RegExp(`<\\s*\\/\\s*${tagName}\\b[^>]*>`, "i");
+  const nextCallClose = nextCallCloseRegex.exec(text);
+  return !nextCallClose || paramClose.index < nextCallClose.index;
+}
+
 function findQwenCallCloseTag(
   text: string,
   startIndex: number,
   tagName: string,
   beforeIndex: number
 ): { start: number; end: number } | null {
-  const closeRegex = new RegExp(`<\\s*\\/\\s*${tagName}\\s*>`, "i");
-  const match = closeRegex.exec(text.slice(startIndex, beforeIndex));
-  if (!match) {
-    return null;
+  const body = text.slice(startIndex, beforeIndex);
+  const closeRegex = new RegExp(`<\\s*\\/\\s*${tagName}\\b[^>]*>`, "gi");
+  let match = closeRegex.exec(body);
+  while (match) {
+    const prefix = body.slice(0, match.index);
+    const suffix = body.slice(match.index + match[0].length);
+    const isParameterValueText =
+      hasUnclosedQwenParamTag(prefix) &&
+      hasQwenParamCloseBeforeNextCallClose(suffix, tagName);
+    if (!isParameterValueText) {
+      const start = startIndex + match.index;
+      return { start, end: start + match[0].length };
+    }
+    match = closeRegex.exec(body);
   }
-  const start = startIndex + match.index;
-  return { start, end: start + match[0].length };
+  return null;
 }
 
 /**

--- a/src/core/utils/generated-text-json-recovery.ts
+++ b/src/core/utils/generated-text-json-recovery.ts
@@ -237,6 +237,12 @@ function toToolCallPart(candidate: ToolCallCandidate): LanguageModelV4Content {
 
 const ORPHAN_TAG_BEFORE_CALL_REGEX = /(?:<\/?tool_call>\s*)+$/;
 const ORPHAN_TAG_AFTER_CALL_REGEX = /^(?:\s*<\/?tool_call>)+/;
+/**
+ * JSON array plumbing left over when calls arrive wrapped in a top-level
+ * array (e.g. `[{...}, {...}]`, observed live on Seed 2.0): brackets and
+ * commas between the recovered objects carry no content.
+ */
+const ARRAY_PUNCTUATION_ONLY_REGEX = /^[\s,[\]]*$/;
 
 /**
  * Append a text segment between recovered calls, trimming orphan tool-call
@@ -253,9 +259,35 @@ function pushRecoveredTextSegment(
   const trimmed = segment
     .replace(ORPHAN_TAG_AFTER_CALL_REGEX, "")
     .replace(ORPHAN_TAG_BEFORE_CALL_REGEX, "");
+  if (ARRAY_PUNCTUATION_ONLY_REGEX.test(trimmed)) {
+    return;
+  }
   if (trimmed.trim().length > 0) {
     out.push({ type: "text", text: trimmed });
   }
+}
+
+/** Envelope key aliases observed live (e.g. Nemotron emits tool/parameters). */
+const TOOL_NAME_KEYS = ["name", "tool"] as const;
+const TOOL_ARGS_KEYS = ["arguments", "parameters"] as const;
+
+function readToolNameField(payload: Record<string, unknown>): string | null {
+  for (const key of TOOL_NAME_KEYS) {
+    const value = payload[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function readToolArgsField(payload: Record<string, unknown>): unknown {
+  for (const key of TOOL_ARGS_KEYS) {
+    if (Object.hasOwn(payload, key)) {
+      return payload[key];
+    }
+  }
+  return {};
 }
 
 function parseAsToolPayload(
@@ -266,10 +298,7 @@ function parseAsToolPayload(
     return null;
   }
 
-  const toolName =
-    typeof payload.name === "string" && payload.name.trim().length > 0
-      ? payload.name.trim()
-      : null;
+  const toolName = readToolNameField(payload);
   if (!toolName) {
     return null;
   }
@@ -278,7 +307,19 @@ function parseAsToolPayload(
     return null;
   }
 
-  const rawArgs = Object.hasOwn(payload, "arguments") ? payload.arguments : {};
+  let rawArgs = readToolArgsField(payload);
+  // Double-encoded arguments (OpenAI native wire habit): a string value that
+  // itself parses to a JSON object.
+  if (
+    typeof rawArgs === "string" &&
+    rawArgs.trimStart().startsWith("{") &&
+    !PROTOTYPE_SENSITIVE_KEY_TEXT_REGEX.test(rawArgs)
+  ) {
+    const unwrapped = parseJsonCandidate(rawArgs);
+    if (isRecord(unwrapped)) {
+      rawArgs = unwrapped;
+    }
+  }
   if (!isRecord(rawArgs) || containsPrototypeSensitiveKey(rawArgs)) {
     return null;
   }
@@ -336,13 +377,17 @@ function parseAsArgumentsOnly(
   if (!isRecord(payload)) {
     return null;
   }
-  const hasNameEnvelope =
-    Object.hasOwn(payload, "name") &&
-    typeof payload.name === "string" &&
-    payload.name.length > 0;
-  const hasArgumentsEnvelope =
-    Object.hasOwn(payload, "arguments") &&
-    (typeof payload.arguments === "string" || isRecord(payload.arguments));
+  const hasNameEnvelope = TOOL_NAME_KEYS.some(
+    (key) =>
+      Object.hasOwn(payload, key) &&
+      typeof payload[key] === "string" &&
+      (payload[key] as string).length > 0
+  );
+  const hasArgumentsEnvelope = TOOL_ARGS_KEYS.some(
+    (key) =>
+      Object.hasOwn(payload, key) &&
+      (typeof payload[key] === "string" || isRecord(payload[key]))
+  );
   if (hasNameEnvelope || hasArgumentsEnvelope) {
     return null;
   }

--- a/src/core/utils/generated-text-json-recovery.ts
+++ b/src/core/utils/generated-text-json-recovery.ts
@@ -2,6 +2,7 @@ import type {
   LanguageModelV4Content,
   LanguageModelV4FunctionTool,
 } from "@ai-sdk/provider";
+import YAML from "yaml";
 import { parse as parseRJSON } from "../../rjson";
 import { getSchemaType, unwrapJsonSchema } from "../../schema-coerce";
 import { generateToolCallId } from "./id";
@@ -9,6 +10,13 @@ import { generateToolCallId } from "./id";
 interface ToolCallCandidate {
   input: string;
   toolName: string;
+}
+
+/** A recovered call with the span of source text it consumes. */
+interface RecoveredCallSpan {
+  endIndex: number;
+  payload: ToolCallCandidate;
+  startIndex: number;
 }
 
 interface JsonCandidate {
@@ -422,12 +430,193 @@ function resolveCandidatePayload(
   );
 }
 
+const FUNCTION_BLOCK_OPEN_REGEX =
+  /<function\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>/]+))\s*>/gi;
+const FUNCTION_PARAM_OPEN_REGEX =
+  /<parameter\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>/]+))\s*>/gi;
+const PARAM_BOUNDARY_REGEX = /<parameter\b|<\/parameter|<\/function/i;
+
+function readFunctionBlockParams(body: string): Record<string, unknown> | null {
+  const params: Record<string, unknown> = {};
+  FUNCTION_PARAM_OPEN_REGEX.lastIndex = 0;
+  let match = FUNCTION_PARAM_OPEN_REGEX.exec(body);
+  while (match) {
+    const key = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+    if (key.length === 0 || PROTOTYPE_SENSITIVE_KEYS.has(key)) {
+      return null;
+    }
+    const valueStart = match.index + match[0].length;
+    const boundaryMatch = PARAM_BOUNDARY_REGEX.exec(body.slice(valueStart));
+    const valueEnd =
+      boundaryMatch == null ? body.length : valueStart + boundaryMatch.index;
+    params[key] = body.slice(valueStart, valueEnd).trim();
+    FUNCTION_PARAM_OPEN_REGEX.lastIndex = valueEnd;
+    match = FUNCTION_PARAM_OPEN_REGEX.exec(body);
+  }
+  return params;
+}
+
 /**
- * Recover tool calls from JSON-like candidates embedded in plain text.
- * Every non-overlapping candidate that resolves to a known tool becomes a
- * tool-call part, so multi-call payloads (e.g. consecutive bare JSON objects
- * separated by newlines or orphan `<tool_call>` tags) are all recovered.
- * Returns null when no candidate resolves.
+ * Recover Qwen3-Coder-style `<function=name><parameter=key>value` blocks for
+ * known tools regardless of the active protocol. Some models emit this
+ * format no matter what the prompt asks for (observed live on Step 3.5 Flash
+ * under the Hermes prompt).
+ */
+function extractFunctionBlockCallSpans(
+  text: string,
+  tools: LanguageModelV4FunctionTool[]
+): RecoveredCallSpan[] {
+  const spans: RecoveredCallSpan[] = [];
+  const lower = text.toLowerCase();
+  const opens = [...text.matchAll(FUNCTION_BLOCK_OPEN_REGEX)];
+
+  for (let index = 0; index < opens.length; index += 1) {
+    const open = opens[index];
+    const toolName = (open[1] ?? open[2] ?? open[3] ?? "").trim();
+    if (!tools.some((tool) => tool.name === toolName)) {
+      continue;
+    }
+
+    const bodyStart = open.index + open[0].length;
+    const nextOpenIndex = opens[index + 1]?.index ?? text.length;
+    const closeIndex = lower.indexOf("</function", bodyStart);
+    const hasClose = closeIndex !== -1 && closeIndex < nextOpenIndex;
+    const bodyEnd = hasClose ? closeIndex : nextOpenIndex;
+
+    const params = readFunctionBlockParams(text.slice(bodyStart, bodyEnd));
+    if (!params) {
+      continue;
+    }
+
+    let endIndex = bodyEnd;
+    if (hasClose) {
+      const closeGt = text.indexOf(">", closeIndex);
+      endIndex = closeGt === -1 ? text.length : closeGt + 1;
+    }
+    spans.push({
+      startIndex: open.index,
+      endIndex,
+      payload: { toolName, input: safeStringify(params) },
+    });
+  }
+
+  return spans;
+}
+
+const TOOL_CALL_BLOCK_OPEN_REGEX = /<tool_call\s*>/gi;
+// Colon included for namespaced garbage closes like `</functions:get_weather>`.
+const CLOSING_TAG_REGEX = /<\/\s*([A-Za-z_][\w.:-]*)\s*>/;
+
+function parseYamlBlockMapping(body: string): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(body);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || containsPrototypeSensitiveKey(parsed)) {
+    return null;
+  }
+  return parsed;
+}
+
+function resolveYamlBlockPayload(
+  mapping: Record<string, unknown>,
+  closeTagName: string | null,
+  tools: LanguageModelV4FunctionTool[]
+): ToolCallCandidate | null {
+  // Envelope form: `name: get_weather\narguments:\n  city: Seoul`.
+  const envelopeName = readToolNameField(mapping);
+  if (envelopeName && tools.some((tool) => tool.name === envelopeName)) {
+    const rawArgs = readToolArgsField(mapping);
+    const args = rawArgs === undefined || rawArgs === null ? {} : rawArgs;
+    if (isRecord(args) && !containsPrototypeSensitiveKey(args)) {
+      return { toolName: envelopeName, input: safeStringify(args) };
+    }
+    return null;
+  }
+
+  // Bare-args form closed by a tag carrying the tool name:
+  // `<tool_call>\ncity: Seoul\n</get_weather>` (possibly namespaced, e.g.
+  // `</functions:get_weather>`).
+  if (closeTagName) {
+    const candidates = [closeTagName, closeTagName.split(":").at(-1) ?? ""];
+    const matched = candidates.find((name) =>
+      tools.some((tool) => tool.name === name)
+    );
+    if (matched) {
+      return { toolName: matched, input: safeStringify(mapping) };
+    }
+  }
+
+  // Bare-args form with a single tool whose schema matches.
+  if (tools.length === 1 && isLikelyArgumentsShapeForTool(mapping, tools[0])) {
+    return { toolName: tools[0].name, input: safeStringify(mapping) };
+  }
+
+  return null;
+}
+
+/**
+ * Recover `<tool_call>` blocks whose body is a YAML mapping instead of JSON
+ * (observed live on IBM Granite 4.0, which emits this shape under every
+ * prompt format, closing with an arbitrary tag such as `</weather>` or the
+ * tool name).
+ */
+function extractYamlToolCallBlockSpans(
+  text: string,
+  tools: LanguageModelV4FunctionTool[]
+): RecoveredCallSpan[] {
+  const spans: RecoveredCallSpan[] = [];
+
+  TOOL_CALL_BLOCK_OPEN_REGEX.lastIndex = 0;
+  let match = TOOL_CALL_BLOCK_OPEN_REGEX.exec(text);
+  while (match) {
+    const bodyStart = match.index + match[0].length;
+    TOOL_CALL_BLOCK_OPEN_REGEX.lastIndex = bodyStart;
+    const nextOpen = TOOL_CALL_BLOCK_OPEN_REGEX.exec(text);
+    const blockEnd = nextOpen == null ? text.length : nextOpen.index;
+
+    let body = text.slice(bodyStart, blockEnd);
+    let endIndex = blockEnd;
+    let closeTagName: string | null = null;
+
+    // The close tag is unreliable in this shape — the first closing tag in
+    // the block (e.g. `</weather>`, `</tool_call>`, `</get_weather>`)
+    // terminates the body and may carry the tool name.
+    const closeMatch = CLOSING_TAG_REGEX.exec(body);
+    if (closeMatch) {
+      closeTagName = closeMatch[1] ?? null;
+      endIndex = bodyStart + closeMatch.index + closeMatch[0].length;
+      body = body.slice(0, closeMatch.index);
+    }
+
+    const mapping = parseYamlBlockMapping(body);
+    const payload = mapping
+      ? resolveYamlBlockPayload(mapping, closeTagName, tools)
+      : null;
+    if (payload) {
+      spans.push({ startIndex: match.index, endIndex, payload });
+    }
+
+    match = nextOpen;
+  }
+
+  return spans;
+}
+
+/**
+ * Recover tool calls embedded in plain text. Candidates come from three
+ * scanners, each validated against the known tools:
+ *
+ *   1. JSON-like candidates (bare objects, fenced blocks, tagged bodies)
+ *   2. Qwen3-Coder-style `<function=name><parameter=key>value` blocks
+ *   3. `<tool_call>` blocks with YAML mapping bodies
+ *
+ * Every non-overlapping candidate that resolves becomes a tool-call part, so
+ * multi-call payloads (consecutive bare JSON objects, orphan `<tool_call>`
+ * separators, array-wrapped lists) are all recovered. Returns null when no
+ * candidate resolves.
  */
 export function recoverToolCallFromJsonCandidates(
   text: string,
@@ -437,24 +626,38 @@ export function recoverToolCallFromJsonCandidates(
     return null;
   }
 
-  const jsonCandidates = extractJsonLikeCandidates(text);
+  const spans: RecoveredCallSpan[] = [];
+  for (const jsonCandidate of extractJsonLikeCandidates(text)) {
+    const payload = resolveCandidatePayload(jsonCandidate, tools);
+    if (payload) {
+      spans.push({
+        startIndex: jsonCandidate.startIndex,
+        endIndex: jsonCandidate.endIndex,
+        payload,
+      });
+    }
+  }
+  spans.push(...extractFunctionBlockCallSpans(text, tools));
+  spans.push(...extractYamlToolCallBlockSpans(text, tools));
+  spans.sort((a, b) =>
+    a.startIndex === b.startIndex
+      ? b.endIndex - a.endIndex
+      : a.startIndex - b.startIndex
+  );
+
   const out: LanguageModelV4Content[] = [];
   let cursor = 0;
   let recoveredAny = false;
 
-  for (const jsonCandidate of jsonCandidates) {
-    if (jsonCandidate.startIndex < cursor) {
+  for (const span of spans) {
+    if (span.startIndex < cursor) {
       // Overlaps a candidate that was already consumed (e.g. the balanced
       // object inside an already-recovered tagged/fenced candidate).
       continue;
     }
-    const payload = resolveCandidatePayload(jsonCandidate, tools);
-    if (!payload) {
-      continue;
-    }
-    pushRecoveredTextSegment(out, text.slice(cursor, jsonCandidate.startIndex));
-    out.push(toToolCallPart(payload));
-    cursor = jsonCandidate.endIndex;
+    pushRecoveredTextSegment(out, text.slice(cursor, span.startIndex));
+    out.push(toToolCallPart(span.payload));
+    cursor = span.endIndex;
     recoveredAny = true;
   }
 

--- a/src/core/utils/generated-text-json-recovery.ts
+++ b/src/core/utils/generated-text-json-recovery.ts
@@ -433,10 +433,6 @@ function resolveCandidatePayload(
 
 const QWEN_CALL_BLOCK_OPEN_REGEX = /<\s*(call|function|tool|invoke)\b[^>]*>/gi;
 const QWEN_PARAM_OPEN_REGEX = /<\s*(?:parameter|param|argument|arg)\b[^>]*>/gi;
-const QWEN_PARAM_TAG_REGEX =
-  /<\s*(\/?)\s*(parameter|param|argument|arg)\b[^>]*>/gi;
-const QWEN_PARAM_CLOSE_TAG_REGEX =
-  /<\s*\/\s*(?:parameter|param|argument|arg)\b[^>]*>/i;
 const QWEN_PARAM_BOUNDARY_REGEX =
   /<\s*(?:parameter|param|argument|arg)\b|<\s*\/\s*(?:parameter|param|argument|arg|call|function|tool|invoke)\s*>/i;
 const QWEN_NAME_CHILD_REGEX =
@@ -509,36 +505,6 @@ function readFunctionBlockParams(body: string): Record<string, unknown> | null {
   return params;
 }
 
-function hasUnclosedQwenParamTag(text: string): boolean {
-  let depth = 0;
-  QWEN_PARAM_TAG_REGEX.lastIndex = 0;
-  let match = QWEN_PARAM_TAG_REGEX.exec(text);
-  while (match) {
-    const isClosingTag = (match[1] ?? "").length > 0;
-    if (isClosingTag) {
-      depth = Math.max(0, depth - 1);
-    } else if (!isSelfClosingTag(match[0] ?? "")) {
-      depth += 1;
-    }
-    match = QWEN_PARAM_TAG_REGEX.exec(text);
-  }
-  return depth > 0;
-}
-
-function hasQwenParamCloseBeforeNextCallClose(
-  text: string,
-  tagName: string
-): boolean {
-  const paramClose = QWEN_PARAM_CLOSE_TAG_REGEX.exec(text);
-  if (!paramClose) {
-    return false;
-  }
-
-  const nextCallCloseRegex = new RegExp(`<\\s*\\/\\s*${tagName}\\b[^>]*>`, "i");
-  const nextCallClose = nextCallCloseRegex.exec(text);
-  return !nextCallClose || paramClose.index < nextCallClose.index;
-}
-
 function findQwenCallCloseTag(
   text: string,
   startIndex: number,
@@ -546,21 +512,36 @@ function findQwenCallCloseTag(
   beforeIndex: number
 ): { start: number; end: number } | null {
   const body = text.slice(startIndex, beforeIndex);
-  const closeRegex = new RegExp(`<\\s*\\/\\s*${tagName}\\b[^>]*>`, "gi");
-  let match = closeRegex.exec(body);
+  const tagRegex = new RegExp(
+    `<\\s*(\\/?)\\s*(parameter|param|argument|arg)\\b[^>]*>|<\\s*\\/\\s*${tagName}\\b[^>]*>`,
+    "gi"
+  );
+  let parameterDepth = 0;
+  let fallbackClose: { start: number; end: number } | null = null;
+  let match = tagRegex.exec(body);
   while (match) {
-    const prefix = body.slice(0, match.index);
-    const suffix = body.slice(match.index + match[0].length);
-    const isParameterValueText =
-      hasUnclosedQwenParamTag(prefix) &&
-      hasQwenParamCloseBeforeNextCallClose(suffix, tagName);
-    if (!isParameterValueText) {
-      const start = startIndex + match.index;
-      return { start, end: start + match[0].length };
+    const tag = match[0] ?? "";
+    const parameterTagName = match[2];
+    if (parameterTagName) {
+      const isClosingTag = (match[1] ?? "").length > 0;
+      if (isClosingTag) {
+        parameterDepth = Math.max(0, parameterDepth - 1);
+      } else if (!isSelfClosingTag(tag)) {
+        parameterDepth += 1;
+      }
+      match = tagRegex.exec(body);
+      continue;
     }
-    match = closeRegex.exec(body);
+
+    const start = startIndex + match.index;
+    const close = { start, end: start + tag.length };
+    if (parameterDepth === 0) {
+      return close;
+    }
+    fallbackClose ??= close;
+    match = tagRegex.exec(body);
   }
-  return null;
+  return fallbackClose;
 }
 
 /**

--- a/src/core/utils/generated-text-json-recovery.ts
+++ b/src/core/utils/generated-text-json-recovery.ts
@@ -27,6 +27,51 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+const PROTOTYPE_SENSITIVE_KEYS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+/**
+ * Textual guard for prototype-sensitive keys in a JSON-like candidate.
+ * Relaxed-JSON parsers may absorb a literal `__proto__` key into the object
+ * prototype instead of surfacing it as an own property, so a post-parse
+ * check alone cannot see it. Declining recovery on a textual match is safe:
+ * the candidate simply stays plain text.
+ */
+const PROTOTYPE_SENSITIVE_KEY_TEXT_REGEX =
+  /["'](?:__proto__|constructor|prototype)["']\s*:|[{,]\s*(?:__proto__|constructor|prototype)\s*:/;
+
+function containsPrototypeSensitiveKey(value: unknown): boolean {
+  const seen = new Set<object>();
+  const stack: unknown[] = [value];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (Array.isArray(current)) {
+      if (seen.has(current)) {
+        continue;
+      }
+      seen.add(current);
+      stack.push(...current);
+      continue;
+    }
+    if (!isRecord(current) || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    for (const key of Object.keys(current)) {
+      if (PROTOTYPE_SENSITIVE_KEYS.has(key)) {
+        return true;
+      }
+      stack.push(current[key]);
+    }
+  }
+
+  return false;
+}
+
 function safeStringify(value: unknown): string {
   try {
     return JSON.stringify(value ?? {});
@@ -190,24 +235,27 @@ function toToolCallPart(candidate: ToolCallCandidate): LanguageModelV4Content {
   };
 }
 
-function toRecoveredParts(
-  text: string,
-  candidate: JsonCandidate,
-  toolCallPart: LanguageModelV4Content
-): LanguageModelV4Content[] {
-  const out: LanguageModelV4Content[] = [];
-  const prefix = text.slice(0, candidate.startIndex);
-  if (prefix.length > 0) {
-    out.push({ type: "text", text: prefix });
-  }
+const ORPHAN_TAG_BEFORE_CALL_REGEX = /(?:<\/?tool_call>\s*)+$/;
+const ORPHAN_TAG_AFTER_CALL_REGEX = /^(?:\s*<\/?tool_call>)+/;
 
-  out.push(toolCallPart);
-
-  const suffix = text.slice(candidate.endIndex);
-  if (suffix.length > 0) {
-    out.push({ type: "text", text: suffix });
+/**
+ * Append a text segment between recovered calls, trimming orphan tool-call
+ * wrappers on both ends. Models that half-follow a tag protocol leave
+ * dangling `<tool_call>` markup around the recovered JSON (e.g.
+ * `<tool_call>{...}</think>` or `<tool_call>` used as a separator between
+ * consecutive payloads); stripping it keeps protocol markup out of visible
+ * text.
+ */
+function pushRecoveredTextSegment(
+  out: LanguageModelV4Content[],
+  segment: string
+): void {
+  const trimmed = segment
+    .replace(ORPHAN_TAG_AFTER_CALL_REGEX, "")
+    .replace(ORPHAN_TAG_BEFORE_CALL_REGEX, "");
+  if (trimmed.trim().length > 0) {
+    out.push({ type: "text", text: trimmed });
   }
-  return out;
 }
 
 function parseAsToolPayload(
@@ -231,7 +279,7 @@ function parseAsToolPayload(
   }
 
   const rawArgs = Object.hasOwn(payload, "arguments") ? payload.arguments : {};
-  if (!isRecord(rawArgs)) {
+  if (!isRecord(rawArgs) || containsPrototypeSensitiveKey(rawArgs)) {
     return null;
   }
 
@@ -300,7 +348,10 @@ function parseAsArgumentsOnly(
   }
 
   const tool = tools[0];
-  if (!isLikelyArgumentsShapeForTool(payload, tool)) {
+  if (
+    !isLikelyArgumentsShapeForTool(payload, tool) ||
+    containsPrototypeSensitiveKey(payload)
+  ) {
     return null;
   }
 
@@ -310,6 +361,29 @@ function parseAsArgumentsOnly(
   };
 }
 
+function resolveCandidatePayload(
+  candidate: JsonCandidate,
+  tools: LanguageModelV4FunctionTool[]
+): ToolCallCandidate | null {
+  if (PROTOTYPE_SENSITIVE_KEY_TEXT_REGEX.test(candidate.text)) {
+    return null;
+  }
+  const parsed = parseJsonCandidate(candidate.text);
+  if (parsed === undefined) {
+    return null;
+  }
+  return (
+    parseAsToolPayload(parsed, tools) ?? parseAsArgumentsOnly(parsed, tools)
+  );
+}
+
+/**
+ * Recover tool calls from JSON-like candidates embedded in plain text.
+ * Every non-overlapping candidate that resolves to a known tool becomes a
+ * tool-call part, so multi-call payloads (e.g. consecutive bare JSON objects
+ * separated by newlines or orphan `<tool_call>` tags) are all recovered.
+ * Returns null when no candidate resolves.
+ */
 export function recoverToolCallFromJsonCandidates(
   text: string,
   tools: LanguageModelV4FunctionTool[]
@@ -319,22 +393,30 @@ export function recoverToolCallFromJsonCandidates(
   }
 
   const jsonCandidates = extractJsonLikeCandidates(text);
+  const out: LanguageModelV4Content[] = [];
+  let cursor = 0;
+  let recoveredAny = false;
+
   for (const jsonCandidate of jsonCandidates) {
-    const parsed = parseJsonCandidate(jsonCandidate.text);
-    if (parsed === undefined) {
+    if (jsonCandidate.startIndex < cursor) {
+      // Overlaps a candidate that was already consumed (e.g. the balanced
+      // object inside an already-recovered tagged/fenced candidate).
       continue;
     }
-
-    const toolPayload = parseAsToolPayload(parsed, tools);
-    if (toolPayload) {
-      return toRecoveredParts(text, jsonCandidate, toToolCallPart(toolPayload));
+    const payload = resolveCandidatePayload(jsonCandidate, tools);
+    if (!payload) {
+      continue;
     }
-
-    const argsPayload = parseAsArgumentsOnly(parsed, tools);
-    if (argsPayload) {
-      return toRecoveredParts(text, jsonCandidate, toToolCallPart(argsPayload));
-    }
+    pushRecoveredTextSegment(out, text.slice(cursor, jsonCandidate.startIndex));
+    out.push(toToolCallPart(payload));
+    cursor = jsonCandidate.endIndex;
+    recoveredAny = true;
   }
 
-  return null;
+  if (!recoveredAny) {
+    return null;
+  }
+
+  pushRecoveredTextSegment(out, text.slice(cursor));
+  return out;
 }

--- a/src/core/utils/provider-options.ts
+++ b/src/core/utils/provider-options.ts
@@ -177,3 +177,15 @@ export function isToolChoiceActive(params: {
     (toolChoice.type === "tool" || toolChoice.type === "required")
   );
 }
+
+export function isToolChoiceNone(params: {
+  providerOptions?: {
+    toolCallMiddleware?: {
+      toolChoice?: { type: string };
+    };
+  };
+}): boolean {
+  return (
+    params.providerOptions?.toolCallMiddleware?.toolChoice?.type === "none"
+  );
+}

--- a/src/core/utils/stream-json-recovery.ts
+++ b/src/core/utils/stream-json-recovery.ts
@@ -19,6 +19,14 @@ const MAX_HELD_BLOCK_LENGTH = 10_000;
  */
 const RECOVERABLE_TAG_PREFIXES = ["<tool_call>", "<function="];
 
+/**
+ * Fenced blocks are held only for info strings the non-streaming recovery
+ * scan actually parses (```json / ```yaml / ```xml or none). A ```python
+ * block can never resolve to a tool call, so it streams through.
+ */
+const RECOVERABLE_FENCE_REGEX = /^```(?:json|ya?ml|xml)?\s*(?:\n|$)/i;
+const FENCE_PREFIX = "```";
+
 type StreamController =
   TransformStreamDefaultController<LanguageModelV4StreamPart>;
 
@@ -28,18 +36,35 @@ interface HeldTextBlock {
   startPart: LanguageModelV4StreamPart;
 }
 
+function fenceStillViable(leading: string): boolean {
+  if (leading.length < FENCE_PREFIX.length) {
+    return FENCE_PREFIX.startsWith(leading);
+  }
+  if (!leading.startsWith(FENCE_PREFIX)) {
+    return false;
+  }
+  const firstLineEnd = leading.indexOf("\n");
+  if (firstLineEnd === -1) {
+    // Info string still streaming in; keep holding only while it could
+    // still become a recoverable fence.
+    return RECOVERABLE_FENCE_REGEX.test(`${leading}\n`) || leading.length < 12;
+  }
+  return RECOVERABLE_FENCE_REGEX.test(leading.slice(0, firstLineEnd + 1));
+}
+
 /**
  * Streaming counterpart of `recoverToolCallFromJsonCandidates`: some models
  * emit a bare `{"name": ..., "arguments": ...}` payload without any protocol
  * markup. The generate path recovers those from the final text; without this
  * stage the stream path would leak the JSON as visible text.
  *
- * A text block whose first non-whitespace character is `{` is held back until
- * the block ends (or the stream finishes). If the accumulated block resolves
- * to a known tool call it is re-emitted as a full tool-input/tool-call
- * lifecycle; otherwise the block is flushed as ordinary text. Blocks that
- * start with anything else stream through untouched, so regular prose keeps
- * its incremental delivery.
+ * A text block that starts like a recoverable payload (bare JSON object,
+ * array of calls, recoverable code fence, or a leaked tool-call tag) is held
+ * back until the block ends (or the stream finishes). If the accumulated
+ * block resolves to known tool calls it is re-emitted as full
+ * tool-input/tool-call lifecycles; otherwise the block is flushed as
+ * ordinary text. Each text block is evaluated independently, mirroring the
+ * generate path's per-content-item recovery.
  */
 export function createStreamJsonRecoveryTransform({
   tools,
@@ -53,7 +78,6 @@ export function createStreamJsonRecoveryTransform({
     >();
   }
 
-  let disabled = false;
   let held: HeldTextBlock | null = null;
 
   const flushHeld = (controller: StreamController, closeBlock: boolean) => {
@@ -121,7 +145,6 @@ export function createStreamJsonRecoveryTransform({
     if (recovered && hasToolCall) {
       held = null;
       emitRecoveredParts(controller, recovered);
-      disabled = true;
       return;
     }
     flushHeld(controller, closeBlock);
@@ -132,20 +155,20 @@ export function createStreamJsonRecoveryTransform({
       return false;
     }
     // A block can still resolve to a tool call when it starts with a bare
-    // JSON object, a JSON array of calls, a fenced code block
-    // (```json ... ```), or a literal <tool_call> tag leaking through a
-    // protocol that does not know it — mirroring the candidate shapes of the
-    // non-streaming recovery scan.
+    // JSON object, a JSON array of calls (`[{`), a recoverable code fence,
+    // or a literal tool-call tag leaking through a protocol that does not
+    // know it — mirroring the candidate shapes of the non-streaming
+    // recovery scan.
     const leading = content.trimStart();
-    if (
-      leading.length === 0 ||
-      leading.startsWith("{") ||
-      leading.startsWith("[")
-    ) {
+    if (leading.length === 0 || leading.startsWith("{")) {
       return true;
     }
-    if ("```".startsWith(leading.slice(0, 3))) {
-      return true;
+    if (leading.startsWith("[")) {
+      const second = leading.slice(1).trimStart();
+      return second.length === 0 || second.startsWith("{");
+    }
+    if (leading.startsWith("`")) {
+      return fenceStillViable(leading);
     }
     return RECOVERABLE_TAG_PREFIXES.some(
       (tag) => leading.startsWith(tag) || tag.startsWith(leading)
@@ -156,22 +179,7 @@ export function createStreamJsonRecoveryTransform({
     LanguageModelV4StreamPart,
     LanguageModelV4StreamPart
   >({
-    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Stream part routing needs one branch per part type interacting with the held block.
     transform(part, controller) {
-      if (disabled) {
-        controller.enqueue(part);
-        return;
-      }
-
-      if (part.type === "tool-call") {
-        // The protocol parser already found a real tool call; recovery is a
-        // fallback for streams where it found none.
-        flushHeld(controller, false);
-        disabled = true;
-        controller.enqueue(part);
-        return;
-      }
-
       if (part.type === "text-start") {
         flushHeld(controller, false);
         held = { startPart: part, id: part.id, content: "" };

--- a/src/core/utils/stream-json-recovery.ts
+++ b/src/core/utils/stream-json-recovery.ts
@@ -1,0 +1,203 @@
+import type {
+  LanguageModelV4FunctionTool,
+  LanguageModelV4StreamPart,
+} from "@ai-sdk/provider";
+import { recoverToolCallFromJsonCandidates } from "./generated-text-json-recovery";
+import { generateId } from "./id";
+
+/**
+ * Maximum number of characters held back while a text block is still a
+ * plausible bare-JSON tool call. Mirrors the candidate size cap used by the
+ * non-streaming recovery scan.
+ */
+const MAX_HELD_BLOCK_LENGTH = 10_000;
+
+type StreamController =
+  TransformStreamDefaultController<LanguageModelV4StreamPart>;
+
+interface HeldTextBlock {
+  content: string;
+  id: string;
+  startPart: LanguageModelV4StreamPart;
+}
+
+/**
+ * Streaming counterpart of `recoverToolCallFromJsonCandidates`: some models
+ * emit a bare `{"name": ..., "arguments": ...}` payload without any protocol
+ * markup. The generate path recovers those from the final text; without this
+ * stage the stream path would leak the JSON as visible text.
+ *
+ * A text block whose first non-whitespace character is `{` is held back until
+ * the block ends (or the stream finishes). If the accumulated block resolves
+ * to a known tool call it is re-emitted as a full tool-input/tool-call
+ * lifecycle; otherwise the block is flushed as ordinary text. Blocks that
+ * start with anything else stream through untouched, so regular prose keeps
+ * its incremental delivery.
+ */
+export function createStreamJsonRecoveryTransform({
+  tools,
+}: {
+  tools: LanguageModelV4FunctionTool[];
+}): TransformStream<LanguageModelV4StreamPart, LanguageModelV4StreamPart> {
+  if (tools.length === 0) {
+    return new TransformStream<
+      LanguageModelV4StreamPart,
+      LanguageModelV4StreamPart
+    >();
+  }
+
+  let disabled = false;
+  let held: HeldTextBlock | null = null;
+
+  const flushHeld = (controller: StreamController, closeBlock: boolean) => {
+    if (!held) {
+      return;
+    }
+    controller.enqueue(held.startPart);
+    if (held.content.length > 0) {
+      controller.enqueue({
+        type: "text-delta",
+        id: held.id,
+        delta: held.content,
+      });
+    }
+    if (closeBlock) {
+      controller.enqueue({ type: "text-end", id: held.id });
+    }
+    held = null;
+  };
+
+  const emitRecoveredParts = (
+    controller: StreamController,
+    recovered: ReturnType<typeof recoverToolCallFromJsonCandidates>
+  ) => {
+    for (const part of recovered ?? []) {
+      if (part.type === "text") {
+        if (part.text.length === 0) {
+          continue;
+        }
+        const textId = generateId();
+        controller.enqueue({ type: "text-start", id: textId });
+        controller.enqueue({
+          type: "text-delta",
+          id: textId,
+          delta: part.text,
+        });
+        controller.enqueue({ type: "text-end", id: textId });
+        continue;
+      }
+      if (part.type === "tool-call") {
+        controller.enqueue({
+          type: "tool-input-start",
+          id: part.toolCallId,
+          toolName: part.toolName,
+        });
+        if (part.input.length > 0) {
+          controller.enqueue({
+            type: "tool-input-delta",
+            id: part.toolCallId,
+            delta: part.input,
+          });
+        }
+        controller.enqueue({ type: "tool-input-end", id: part.toolCallId });
+        controller.enqueue(part);
+      }
+    }
+  };
+
+  const resolveHeld = (controller: StreamController, closeBlock: boolean) => {
+    if (!held) {
+      return;
+    }
+    const recovered = recoverToolCallFromJsonCandidates(held.content, tools);
+    const hasToolCall = recovered?.some((part) => part.type === "tool-call");
+    if (recovered && hasToolCall) {
+      held = null;
+      emitRecoveredParts(controller, recovered);
+      disabled = true;
+      return;
+    }
+    flushHeld(controller, closeBlock);
+  };
+
+  const heldBlockStillViable = (content: string): boolean => {
+    if (content.length > MAX_HELD_BLOCK_LENGTH) {
+      return false;
+    }
+    // A block can still resolve to a tool call when it starts with a bare
+    // JSON object or a fenced code block (```json ... ```), mirroring the
+    // candidate shapes of the non-streaming recovery scan.
+    const leading = content.trimStart();
+    if (leading.length === 0 || leading.startsWith("{")) {
+      return true;
+    }
+    const fencePrefix = leading.slice(0, 3);
+    return "```".startsWith(fencePrefix);
+  };
+
+  return new TransformStream<
+    LanguageModelV4StreamPart,
+    LanguageModelV4StreamPart
+  >({
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Stream part routing needs one branch per part type interacting with the held block.
+    transform(part, controller) {
+      if (disabled) {
+        controller.enqueue(part);
+        return;
+      }
+
+      if (part.type === "tool-call") {
+        // The protocol parser already found a real tool call; recovery is a
+        // fallback for streams where it found none.
+        flushHeld(controller, false);
+        disabled = true;
+        controller.enqueue(part);
+        return;
+      }
+
+      if (part.type === "text-start") {
+        flushHeld(controller, false);
+        held = { startPart: part, id: part.id, content: "" };
+        return;
+      }
+
+      if (part.type === "text-delta" && held && part.id === held.id) {
+        held.content += part.delta;
+        if (!heldBlockStillViable(held.content)) {
+          flushHeld(controller, false);
+        }
+        return;
+      }
+
+      if (part.type === "text-end") {
+        if (held && part.id === held.id) {
+          resolveHeld(controller, true);
+          return;
+        }
+        // A text-end for a block that already streamed through (protocol
+        // parsers re-identify published text, so the provider's original
+        // block close can arrive while a re-identified block is held).
+        // Forward it without disturbing the held block.
+        controller.enqueue(part);
+        return;
+      }
+
+      if (part.type === "finish") {
+        resolveHeld(controller, true);
+        controller.enqueue(part);
+        return;
+      }
+
+      if (held) {
+        flushHeld(controller, false);
+      }
+      controller.enqueue(part);
+    },
+
+    flush(controller) {
+      // Defensive: a stream that ends without a finish part still must not
+      // swallow held text.
+      resolveHeld(controller, true);
+    },
+  });
+}

--- a/src/core/utils/stream-json-recovery.ts
+++ b/src/core/utils/stream-json-recovery.ts
@@ -12,6 +12,13 @@ import { generateId } from "./id";
  */
 const MAX_HELD_BLOCK_LENGTH = 10_000;
 
+/**
+ * Tag tokens that can open a recoverable call block when they leak through a
+ * protocol that does not know them (`<tool_call>` wrappers, Qwen-style
+ * `<function=...>` blocks).
+ */
+const RECOVERABLE_TAG_PREFIXES = ["<tool_call>", "<function="];
+
 type StreamController =
   TransformStreamDefaultController<LanguageModelV4StreamPart>;
 
@@ -140,8 +147,9 @@ export function createStreamJsonRecoveryTransform({
     if ("```".startsWith(leading.slice(0, 3))) {
       return true;
     }
-    const tag = "<tool_call>";
-    return leading.startsWith(tag) || tag.startsWith(leading);
+    return RECOVERABLE_TAG_PREFIXES.some(
+      (tag) => leading.startsWith(tag) || tag.startsWith(leading)
+    );
   };
 
   return new TransformStream<

--- a/src/core/utils/stream-json-recovery.ts
+++ b/src/core/utils/stream-json-recovery.ts
@@ -13,19 +13,15 @@ import { generateId } from "./id";
 const MAX_HELD_BLOCK_LENGTH = 10_000;
 
 /**
- * Tag tokens that can open a recoverable call block when they leak through a
- * protocol that does not know them (`<tool_call>` wrappers, Qwen-style
- * `<function=...>` blocks).
- */
-const RECOVERABLE_TAG_PREFIXES = ["<tool_call>", "<function="];
-
-/**
  * Fenced blocks are held only for info strings the non-streaming recovery
  * scan actually parses (```json / ```yaml / ```xml or none). A ```python
  * block can never resolve to a tool call, so it streams through.
  */
 const RECOVERABLE_FENCE_REGEX = /^```(?:json|ya?ml|xml)?\s*(?:\n|$)/i;
 const FENCE_PREFIX = "```";
+const RECOVERABLE_TOOL_CALL_TAG = "<tool_call>";
+const RECOVERABLE_QWEN_CALL_TAGS = ["call", "function", "tool", "invoke"];
+const ASCII_WHITESPACE_REGEX = /\s/;
 
 type StreamController =
   TransformStreamDefaultController<LanguageModelV4StreamPart>;
@@ -50,6 +46,36 @@ function fenceStillViable(leading: string): boolean {
     return RECOVERABLE_FENCE_REGEX.test(`${leading}\n`) || leading.length < 12;
   }
   return RECOVERABLE_FENCE_REGEX.test(leading.slice(0, firstLineEnd + 1));
+}
+
+function recoverableTagStillViable(leading: string): boolean {
+  const lower = leading.toLowerCase();
+  if (
+    RECOVERABLE_TOOL_CALL_TAG.startsWith(lower) ||
+    lower.startsWith(RECOVERABLE_TOOL_CALL_TAG)
+  ) {
+    return true;
+  }
+
+  for (const tagName of RECOVERABLE_QWEN_CALL_TAGS) {
+    const tagStart = `<${tagName}`;
+    if (tagStart.startsWith(lower)) {
+      return true;
+    }
+    if (!lower.startsWith(tagStart)) {
+      continue;
+    }
+    const next = lower[tagStart.length];
+    return (
+      next === undefined ||
+      next === "=" ||
+      next === ">" ||
+      next === "/" ||
+      ASCII_WHITESPACE_REGEX.test(next)
+    );
+  }
+
+  return false;
 }
 
 /**
@@ -170,9 +196,7 @@ export function createStreamJsonRecoveryTransform({
     if (leading.startsWith("`")) {
       return fenceStillViable(leading);
     }
-    return RECOVERABLE_TAG_PREFIXES.some(
-      (tag) => leading.startsWith(tag) || tag.startsWith(leading)
-    );
+    return recoverableTagStillViable(leading);
   };
 
   return new TransformStream<

--- a/src/core/utils/stream-json-recovery.ts
+++ b/src/core/utils/stream-json-recovery.ts
@@ -125,14 +125,23 @@ export function createStreamJsonRecoveryTransform({
       return false;
     }
     // A block can still resolve to a tool call when it starts with a bare
-    // JSON object or a fenced code block (```json ... ```), mirroring the
-    // candidate shapes of the non-streaming recovery scan.
+    // JSON object, a JSON array of calls, a fenced code block
+    // (```json ... ```), or a literal <tool_call> tag leaking through a
+    // protocol that does not know it — mirroring the candidate shapes of the
+    // non-streaming recovery scan.
     const leading = content.trimStart();
-    if (leading.length === 0 || leading.startsWith("{")) {
+    if (
+      leading.length === 0 ||
+      leading.startsWith("{") ||
+      leading.startsWith("[")
+    ) {
       return true;
     }
-    const fencePrefix = leading.slice(0, 3);
-    return "```".startsWith(fencePrefix);
+    if ("```".startsWith(leading.slice(0, 3))) {
+      return true;
+    }
+    const tag = "<tool_call>";
+    return leading.startsWith(tag) || tag.startsWith(leading);
   };
 
   return new TransformStream<

--- a/src/core/utils/xml-tool-tag-scanner.ts
+++ b/src/core/utils/xml-tool-tag-scanner.ts
@@ -60,6 +60,62 @@ export function findNextToolTag(
   };
 }
 
+const WHITESPACE_CHAR_RE = /\s/;
+const PENDING_SELF_CLOSING_SUFFIX_RE = /^\s*\/?$/;
+
+function isPartialToolTagPrefix(suffix: string, toolName: string): boolean {
+  // Complete open tag shape is exactly `<toolName>`; self-closing allows
+  // whitespace: `<\s*toolName\s*/>`. Anything that could still grow into one
+  // of those keeps the suffix held back.
+  if (suffix.length <= 1) {
+    return suffix === "<";
+  }
+
+  let cursor = 1;
+  while (cursor < suffix.length && WHITESPACE_CHAR_RE.test(suffix[cursor])) {
+    cursor += 1;
+  }
+  const rest = suffix.slice(cursor);
+  if (rest.length === 0) {
+    return true;
+  }
+
+  if (toolName.startsWith(rest)) {
+    return true;
+  }
+  if (!rest.startsWith(toolName)) {
+    return false;
+  }
+
+  // Name complete — the remainder may only be whitespace and an optional `/`
+  // while waiting for the closing `>`.
+  return PENDING_SELF_CLOSING_SUFFIX_RE.test(rest.slice(toolName.length));
+}
+
+/**
+ * Index in `buffer` where a not-yet-complete tool tag may start, or null when
+ * the buffer tail cannot be the beginning of any tool tag. Used by streaming
+ * parsers to flush everything that is provably plain text instead of holding
+ * back a fixed-size tail on every chunk.
+ */
+export function findPotentialPartialToolTagStart(
+  buffer: string,
+  toolNames: string[]
+): number | null {
+  let from = 0;
+  while (true) {
+    const lt = buffer.indexOf("<", from);
+    if (lt === -1) {
+      return null;
+    }
+    const suffix = buffer.slice(lt);
+    if (toolNames.some((name) => isPartialToolTagPrefix(suffix, name))) {
+      return lt;
+    }
+    from = lt + 1;
+  }
+}
+
 export function findEarliestToolTag(
   buffer: string,
   toolNames: string[]

--- a/src/generate-handler.ts
+++ b/src/generate-handler.ts
@@ -11,6 +11,10 @@ import {
   logParsedSummary,
   logRawChunk,
 } from "./core/utils/debug";
+import {
+  normalizeToolCallsFinishReason,
+  shouldRewriteFinishReasonToToolCalls,
+} from "./core/utils/finish-reason";
 import { recoverToolCallFromJsonCandidates } from "./core/utils/generated-text-json-recovery";
 import { generateToolCallId } from "./core/utils/id";
 import { extractOnErrorOption } from "./core/utils/on-error";
@@ -18,6 +22,7 @@ import {
   decodeOriginalToolsFromProviderOptions,
   getToolCallMiddlewareOptions,
   isToolChoiceActive,
+  isToolChoiceNone,
   type ToolCallMiddlewareProviderOptions,
 } from "./core/utils/provider-options";
 import { coerceToolCallPart } from "./core/utils/tool-call-coercion";
@@ -76,6 +81,7 @@ async function handleToolChoice(
   return {
     ...result,
     content: [toolCall],
+    finishReason: normalizeToolCallsFinishReason(result.finishReason),
   };
 }
 
@@ -184,6 +190,12 @@ export async function wrapGenerate({
     providerOptions?: ToolCallMiddlewareProviderOptions;
   };
 }) {
+  if (isToolChoiceNone(params)) {
+    // toolChoice 'none': no tool prompt was injected and no tool calls are
+    // expected, so return the model result untouched.
+    return doGenerate();
+  }
+
   const onError = extractOnErrorOption(params.providerOptions);
   const tools = decodeOriginalToolsFromProviderOptions(
     params.providerOptions,
@@ -216,8 +228,17 @@ export async function wrapGenerate({
     providerOptions: params.providerOptions,
   });
 
+  const hasParsedToolCall = newContent.some(
+    (part) => part.type === "tool-call"
+  );
+
   return {
     ...result,
     content: newContent,
+    finishReason:
+      hasParsedToolCall &&
+      shouldRewriteFinishReasonToToolCalls(result.finishReason)
+        ? normalizeToolCallsFinishReason(result.finishReason)
+        : result.finishReason,
   };
 }

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -1,4 +1,5 @@
 import { parse as parseRJSON } from "../rjson";
+import { unescapeXml } from "../rxml/utils/helpers";
 
 // Regex constants for performance
 const NUMERIC_REGEX = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
@@ -694,7 +695,7 @@ const COERCE_PROTOTYPE_SENSITIVE_KEYS = new Set([
 const COERCE_PROTO_KEY_TEXT_REGEX =
   /["'](?:__proto__|constructor|prototype)["']\s*:|[{,]\s*(?:__proto__|constructor|prototype)\s*:/;
 /** Python literals models leak into JSON-ish payloads (`True`, `None`). */
-const PYTHON_LITERAL_TOKEN_REGEX = /\b(?:True|False|None)\b/g;
+const IDENTIFIER_CHAR_REGEX = /[\w$]/;
 const XML_CHILD_VALUE_CLOSED_RE = /^<([A-Za-z_][\w.-]*)\s*>([^<]*)<\/\1\s*>$/;
 const XML_CHILD_VALUE_OPEN_RE = /^<([A-Za-z_][\w.-]*)\s*>([^<]*\S[^<]*)$/;
 
@@ -704,11 +705,60 @@ const PYTHON_LITERAL_REPLACEMENTS: Record<string, string> = {
   None: "null",
 };
 
+/**
+ * Replace bare Python literals (`True`/`False`/`None`) with their JSON
+ * equivalents, quote-aware so occurrences inside string values (e.g.
+ * `{'note': 'True story'}`) are never touched.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Quote-aware token replacement requires explicit string-state transitions.
 function normalizePythonLiterals(s: string): string {
-  return s.replace(
-    PYTHON_LITERAL_TOKEN_REGEX,
-    (token) => PYTHON_LITERAL_REPLACEMENTS[token] ?? token
-  );
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+  let out: string[] | null = null;
+  let chunkStart = 0;
+
+  for (let i = 0; i < s.length; i += 1) {
+    const ch = s[i];
+    if (quote !== null) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+
+    const replacement =
+      ch === "T" || ch === "F" || ch === "N"
+        ? Object.keys(PYTHON_LITERAL_REPLACEMENTS).find(
+            (token) =>
+              s.startsWith(token, i) &&
+              !IDENTIFIER_CHAR_REGEX.test(s[i - 1] ?? "") &&
+              !IDENTIFIER_CHAR_REGEX.test(s[i + token.length] ?? "")
+          )
+        : undefined;
+    if (replacement) {
+      out ??= [];
+      out.push(
+        s.slice(chunkStart, i),
+        PYTHON_LITERAL_REPLACEMENTS[replacement]
+      );
+      i += replacement.length - 1;
+      chunkStart = i + 1;
+    }
+  }
+
+  if (out === null) {
+    return s;
+  }
+  out.push(s.slice(chunkStart));
+  return out.join("");
 }
 
 function hasPrototypeSensitiveOwnKey(value: unknown): boolean {
@@ -742,21 +792,22 @@ function parseLooseStructuredString(s: string): unknown {
   if (COERCE_PROTO_KEY_TEXT_REGEX.test(s)) {
     return;
   }
-  const candidates = [s, normalizePythonLiterals(s)];
-  for (const candidate of candidates) {
-    try {
-      return JSON.parse(candidate);
-    } catch {
-      // try relaxed JSON next
+  // Python literals are normalized up front (quote-aware, so string values
+  // are untouched); otherwise the relaxed parser would absorb bare `None` /
+  // `True` tokens as identifier strings before the normalized candidate ran.
+  const normalized = normalizePythonLiterals(s);
+  try {
+    return JSON.parse(normalized);
+  } catch {
+    // try relaxed JSON next
+  }
+  try {
+    const parsed = parseRJSON(normalized) as unknown;
+    if (!hasPrototypeSensitiveOwnKey(parsed)) {
+      return parsed;
     }
-    try {
-      const parsed = parseRJSON(candidate) as unknown;
-      if (!hasPrototypeSensitiveOwnKey(parsed)) {
-        return parsed;
-      }
-    } catch {
-      // try next candidate
-    }
+  } catch {
+    // not parseable as a structured value
   }
   return;
 }
@@ -786,7 +837,17 @@ function parseXmlChildrenValue(s: string): Record<string, unknown> | null {
     if (COERCE_PROTOTYPE_SENSITIVE_KEYS.has(key)) {
       return null;
     }
-    record[key] = (match[2] ?? "").trim();
+    // Match the yaml-xml protocol's body fallback: unescape XML entities
+    // and merge repeated keys into arrays.
+    const value = unescapeXml((match[2] ?? "").trim());
+    const existing = record[key];
+    if (existing === undefined) {
+      record[key] = value;
+    } else if (Array.isArray(existing)) {
+      existing.push(value);
+    } else {
+      record[key] = [existing, value];
+    }
   }
   return record;
 }

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -797,7 +797,11 @@ function parseLooseStructuredString(s: string): unknown {
   // `True` tokens as identifier strings before the normalized candidate ran.
   const normalized = normalizePythonLiterals(s);
   try {
-    return JSON.parse(normalized);
+    const parsed = JSON.parse(normalized) as unknown;
+    if (!hasPrototypeSensitiveOwnKey(parsed)) {
+      return parsed;
+    }
+    return;
   } catch {
     // try relaxed JSON next
   }

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -692,8 +692,6 @@ const COERCE_PROTOTYPE_SENSITIVE_KEYS = new Set([
   "constructor",
   "prototype",
 ]);
-const COERCE_PROTO_KEY_TEXT_REGEX =
-  /["'](?:__proto__|constructor|prototype)["']\s*:|[{,]\s*(?:__proto__|constructor|prototype)\s*:/;
 /** Python literals models leak into JSON-ish payloads (`True`, `None`). */
 const IDENTIFIER_CHAR_REGEX = /[\w$]/;
 const XML_CHILD_VALUE_CLOSED_RE = /^<([A-Za-z_][\w.-]*)\s*>([^<]*)<\/\1\s*>$/;
@@ -789,9 +787,6 @@ function parseLooseStructuredString(s: string): unknown {
   if (first !== "{" && first !== "[") {
     return;
   }
-  if (COERCE_PROTO_KEY_TEXT_REGEX.test(s)) {
-    return;
-  }
   // Python literals are normalized up front (quote-aware, so string values
   // are untouched); otherwise the relaxed parser would absorb bare `None` /
   // `True` tokens as identifier strings before the normalized candidate ran.
@@ -806,10 +801,18 @@ function parseLooseStructuredString(s: string): unknown {
     // try relaxed JSON next
   }
   try {
-    const parsed = parseRJSON(normalized) as unknown;
-    if (!hasPrototypeSensitiveOwnKey(parsed)) {
-      return parsed;
+    let foundPrototypeSensitiveKey = false;
+    const parsed = parseRJSON(normalized, (key: string, value: unknown) => {
+      if (COERCE_PROTOTYPE_SENSITIVE_KEYS.has(key)) {
+        foundPrototypeSensitiveKey = true;
+        return;
+      }
+      return value;
+    });
+    if (foundPrototypeSensitiveKey || hasPrototypeSensitiveOwnKey(parsed)) {
+      return;
     }
+    return parsed;
   } catch {
     // not parseable as a structured value
   }

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -1,6 +1,7 @@
+import { parse as parseRJSON } from "../rjson";
+
 // Regex constants for performance
 const NUMERIC_REGEX = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
-const EMPTY_OBJECT_REGEX = /^\{\s*\}$/s;
 const NEWLINE_SPLIT_REGEX = /\n+/;
 const COMMA_SPLIT_REGEX = /,\s*/;
 const DIGIT_KEY_REGEX = /^\d+$/;
@@ -685,6 +686,111 @@ function coerceStringWithoutSchema(value: string): unknown {
   return value;
 }
 
+const COERCE_PROTOTYPE_SENSITIVE_KEYS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+const COERCE_PROTO_KEY_TEXT_REGEX =
+  /["'](?:__proto__|constructor|prototype)["']\s*:|[{,]\s*(?:__proto__|constructor|prototype)\s*:/;
+/** Python literals models leak into JSON-ish payloads (`True`, `None`). */
+const PYTHON_LITERAL_TOKEN_REGEX = /\b(?:True|False|None)\b/g;
+const XML_CHILD_VALUE_CLOSED_RE = /^<([A-Za-z_][\w.-]*)\s*>([^<]*)<\/\1\s*>$/;
+const XML_CHILD_VALUE_OPEN_RE = /^<([A-Za-z_][\w.-]*)\s*>([^<]*\S[^<]*)$/;
+
+const PYTHON_LITERAL_REPLACEMENTS: Record<string, string> = {
+  True: "true",
+  False: "false",
+  None: "null",
+};
+
+function normalizePythonLiterals(s: string): string {
+  return s.replace(
+    PYTHON_LITERAL_TOKEN_REGEX,
+    (token) => PYTHON_LITERAL_REPLACEMENTS[token] ?? token
+  );
+}
+
+function hasPrototypeSensitiveOwnKey(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some(hasPrototypeSensitiveOwnKey);
+  }
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    if (COERCE_PROTOTYPE_SENSITIVE_KEYS.has(key)) {
+      return true;
+    }
+    if (hasPrototypeSensitiveOwnKey((value as Record<string, unknown>)[key])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Parse a string that should have been a structured value: strict JSON,
+ * then relaxed JSON (single quotes, unquoted keys), then Python-literal
+ * normalization (`True`/`False`/`None` — observed live on KAT Coder Pro).
+ */
+function parseLooseStructuredString(s: string): unknown {
+  const first = s.trimStart().charAt(0);
+  if (first !== "{" && first !== "[") {
+    return;
+  }
+  if (COERCE_PROTO_KEY_TEXT_REGEX.test(s)) {
+    return;
+  }
+  const candidates = [s, normalizePythonLiterals(s)];
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // try relaxed JSON next
+    }
+    try {
+      const parsed = parseRJSON(candidate) as unknown;
+      if (!hasPrototypeSensitiveOwnKey(parsed)) {
+        return parsed;
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+  return;
+}
+
+/**
+ * Parse line-oriented `<key>value</key>` children into a record (observed
+ * live on Cohere Command R+, which nests XML children inside an object-typed
+ * parameter value). Tolerates a missing close tag on a line.
+ */
+function parseXmlChildrenValue(s: string): Record<string, unknown> | null {
+  const lines = s
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0 || !lines[0].startsWith("<")) {
+    return null;
+  }
+  const record: Record<string, unknown> = {};
+  for (const line of lines) {
+    const match =
+      XML_CHILD_VALUE_CLOSED_RE.exec(line) ??
+      XML_CHILD_VALUE_OPEN_RE.exec(line);
+    if (!match) {
+      return null;
+    }
+    const key = match[1];
+    if (COERCE_PROTOTYPE_SENSITIVE_KEYS.has(key)) {
+      return null;
+    }
+    record[key] = (match[2] ?? "").trim();
+  }
+  return record;
+}
+
 /**
  * Coerce string to object using schema
  */
@@ -692,26 +798,16 @@ function coerceStringToObject(
   s: string,
   unwrapped: Record<string, unknown>
 ): unknown {
-  // First try parsing the original string as-is
-  try {
-    const obj = JSON.parse(s);
-    if (obj && typeof obj === "object" && !Array.isArray(obj)) {
-      return coerceObjectToObject(obj as Record<string, unknown>, unwrapped);
-    }
-  } catch {
-    // Fallback: try replacing single quotes with double quotes
-    // (for cases where model uses single-quoted JSON)
-    try {
-      let normalized = s.replace(/'/g, '"');
-      normalized = normalized.replace(EMPTY_OBJECT_REGEX, "{}");
-      const obj = JSON.parse(normalized);
-      if (obj && typeof obj === "object" && !Array.isArray(obj)) {
-        return coerceObjectToObject(obj as Record<string, unknown>, unwrapped);
-      }
-    } catch {
-      // fallthrough
-    }
+  const parsed = parseLooseStructuredString(s);
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return coerceObjectToObject(parsed as Record<string, unknown>, unwrapped);
   }
+
+  const xmlChildren = parseXmlChildrenValue(s);
+  if (xmlChildren) {
+    return coerceObjectToObject(xmlChildren, unwrapped);
+  }
+
   return null;
 }
 
@@ -727,29 +823,26 @@ function coerceStringToArray(
     : undefined;
   const itemsSchema = unwrapped.items as unknown;
 
+  const coerceArrayItems = (arr: unknown[]): unknown => {
+    if (prefixItems && arr.length === prefixItems.length) {
+      return arr.map((v, i) => coerceBySchema(v, prefixItems[i]));
+    }
+    return arr.map((v) => coerceBySchema(v, itemsSchema));
+  };
+
   try {
     const arr = JSON.parse(s);
     if (Array.isArray(arr)) {
-      if (prefixItems && arr.length === prefixItems.length) {
-        return arr.map((v, i) => coerceBySchema(v, prefixItems[i]));
-      }
-      return arr.map((v) => coerceBySchema(v, itemsSchema));
+      return coerceArrayItems(arr);
     }
   } catch {
-    // Fallback: try replacing single quotes with double quotes
-    // (for cases where model uses single-quoted JSON)
-    try {
-      const normalized = s.replace(/'/g, '"');
-      const arr = JSON.parse(normalized);
-      if (Array.isArray(arr)) {
-        if (prefixItems && arr.length === prefixItems.length) {
-          return arr.map((v, i) => coerceBySchema(v, prefixItems[i]));
-        }
-        return arr.map((v) => coerceBySchema(v, itemsSchema));
-      }
-    } catch {
-      // Both failed — fall through to CSV split
+    // Relaxed parsing (single quotes, unquoted keys, Python literals).
+    const parsed = parseLooseStructuredString(s);
+    if (Array.isArray(parsed)) {
+      return coerceArrayItems(parsed);
     }
+
+    // Fall back to CSV/line splitting for plain enumerations.
     const csv = s.includes("\n")
       ? s.split(NEWLINE_SPLIT_REGEX)
       : s.split(COMMA_SPLIT_REGEX);

--- a/src/stream-handler.ts
+++ b/src/stream-handler.ts
@@ -1,20 +1,25 @@
 import type {
   LanguageModelV4,
-  LanguageModelV4FinishReason,
   LanguageModelV4FunctionTool,
   LanguageModelV4StreamPart,
   LanguageModelV4Usage,
 } from "@ai-sdk/provider";
 import type { TCMCoreProtocol } from "./core/protocols/protocol-interface";
 import { getDebugLevel, logParsedChunk, logRawChunk } from "./core/utils/debug";
+import {
+  normalizeToolCallsFinishReason,
+  shouldRewriteFinishReasonToToolCalls,
+} from "./core/utils/finish-reason";
 import { generateToolCallId } from "./core/utils/id";
 import { extractOnErrorOption } from "./core/utils/on-error";
 import {
   decodeOriginalToolsFromProviderOptions,
   getToolCallMiddlewareOptions,
   isToolChoiceActive,
+  isToolChoiceNone,
   type ToolCallMiddlewareProviderOptions,
 } from "./core/utils/provider-options";
+import { createStreamJsonRecoveryTransform } from "./core/utils/stream-json-recovery";
 import { coerceToolCallPart } from "./core/utils/tool-call-coercion";
 import { resolveToolChoiceSelection } from "./core/utils/tool-choice";
 
@@ -31,6 +36,12 @@ export async function wrapStream({
     providerOptions?: ToolCallMiddlewareProviderOptions;
   };
 }) {
+  if (isToolChoiceNone(params)) {
+    // toolChoice 'none': no tool prompt was injected and no tool calls are
+    // expected, so pass the model stream through untouched.
+    return doStream();
+  }
+
   const onErrorOptions = extractOnErrorOption(params.providerOptions);
   const tools = decodeOriginalToolsFromProviderOptions(
     params.providerOptions,
@@ -65,7 +76,8 @@ export async function wrapStream({
         }
       )
     )
-    .pipeThrough(protocol.createStreamParser({ tools, options }));
+    .pipeThrough(protocol.createStreamParser({ tools, options }))
+    .pipeThrough(createStreamJsonRecoveryTransform({ tools }));
 
   let seenToolCall = false;
   const v3Stream = coreStream.pipeThrough(
@@ -81,7 +93,7 @@ export async function wrapStream({
         if (
           normalizedPart.type === "finish" &&
           seenToolCall &&
-          normalizedPart.finishReason.unified === "stop"
+          shouldRewriteFinishReasonToToolCalls(normalizedPart.finishReason)
         ) {
           normalizedPart = {
             ...normalizedPart,
@@ -127,11 +139,32 @@ export async function toolChoiceStream({
     errorMessage: "Failed to parse toolChoice JSON from streamed model output",
   });
 
+  const toolCallId = generateToolCallId();
   const stream = new ReadableStream<LanguageModelV4StreamPart>({
     start(controller) {
       controller.enqueue({
+        type: "stream-start",
+        warnings: result?.warnings ?? [],
+      });
+      controller.enqueue({
+        type: "tool-input-start",
+        id: toolCallId,
+        toolName,
+      });
+      if (input.length > 0) {
+        controller.enqueue({
+          type: "tool-input-delta",
+          id: toolCallId,
+          delta: input,
+        });
+      }
+      controller.enqueue({
+        type: "tool-input-end",
+        id: toolCallId,
+      });
+      controller.enqueue({
         type: "tool-call",
-        toolCallId: generateToolCallId(),
+        toolCallId,
         toolName,
         input,
       });
@@ -139,6 +172,9 @@ export async function toolChoiceStream({
         type: "finish",
         usage: normalizeUsage(result?.usage),
         finishReason: normalizeToolCallsFinishReason(result?.finishReason),
+        ...(result?.providerMetadata
+          ? { providerMetadata: result.providerMetadata }
+          : {}),
       });
       controller.close();
     },
@@ -164,34 +200,6 @@ const ZERO_USAGE: LanguageModelV4Usage = {
     reasoning: undefined,
   },
 };
-
-function normalizeToolCallsFinishReason(
-  finishReason: unknown
-): LanguageModelV4FinishReason {
-  let raw = "tool-calls";
-  if (typeof finishReason === "string") {
-    raw = finishReason;
-  } else if (
-    finishReason &&
-    typeof finishReason === "object" &&
-    "raw" in finishReason &&
-    typeof (finishReason as { raw?: unknown }).raw === "string"
-  ) {
-    raw = (finishReason as { raw: string }).raw;
-  } else if (
-    finishReason &&
-    typeof finishReason === "object" &&
-    "unified" in finishReason &&
-    typeof (finishReason as { unified?: unknown }).unified === "string"
-  ) {
-    raw = (finishReason as { unified: string }).unified;
-  }
-
-  return {
-    unified: "tool-calls",
-    raw,
-  };
-}
 
 function normalizeUsage(usage: unknown): LanguageModelV4Usage {
   if (!usage || typeof usage !== "object") {

--- a/src/transform-handler.ts
+++ b/src/transform-handler.ts
@@ -278,6 +278,21 @@ export function transformParams({
     extractOnErrorOption(params.providerOptions)
   );
 
+  if (params.toolChoice?.type === "none") {
+    // 'none' means the model must not call tools on this step. Tool-call
+    // history is still serialized to text above, but no tool definitions are
+    // injected and the wrap handlers skip tool-call parsing entirely.
+    return {
+      ...params,
+      prompt: processedPrompt,
+      tools: [] as never[],
+      toolChoice: undefined,
+      providerOptions: mergeToolCallMiddlewareOptions(params.providerOptions, {
+        toolChoice: { type: "none" as const },
+      }),
+    };
+  }
+
   const finalPrompt = buildFinalPrompt(
     systemPrompt,
     processedPrompt,
@@ -288,12 +303,6 @@ export function transformParams({
     finalPrompt,
     functionTools
   );
-
-  if (params.toolChoice?.type === "none") {
-    throw new Error(
-      "The 'none' toolChoice type is not supported by this middleware. Please use 'auto', 'required', or specify a tool name."
-    );
-  }
 
   if (params.toolChoice?.type === "tool") {
     return handleToolChoiceTool(params, baseReturnParams);


### PR DESCRIPTION
## What & why

This PR is the result of a three-track investigation into where the middleware falls short on AI SDK v7, followed by fixes for everything found:

1. **Spec audit** — compared the `LanguageModelV4` provider spec surface against what the middleware actually handles.
2. **Code review** — hunted for generate/stream behavioral divergences and dead code across the four protocols.
3. **Live model testing** — ran a 4 middlewares × 6 models × 5 scenarios matrix (GLM-4.7, Qwen2.5-7B, Kimi K2.5, gpt-oss-20b, Llama 3.1-8B, Gemma 4) plus raw-output capture to reproduce every failure class at the wire level.

## Fixes (each verified live and covered by new tests)

### Generate/stream parity
- **`wrapGenerate` now rewrites `finishReason` → `tool-calls`** when tool calls were parsed from text. The stream path did this; the generate path silently reported `stop`. Meaningful reasons (`length`, `content-filter`) are preserved, and the stream rewrite gate now also covers `unified: "other"`.
- **Streaming bare-JSON recovery** (new `stream-json-recovery` stage): GLM-4.7 with the Hermes prompt frequently emits the tool call as a bare `{"name": ..., "arguments": ...}` payload or a fenced ```json block with no markup at all. The generate path has recovered these for a long time; the stream path leaked them as visible text. A post-protocol transform now holds text blocks that start with `{`/``` and re-emits them as full tool-input/tool-call lifecycles using the exact same recovery function as generate.
- **Multi-call recovery**: GLM-4.7 emits *parallel* calls as newline-separated payloads or with orphan `<tool_call>` tags as separators. Recovery now converts every resolvable candidate, not just the first — live result went from **0 recovered calls to 3/3 in every run**.

### Spec coverage
- **`toolChoice: "none"` is now supported** instead of throwing: no tool prompt injection, no parsing, history still serialized (`LanguageModelV4ToolChoice` lists it as a legal variant).
- **Forced tool-choice streams emit the full lifecycle**: `stream-start` (with the underlying model's warnings, previously dropped), `tool-input-start/delta/end` reconciled to the final `toolCallId`, and `finish` carrying `providerMetadata`.
- **Canonical v4 `type: "file"` tool-result content parts** (tagged `data`/`url`/`reference`/`text`) were falling through to `"[Unknown content]"` — now normalized in placeholder and model modes.

### Protocol hardening (from raw-output captures)
- **Hermes — mismatched close tags**: GLM-4.7 emits `<tool_call>{...}</think>`. Both parse paths now salvage the balanced JSON body, gated behind the same argument key policy and prototype-pollution guards as the primary parser, and narrow enough that truncated JSON / trailing-prose bodies still fall back as before. Orphan `<tool_call>` fragments no longer leak into recovered text.
- **Qwen3-Coder — nameless parameters**: Qwen2.5-7B emits `<parameter>city</parameter>\nSeoul` (name as element text). This produced tool calls with empty `{}` inputs 3/3 times; both parse paths now recover the full arguments 3/3.
- **Qwen3-Coder — streaming freeze**: prose containing tag-like substrings (`<callback>`, `<toolbar>`, `<invoker>`) pinned the stream buffer until finish. Tag detection is now boundary-aware.
- **YAML-XML — fixed-tail holdback**: every chunk withheld `maxTagLen - 1` chars even with no `<` in sight (short chunks never streamed). Only genuine partial tool-tag suffixes are held now.
- **Recovery prototype-pollution gap**: relaxed-JSON parsing can absorb `__proto__` keys past post-parse checks; recovery now rejects prototype-sensitive keys textually.

### Cleanup
- Removed dead `speculativeToolCall` state and an unreachable `flushBuffer` branch from the Hermes stream parser (leftovers from an abandoned speculative-commit design).

## Verification

- Tests: 1,940 → **1,993 passing** (53 new tests across 8 files); `pnpm check` clean; build clean.
- Live matrix pass rate: **102/120 → 106/120**. All remaining failures are model behavior (weak models re-calling the tool in multiturn instead of answering, Llama inventing a `location` param, gpt-oss occasionally emitting raw Harmony channel tokens), not parser drops — every parser-attributable failure class from the baseline run is fixed.
- Targeted live re-verification: GLM bare-JSON streaming ✅, GLM parallel calls 3/3 ✅, GLM mismatched-close salvage ✅, Qwen2.5 nameless params 3/3 ✅.

## Future work (out of scope)

- gpt-oss sometimes emits raw Harmony format (`<|channel|>commentary to=functions.x`) — would need a dedicated Harmony protocol.
- Multiturn "re-call instead of answer" on weak models is prompt-template territory (deliberately untouched per repo conventions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes AI SDK v7 generate/stream parity gaps and hardens parsing/coercion across Hermes, Qwen, and YAML/XML. Adds `toolChoice: "none"`, streaming bare/fenced JSON recovery with multi-call support, unified `finishReason` normalization, canonical v4 `type: "file"` handling, and reduces prototype-key guard false positives.

- New Features
  - End-to-end `toolChoice: "none"`: no tool prompt injection or parsing; tool-call history still serialized.
  - Streaming JSON recovery parity with generate: handle bare/fenced/array JSON and multi-call payloads; detect `<tool_call>` and Qwen `<function=name>`; emit `tool-input-start/delta/end`; forward `stream-start` warnings and `finish.providerMetadata`.
  - Consistent `finishReason`: rewrite to `tool-calls` in both generate and stream when calls are parsed, preserving provider raw values.
  - Canonical v4 `type: "file"` tool-result parts now render (including image/file placeholders); schema coercion parses string-delivered objects/arrays via quote-aware Python literals and line-oriented XML children with prototype-key guards.

- Bug Fixes
  - Hermes: salvage `{...}</think>`, orphan `<tool_call>`, array-wrapped calls, double-encoded args, and invalid JSON escapes; removed dead speculative state.
  - Qwen3-Coder: recover `<parameter>name</parameter>value`; boundary-aware tag detection to prevent freezes; linear-time close-tag recovery; salvage payload-only Hermes-style JSON under `<tool_call>` at stream finish; tolerate malformed close tags.
  - YAML/XML: stream text immediately and hold only genuine partial tool-tag prefixes; XML child-tag fallback matches body parsing and tolerates missing closes.
  - Recovery: per-text-block evaluation; stricter holds (recoverable fences/tags or leading `[{` only); accept tool/parameters envelope aliases; unwrap double-encoded args; drop array plumbing; prototype-key text guard tightened to avoid false positives.

<sup>Written for commit 892ddac060c70bec31e3b2142a33b230060153dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

