### PR TITLE
chore: force patched js-yaml via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,9 @@
     "overrides": {
       "esbuild": "^0.28.1",
       "vite": "^8.1.3",
-      "shell-quote": "^1.8.4"
+      "shell-quote": "^1.8.4",
+      "js-yaml@3": "^3.15.0",
+      "js-yaml@4": "^4.2.0"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   esbuild: ^0.28.1
   vite: ^8.1.3
   shell-quote: ^1.8.4
+  js-yaml@3: ^3.15.0
+  js-yaml@4: ^4.2.0
 
 importers:
 
@@ -1575,12 +1577,12 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -2671,7 +2673,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -3966,12 +3968,12 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -4326,7 +4328,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 


### PR DESCRIPTION
Resolves both open moderate Dependabot alerts (JS-YAML quadratic-complexity DoS in merge key handling via repeated aliases):

- `js-yaml@3` (via `@changesets/cli` → `read-yaml-file`): 3.14.2 → **3.15.0**
- `js-yaml@4` (via `eslint`): 4.1.1 → **4.3.0**

Both are dev-only transitive dependencies. Verified locally: `pnpm check` clean, 4,185 tests pass, and `changeset status` still parses YAML correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force patched `js-yaml` via `pnpm` overrides to address quadratic-complexity DoS alerts in transitive dev deps. Verified `pnpm check` is clean and tests pass; no runtime impact.

- **Dependencies**
  - Override `js-yaml` v3 to ^3.15.0 (via `@changesets/cli` → `read-yaml-file`; resolves to 3.15.0).
  - Override `js-yaml` v4 to ^4.2.0 (via `eslint`; resolves to 4.3.0).

<sup>Written for commit f978aeeb85378c4ebea2ee5d3d7085cc3a81ea84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

