### PR TITLE
chore: adopt ultracite 7.9.0 lint rules that fit the codebase

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -4,11 +4,11 @@
   "files": {
     "includes": ["!!.changeset", "!!**/.claude", "!!**/.demo-output"]
   },
-  // The rules newly enabled by ultracite 7.9.0 are switched off below to keep
-  // the existing code style; adopt them incrementally in dedicated PRs.
   "assist": {
     "actions": {
       "source": {
+        // Off: object-key sorting would reorder literals that tests compare
+        // against JSON.stringify output, and would churn ~3.4k sites.
         "useSortedKeys": "off"
       }
     }
@@ -19,25 +19,22 @@
         "useImportExtensions": "off",
         "noUnresolvedImports": "off"
       },
-      "complexity": {
-        "noDivRegex": "off",
-        "noUselessReturn": "off"
-      },
       "performance": {
+        // Off: stream parsing and chunk-replay tests are inherently
+        // sequential; awaiting in loops is intentional there.
         "noAwaitInLoops": "off"
       },
       "suspicious": {
         "noConsole": "off",
+        // Off: `== null` / `!= null` is the deliberate idiom for
+        // null-or-undefined checks throughout the codebase.
         "noEqualsToNull": "off",
-        "noShadow": "off",
+        // Off: type-driven and flags intentional runtime guards against
+        // malformed LLM output (plus `while (true)` scan loops).
         "noUnnecessaryConditions": "off"
       },
       "style": {
-        "noIncrementDecrement": "off",
-        "noMagicNumbers": "off",
-        "useConsistentMethodSignatures": "off",
-        "useDestructuring": "off",
-        "useErrorCause": "off"
+        "noMagicNumbers": "off"
       }
     }
   }

--- a/examples/parser-core/src/94-extended-matrix.local.ts
+++ b/examples/parser-core/src/94-extended-matrix.local.ts
@@ -316,7 +316,7 @@ const scenarios: Scenario[] = [
         providerOptions: collectOnError(parserErrors),
         abortSignal: AbortSignal.timeout(TIMEOUT),
       });
-      const call = result.toolCalls.find((c) => c.toolName === "write_file");
+      const call = result.toolCalls.find((tc) => tc.toolName === "write_file");
       if (!call) {
         throw new Error(
           `no write_file call; text=${JSON.stringify(result.text.slice(0, 200))}`

--- a/examples/parser-core/src/console-output.ts
+++ b/examples/parser-core/src/console-output.ts
@@ -110,7 +110,7 @@ const unwrapToolOutput = (output: unknown): unknown => {
     return output;
   }
   const typed = output as Record<string, unknown>;
-  const type = typed.type;
+  const { type } = typed;
   switch (type) {
     case "text":
       return typed.value ?? "";

--- a/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
+++ b/src/__tests__/core/utils/generated-text-json-recovery.unit.test.ts
@@ -437,7 +437,7 @@ describe("recoverToolCallFromJsonCandidates namespaced close tags", () => {
 
 describe("function key alias", () => {
   it("recovers a bare JSON payload using function/parameters keys", () => {
-    const tools: LanguageModelV4FunctionTool[] = [
+    const aliasTools: LanguageModelV4FunctionTool[] = [
       {
         type: "function" as const,
         name: "create_shipment",
@@ -451,7 +451,7 @@ describe("function key alias", () => {
     ];
     const out = recoverToolCallFromJsonCandidates(
       '{\n  "function": "create_shipment",\n  "parameters": { "zip": "01234" }\n}',
-      tools
+      aliasTools
     );
     const call = out?.find((part) => part.type === "tool-call");
     if (call?.type !== "tool-call") {

--- a/src/__tests__/entry/community-prompt-templates.test.ts
+++ b/src/__tests__/entry/community-prompt-templates.test.ts
@@ -71,7 +71,7 @@ describe("community middleware prompt templates", () => {
       params: { prompt: [], tools },
     });
 
-    const system = out.prompt[0];
+    const [system] = out.prompt;
     expect(system?.role).toBe("system");
     const text = String(system?.content ?? "");
     expect(text).toContain("# Input Examples");
@@ -112,7 +112,7 @@ describe("community middleware prompt templates", () => {
       params: { prompt: [], tools },
     });
 
-    const system = out.prompt[0];
+    const [system] = out.prompt;
     expect(system?.role).toBe("system");
     const text = String(system?.content ?? "");
     expect(text).toContain("# Input Examples");
@@ -153,7 +153,7 @@ describe("community middleware prompt templates", () => {
       params: { prompt: [], tools },
     });
 
-    const system = out.prompt[0];
+    const [system] = out.prompt;
     expect(system?.role).toBe("system");
     const text = String(system?.content ?? "");
     expect(text).toContain("# Input Examples");
@@ -194,7 +194,7 @@ describe("community middleware prompt templates", () => {
       params: { prompt: [], tools },
     });
 
-    const system = out.prompt[0];
+    const [system] = out.prompt;
     expect(system?.role).toBe("system");
     const text = String(system?.content ?? "");
     expect(text).toContain("# Input Examples");

--- a/src/__tests__/entry/preconfigured-prompt-templates.test.ts
+++ b/src/__tests__/entry/preconfigured-prompt-templates.test.ts
@@ -27,7 +27,7 @@ describe("preconfigured middleware prompt templates", () => {
       params: { prompt: [], tools },
     } as any);
 
-    const system = out.prompt[0];
+    const [system] = out.prompt;
     expect(system.role).toBe("system");
     const text = String(system.content);
     expect(text).toMatch(REGEX_FUNCTION_CALLING_MODEL);
@@ -41,7 +41,7 @@ describe("preconfigured middleware prompt templates", () => {
       params: { prompt: [], tools },
     } as any);
 
-    const system = out.prompt[0];
+    const [system] = out.prompt;
     expect(system.role).toBe("system");
     const text = String(system.content);
     expect(text).toMatch(REGEX_MAY_CALL_FUNCTIONS);

--- a/src/__tests__/fixtures/dummy-protocol.ts
+++ b/src/__tests__/fixtures/dummy-protocol.ts
@@ -7,7 +7,7 @@ function handleTextDelta(
   controller: TransformStreamDefaultController<LanguageModelV4StreamPart>,
   state: { currentTextId: string | null; hasEmittedText: boolean }
 ): void {
-  const delta = chunk.delta;
+  const { delta } = chunk;
   if (delta !== undefined && delta !== "") {
     if (!state.currentTextId) {
       state.currentTextId = generateId();

--- a/src/__tests__/protocols/cross-protocol/tool-input/delta-compare.example-output.test.ts
+++ b/src/__tests__/protocols/cross-protocol/tool-input/delta-compare.example-output.test.ts
@@ -9,10 +9,10 @@ import { morphXmlProtocol } from "../../../../core/protocols/morph-xml-protocol"
 import { yamlXmlProtocol } from "../../../../core/protocols/yaml-xml-protocol";
 
 const XML_CURRENT_VIEW_OBJECT_DELTA_RE =
-  /=== XML protocol ===[\s\S]*Current view: parsed-object streaming tool input[\s\S]*tool-input-delta\(id=[^,]+, delta="\{"location":"Seoul","unit":"celsius"/;
+  /[=]== XML protocol ===[\s\S]*Current view: parsed-object streaming tool input[\s\S]*tool-input-delta\(id=[^,]+, delta="\{"location":"Seoul","unit":"celsius"/;
 
 const YAML_CURRENT_VIEW_OBJECT_DELTA_RE =
-  /=== YAML protocol ===[\s\S]*Current view: parsed-object streaming tool input[\s\S]*tool-input-delta\(id=[^,]+, delta="\{"location":"Seoul","unit":"celsius"/;
+  /[=]== YAML protocol ===[\s\S]*Current view: parsed-object streaming tool input[\s\S]*tool-input-delta\(id=[^,]+, delta="\{"location":"Seoul","unit":"celsius"/;
 
 const tool: LanguageModelV4FunctionTool = {
   type: "function",

--- a/src/__tests__/protocols/cross-protocol/tool-input/object-delta.yaml.progressive.test.ts
+++ b/src/__tests__/protocols/cross-protocol/tool-input/object-delta.yaml.progressive.test.ts
@@ -282,16 +282,16 @@ describe("YAML object-delta progressive invariants", () => {
   it("yaml progress incomplete-tail branch suppresses deltas when truncated reparse fails", async () => {
     const parseSpy = vi.spyOn(YAML, "parseDocument");
     let calls = 0;
-    parseSpy.mockImplementation(
-      () =>
-        ({
-          errors:
-            ++calls === 1 || calls === 3
-              ? []
-              : [{ message: "mock reparsing/final parse failure" }],
-          toJSON: () => ({ location: "Seoul", unit: null }),
-        }) as unknown as ReturnType<typeof YAML.parseDocument>
-    );
+    parseSpy.mockImplementation(() => {
+      calls += 1;
+      return {
+        errors:
+          calls === 1 || calls === 3
+            ? []
+            : [{ message: "mock reparsing/final parse failure" }],
+        toJSON: () => ({ location: "Seoul", unit: null }),
+      } as unknown as ReturnType<typeof YAML.parseDocument>;
+    });
 
     try {
       // A schema without properties keeps the schema-keyed raw-string salvage

--- a/src/__tests__/protocols/hermes-protocol/stream/partial-tag.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/partial-tag.test.ts
@@ -15,7 +15,7 @@ function joinTextDeltas(parts: LanguageModelV4StreamPart[]): string {
     if (part.type !== "text-delta") {
       continue;
     }
-    const delta = (part as unknown as { delta?: unknown }).delta;
+    const { delta } = part as unknown as { delta?: unknown };
     if (typeof delta === "string") {
       deltas.push(delta);
     }

--- a/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/core-parsing.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/core-parsing.test.ts
@@ -26,7 +26,7 @@ describe("qwen3CoderProtocol", () => {
     expect(out[0]).toEqual({ type: "text", text: "before " });
     expect(out[2]).toEqual({ type: "text", text: " after" });
 
-    const toolCall = out[1];
+    const [, toolCall] = out;
     if (toolCall.type !== "tool-call") {
       throw new Error("Expected tool-call part");
     }
@@ -58,8 +58,8 @@ describe("qwen3CoderProtocol", () => {
     ]);
     const calls = out.filter((x) => x.type === "tool-call");
     expect(calls).toHaveLength(2);
-    const first = calls[0];
-    const second = calls[1];
+    const [first] = calls;
+    const [, second] = calls;
     if (first?.type !== "tool-call" || second?.type !== "tool-call") {
       throw new Error("Expected tool-call parts");
     }

--- a/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/format-roundtrip.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/format-roundtrip.test.ts
@@ -26,7 +26,7 @@ describe("qwen3CoderProtocol", () => {
     });
     const calls = parsed.filter((x) => x.type === "tool-call");
     expect(calls).toHaveLength(1);
-    const call = calls[0];
+    const [call] = calls;
     if (call?.type !== "tool-call") {
       throw new Error("Expected tool-call part");
     }
@@ -72,7 +72,7 @@ describe("qwen3CoderProtocol", () => {
     });
     const calls = parsed.filter((x) => x.type === "tool-call");
     expect(calls).toHaveLength(1);
-    const call = calls[0];
+    const [call] = calls;
     if (call?.type !== "tool-call") {
       throw new Error("Expected tool-call part");
     }

--- a/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/recovery.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/recovery.test.ts
@@ -47,7 +47,7 @@ describe("qwen3CoderProtocol", () => {
       tools,
     });
 
-    const toolCall = out[0];
+    const [toolCall] = out;
     if (toolCall?.type !== "tool-call") {
       throw new Error("Expected tool-call part");
     }
@@ -68,7 +68,7 @@ describe("qwen3CoderProtocol", () => {
     const out = p.parseGeneratedText({ text, tools });
     const calls = out.filter((x) => x.type === "tool-call");
     expect(calls).toHaveLength(1);
-    const call = calls[0];
+    const [call] = calls;
     if (call?.type !== "tool-call") {
       throw new Error("Expected tool-call part");
     }
@@ -146,7 +146,7 @@ describe("qwen3CoderProtocol", () => {
     const out = p.parseGeneratedText({ text, tools });
     const calls = out.filter((part) => part.type === "tool-call");
     expect(calls).toHaveLength(1);
-    const call = calls[0];
+    const [call] = calls;
     if (call?.type !== "tool-call") {
       throw new Error("Expected tool-call part");
     }
@@ -179,7 +179,7 @@ describe("qwen3CoderProtocol", () => {
     const out = p.parseGeneratedText({ text, tools });
     const calls = out.filter((x) => x.type === "tool-call");
     expect(calls).toHaveLength(1);
-    const call = calls[0];
+    const [call] = calls;
     if (call?.type !== "tool-call") {
       throw new Error("Expected tool-call part");
     }
@@ -197,7 +197,7 @@ describe("qwen3CoderProtocol", () => {
     expect(out[0]).toEqual({ type: "text", text: "before " });
     expect(out[2]).toEqual({ type: "text", text: " after" });
 
-    const call = out[1];
+    const [, call] = out;
     if (call.type !== "tool-call") {
       throw new Error("Expected tool-call part");
     }

--- a/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/wrapperless.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/parse-generated-text/wrapperless.test.ts
@@ -12,7 +12,7 @@ describe("qwen3CoderProtocol", () => {
     const out = p.parseGeneratedText({ text, tools });
     const calls = out.filter((part) => part.type === "tool-call");
     expect(calls).toHaveLength(1);
-    const call = calls[0];
+    const [call] = calls;
     if (call?.type !== "tool-call") {
       throw new Error("Expected tool-call part");
     }
@@ -21,7 +21,7 @@ describe("qwen3CoderProtocol", () => {
 
     const texts = out.filter((part) => part.type === "text");
     expect(texts).toHaveLength(1);
-    const textPart = texts[0];
+    const [textPart] = texts;
     if (textPart?.type !== "text") {
       throw new Error("Expected text part");
     }
@@ -41,7 +41,7 @@ describe("qwen3CoderProtocol", () => {
     expect(out[0]).toEqual({ type: "text", text: "before " });
     expect(out[2]).toEqual({ type: "text", text: " after" });
 
-    const call = out[1];
+    const [, call] = out;
     if (call.type !== "tool-call") {
       throw new Error("Expected tool-call part");
     }
@@ -70,8 +70,8 @@ describe("qwen3CoderProtocol", () => {
 
     const calls = out.filter((part) => part.type === "tool-call");
     expect(calls).toHaveLength(2);
-    const first = calls[0];
-    const second = calls[1];
+    const [first] = calls;
+    const [, second] = calls;
     if (first?.type !== "tool-call" || second?.type !== "tool-call") {
       throw new Error("Expected tool-call parts");
     }
@@ -90,7 +90,7 @@ describe("qwen3CoderProtocol", () => {
     const out = p.parseGeneratedText({ text, tools });
     const calls = out.filter((part) => part.type === "tool-call");
     expect(calls).toHaveLength(1);
-    const call = calls[0];
+    const [call] = calls;
     if (call?.type !== "tool-call") {
       throw new Error("Expected tool-call part");
     }

--- a/src/__tests__/protocols/yaml-xml-protocol/parse-generated-text/onerror-metadata.test.ts
+++ b/src/__tests__/protocols/yaml-xml-protocol/parse-generated-text/onerror-metadata.test.ts
@@ -44,7 +44,7 @@ describe("yamlXmlProtocol parseGeneratedText onError metadata", () => {
       toolName: "get_weather",
       dropReason: "malformed-tool-call-body",
     });
-    const cause = (metadata as { cause?: { kind?: string } }).cause;
+    const { cause } = metadata as { cause?: { kind?: string } };
     expect(cause).toMatchObject({ kind: "yaml-parse-error" });
     expect(typeof metadata?.toolCallId).toBe("string");
     expect((metadata?.toolCallId as string).length).toBeGreaterThan(0);
@@ -67,7 +67,7 @@ describe("yamlXmlProtocol parseGeneratedText onError metadata", () => {
       toolName: "get_weather",
       dropReason: "malformed-tool-call-body",
     });
-    const cause = (metadata as { cause?: { kind?: string } }).cause;
+    const { cause } = metadata as { cause?: { kind?: string } };
     expect(cause).toMatchObject({ kind: "yaml-non-mapping" });
     expect(typeof metadata?.toolCallId).toBe("string");
     expect((metadata?.toolCallId as string).length).toBeGreaterThan(0);

--- a/src/__tests__/rxml/core/parser.unit.test.ts
+++ b/src/__tests__/rxml/core/parser.unit.test.ts
@@ -441,7 +441,7 @@ describe("robust-xml parser", () => {
       );
       const simplified = simplify(parsed);
       if (isRecord(simplified) && isRecord(simplified.test)) {
-        const cc = (simplified.test as Record<string, unknown>).cc;
+        const { cc } = simplified.test as Record<string, unknown>;
         expect(cc).toEqual(["one", "two"]);
       } else {
         expect.fail("simplified result was not an object with 'test'");

--- a/src/__tests__/rxml/heuristics/engine.unit.test.ts
+++ b/src/__tests__/rxml/heuristics/engine.unit.test.ts
@@ -121,8 +121,8 @@ describe("heuristic-engine", () => {
         id: "normalize",
         phase: "pre-parse",
         applies: () => true,
-        run: (ctx) => ({
-          rawSegment: ctx.rawSegment.replace("BAD", "GOOD"),
+        run: (call) => ({
+          rawSegment: call.rawSegment.replace("BAD", "GOOD"),
         }),
       };
 
@@ -139,8 +139,8 @@ describe("heuristic-engine", () => {
         id: "fix-xml",
         phase: "fallback-reparse",
         applies: () => true,
-        run: (ctx) => ({
-          rawSegment: ctx.rawSegment.replace("invalid", "valid"),
+        run: (call) => ({
+          rawSegment: call.rawSegment.replace("invalid", "valid"),
           reparse: true,
         }),
       };
@@ -161,9 +161,9 @@ describe("heuristic-engine", () => {
       const postParseHeuristic: ToolCallHeuristic = {
         id: "transform",
         phase: "post-parse",
-        applies: (ctx) => ctx.parsed !== null,
-        run: (ctx) => ({
-          parsed: { ...(ctx.parsed as object), transformed: true },
+        applies: (call) => call.parsed !== null,
+        run: (call) => ({
+          parsed: { ...(call.parsed as object), transformed: true },
         }),
       };
 
@@ -244,7 +244,7 @@ describe("heuristic-engine", () => {
         phase: "fallback-reparse",
         applies: () => true,
         run: () => {
-          reparseCount++;
+          reparseCount += 1;
           return { rawSegment: "<still>invalid</still>", reparse: true };
         },
       };

--- a/src/__tests__/rxml/integration/end-to-end.performance.integration.test.ts
+++ b/src/__tests__/rxml/integration/end-to-end.performance.integration.test.ts
@@ -32,9 +32,9 @@ describe("robust-xml integration", () => {
       if (process.env.VITEST_PERF_CHECK === "1") {
         expect(durationMs).toBeLessThan(1000);
       }
-      const data = (
-        result as unknown as { data: Array<{ value: number; active: boolean }> }
-      ).data;
+      const { data } = result as unknown as {
+        data: Array<{ value: number; active: boolean }>;
+      };
       expect(data).toHaveLength(100);
       expect(typeof data[0].value).toBe("number");
       expect(typeof data[0].active).toBe("boolean");

--- a/src/__tests__/tool-call-middleware/create.transform-params.positive-paths.test.ts
+++ b/src/__tests__/tool-call-middleware/create.transform-params.positive-paths.test.ts
@@ -54,7 +54,7 @@ describe("createToolMiddleware transformParams positive paths", () => {
     expect(out.prompt[0].role).toBe("system");
     expect(String(out.prompt[0].content)).toContain("SYS:");
     // merged two user messages
-    const mergedUser = out.prompt[1];
+    const [, mergedUser] = out.prompt;
     expect(mergedUser.role).toBe("user");
     const text = (mergedUser.content as any[])
       .filter((c) => c.type === "text")

--- a/src/__tests__/tool-call-middleware/create.wrap-stream.protocol-compliance.integration.test.ts
+++ b/src/__tests__/tool-call-middleware/create.wrap-stream.protocol-compliance.integration.test.ts
@@ -41,7 +41,7 @@ describe("createToolMiddleware wrapStream protocol compliance integration", () =
     const MINIMUM_EXPECTED_CHUNKS = 3;
     expect(chunks.length).toBeGreaterThanOrEqual(MINIMUM_EXPECTED_CHUNKS);
     expect(chunks[0].type).toBe("text-start");
-    const id = (chunks[0] as any).id;
+    const { id } = chunks[0] as any;
     expect(chunks[1]).toEqual({ type: "text-delta", id, delta: "Hello world" });
     expect(chunks[2]).toEqual({ type: "text-end", id });
   });

--- a/src/__tests__/transform-handler/prompt-template.placement-last-behavior.test.ts
+++ b/src/__tests__/transform-handler/prompt-template.placement-last-behavior.test.ts
@@ -100,7 +100,7 @@ describe("placement last behaviour (default)", () => {
     } as any);
     const systems = out.prompt.filter((m: any) => m.role === "system");
     expect(systems).toHaveLength(1);
-    const system = systems[0];
+    const [system] = systems;
     const text = String(system.content);
     expect(text.startsWith("BASE")).toBe(true);
     expect(text).toContain("SYS:");

--- a/src/__tests__/transform-handler/prompt-template.transform-params-convert-tool-prompt-mapping.test.ts
+++ b/src/__tests__/transform-handler/prompt-template.transform-params-convert-tool-prompt-mapping.test.ts
@@ -108,8 +108,7 @@ describe("transformParams convertToolPrompt mapping and merge", () => {
 
     // tools cleared; originalTools propagated into providerOptions
     expect(out.tools).toEqual([]);
-    const originalTools = (out.providerOptions as any).toolCallMiddleware
-      .originalTools;
+    const { originalTools } = (out.providerOptions as any).toolCallMiddleware;
     expect(originalTools).toEqual([
       {
         name: "t1",

--- a/src/core/prompts/hermes-prompt.ts
+++ b/src/core/prompts/hermes-prompt.ts
@@ -42,7 +42,7 @@ export function formatToolResponseAsHermes(toolResult: ToolResultPart): string {
 export function jsonSchemaToPythonType(
   schema: Record<string, unknown>
 ): string {
-  const type = schema.type;
+  const { type } = schema;
 
   if (type === "string") {
     return "str";

--- a/src/core/prompts/qwen3coder-prompt.ts
+++ b/src/core/prompts/qwen3coder-prompt.ts
@@ -151,7 +151,7 @@ function renderTool(tool: Qwen3CoderToolShape): string {
 
   out += "\n<parameters>";
 
-  const parameters = tool.parameters;
+  const { parameters } = tool;
   if (isMapping(parameters) && isMapping((parameters as Mapping).properties)) {
     for (const [paramName, paramFieldsRaw] of Object.entries(
       (parameters as Mapping).properties as Mapping

--- a/src/core/prompts/shared/input-examples.ts
+++ b/src/core/prompts/shared/input-examples.ts
@@ -7,11 +7,9 @@ interface ToolInputExample {
 function getToolInputExamples(
   tool: LanguageModelV4FunctionTool
 ): ToolInputExample[] {
-  const inputExamples = (
-    tool as LanguageModelV4FunctionTool & {
-      inputExamples?: Array<{ input: unknown }>;
-    }
-  ).inputExamples;
+  const { inputExamples } = tool as LanguageModelV4FunctionTool & {
+    inputExamples?: Array<{ input: unknown }>;
+  };
 
   if (!Array.isArray(inputExamples)) {
     return [];

--- a/src/core/prompts/shared/tool-result-normalizer.ts
+++ b/src/core/prompts/shared/tool-result-normalizer.ts
@@ -200,7 +200,7 @@ function formatContentPartPlaceholder(part: unknown): string {
     case "image-url":
       return `[Image URL: ${(contentPart as { url?: string }).url}]`;
     case "image-file-id": {
-      const fileId = (contentPart as { fileId?: unknown }).fileId;
+      const { fileId } = contentPart as { fileId?: unknown };
       return formatIdPlaceholder("Image ID", fileId);
     }
     case "file-data": {
@@ -216,7 +216,7 @@ function formatContentPartPlaceholder(part: unknown): string {
     case "file-url":
       return `[File URL: ${(contentPart as { url?: string }).url}]`;
     case "file-id": {
-      const fileId = (contentPart as { fileId?: unknown }).fileId;
+      const { fileId } = contentPart as { fileId?: unknown };
       return formatIdPlaceholder("File ID", fileId);
     }
     case "media":
@@ -327,7 +327,7 @@ export function unwrapToolResult(
     case "json":
       return result.value;
     case "execution-denied": {
-      const reason = result.reason;
+      const { reason } = result;
       return reason ? `[Execution Denied: ${reason}]` : "[Execution Denied]";
     }
     case "error-text":
@@ -358,11 +358,9 @@ export function normalizeToolResultForUserContent(
   }
 
   const unwrapped = unwrapToolResult(result, mediaStrategy);
-  const providerOptions = (
-    result as {
-      providerOptions?: LanguageModelV4TextPart["providerOptions"];
-    }
-  ).providerOptions;
+  const { providerOptions } = result as {
+    providerOptions?: LanguageModelV4TextPart["providerOptions"];
+  };
 
   return [toTextPart(stringifyJsonValue(unwrapped), providerOptions)];
 }

--- a/src/core/protocols/hermes-argument-schema.ts
+++ b/src/core/protocols/hermes-argument-schema.ts
@@ -191,7 +191,7 @@ function getPropertySchema(
   schema: Record<string, unknown>,
   key: string
 ): unknown | undefined {
-  const properties = schema.properties;
+  const { properties } = schema;
   if (!(isRecord(properties) && Object.hasOwn(properties, key))) {
     return;
   }

--- a/src/core/protocols/hermes-call-parsing.ts
+++ b/src/core/protocols/hermes-call-parsing.ts
@@ -1417,7 +1417,7 @@ function getTopLevelPositionMap(argsBody: string): Uint8Array {
   let inStr = false;
   let esc = false;
   topLevelAtPosition[0] = 1;
-  for (let i = 0; i < argsBody.length; i++) {
+  for (let i = 0; i < argsBody.length; i += 1) {
     const ch = argsBody[i];
     if (esc) {
       esc = false;
@@ -1427,10 +1427,10 @@ function getTopLevelPositionMap(argsBody: string): Uint8Array {
       inStr = !inStr;
     } else if (!inStr) {
       if (ch === "{" || ch === "[") {
-        depth++;
+        depth += 1;
       }
       if (ch === "}" || ch === "]") {
-        depth--;
+        depth -= 1;
       }
     }
     topLevelAtPosition[i + 1] = depth === 0 ? 1 : 0;
@@ -1533,7 +1533,7 @@ function findRepairArgumentsBody(raw: string): string | null {
     return null;
   }
   let outerClose = -1;
-  for (let i = raw.length - 1; i >= argsStart; i--) {
+  for (let i = raw.length - 1; i >= argsStart; i -= 1) {
     if (raw.charAt(i) === "}") {
       outerClose = i;
       break;
@@ -1547,7 +1547,7 @@ function findRepairArgumentsBody(raw: string): string | null {
   }
 
   let argsClose = -1;
-  for (let j = outerClose - 1; j >= argsStart; j--) {
+  for (let j = outerClose - 1; j >= argsStart; j -= 1) {
     if (raw.charAt(j) === "}") {
       argsClose = j;
       break;
@@ -1666,7 +1666,7 @@ function parsePossiblyMalformedJsonString(value: string): unknown | undefined {
   try {
     return JSON.parse(`"${escaped}"`);
   } catch {
-    return;
+    // swallow parse failures and return undefined
   }
 }
 
@@ -2304,8 +2304,6 @@ function extractTopLevelStringProperty(
     }
     valueEnd += 1;
   }
-
-  return;
 }
 
 function extractStrictTopLevelStringProperty(
@@ -2333,8 +2331,6 @@ function extractStrictTopLevelStringProperty(
     }
     valueEnd += 1;
   }
-
-  return;
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Streaming JSON value slicing must handle nested arrays/objects and escaped strings.

--- a/src/core/protocols/hermes-unsafe-pattern.ts
+++ b/src/core/protocols/hermes-unsafe-pattern.ts
@@ -154,7 +154,7 @@ function addCharacterClassHints(
     const char = pattern.charAt(index);
     if (escaped) {
       const result = consumeEscapedClassHint(pattern, index, hints, previous);
-      previous = result.previous;
+      ({ previous } = result);
       index = result.nextIndex;
       escaped = false;
       continue;
@@ -233,7 +233,7 @@ function collectPatternCharacterHints(pattern: string): PatternCharacterHints {
         hints,
         literalRun
       );
-      literalRun = result.literalRun;
+      ({ literalRun } = result);
       index = result.nextIndex;
       escaped = false;
       continue;

--- a/src/core/protocols/morph-xml-protocol.ts
+++ b/src/core/protocols/morph-xml-protocol.ts
@@ -450,7 +450,7 @@ function getRequiredMessageStringProperty(schema: unknown): string | null {
   }
 
   const schemaRecord = schema as Record<string, unknown>;
-  const required = schemaRecord.required;
+  const { required } = schemaRecord;
   if (
     !(
       Array.isArray(required) &&
@@ -471,7 +471,7 @@ function getOptionalMessageStringProperty(schema: unknown): string | null {
   }
 
   const schemaRecord = schema as Record<string, unknown>;
-  const required = schemaRecord.required;
+  const { required } = schemaRecord;
   if (Array.isArray(required) && required.length > 0) {
     return null;
   }
@@ -602,7 +602,7 @@ function findTrailingUnclosedStringTag(options: {
 
     let lastOpen = -1;
     for (const match of options.toolContent.matchAll(openPattern)) {
-      const index = match.index;
+      const { index } = match;
       if (index !== undefined) {
         lastOpen = index;
       }
@@ -614,7 +614,7 @@ function findTrailingUnclosedStringTag(options: {
 
     let lastClose = -1;
     for (const match of options.toolContent.matchAll(closePattern)) {
-      const index = match.index;
+      const { index } = match;
       if (index !== undefined) {
         lastClose = index;
       }
@@ -638,7 +638,7 @@ function getSchemaObjectProperty(
   }
 
   const schemaObject = schema as Record<string, unknown>;
-  const properties = schemaObject.properties;
+  const { properties } = schemaObject;
   if (!properties || typeof properties !== "object") {
     return null;
   }
@@ -688,7 +688,7 @@ function isStableXmlProgressCandidate(options: {
   }
 
   if (structure.topLevelTagNames.length === 1) {
-    const onlyTopLevelTag = structure.topLevelTagNames[0];
+    const [onlyTopLevelTag] = structure.topLevelTagNames;
     if (
       !schemaProperties ||
       schemaProperties.size === 0 ||
@@ -869,7 +869,7 @@ function findClosingTagEndFlexible(
       break;
     }
     const result = updateDepthWithToken(tok, toolName, depth);
-    depth = result.depth;
+    ({ depth } = result);
     if (result.closedAt !== undefined) {
       return result.closedAt;
     }
@@ -1203,9 +1203,9 @@ function findLinePrefixedXmlBodyEnd(
       result = handleCloseToken(token, depth);
     }
 
-    depth = result.depth;
+    ({ depth } = result);
     if (result.lastCompleteEnd !== -1) {
-      lastCompleteEnd = result.lastCompleteEnd;
+      ({ lastCompleteEnd } = result);
     }
     if (result.shouldBreak) {
       break;

--- a/src/core/protocols/protocol-interface.ts
+++ b/src/core/protocols/protocol-interface.ts
@@ -19,13 +19,13 @@ export interface ParserOptions {
 }
 
 export interface TCMProtocol {
-  createStreamParser({
+  createStreamParser: ({
     tools,
     options,
   }: {
     tools: LanguageModelV4FunctionTool[];
     options?: ParserOptions;
-  }): TransformStream<LanguageModelV4StreamPart, LanguageModelV4StreamPart>;
+  }) => TransformStream<LanguageModelV4StreamPart, LanguageModelV4StreamPart>;
 
   extractToolCallSegments?: ({
     text,
@@ -35,16 +35,16 @@ export interface TCMProtocol {
     tools: LanguageModelV4FunctionTool[];
   }) => string[];
 
-  formatToolCall(toolCall: LanguageModelV4ToolCall): string;
-  formatTools({
+  formatToolCall: (toolCall: LanguageModelV4ToolCall) => string;
+  formatTools: ({
     tools,
     toolSystemPromptTemplate,
   }: {
     tools: LanguageModelV4FunctionTool[];
     toolSystemPromptTemplate: (tools: LanguageModelV4FunctionTool[]) => string;
-  }): string;
+  }) => string;
 
-  parseGeneratedText({
+  parseGeneratedText: ({
     text,
     tools,
     options,
@@ -52,7 +52,7 @@ export interface TCMProtocol {
     text: string;
     tools: LanguageModelV4FunctionTool[];
     options?: ParserOptions;
-  }): LanguageModelV4Content[];
+  }) => LanguageModelV4Content[];
 }
 
 export type TCMCoreProtocol = TCMProtocol;

--- a/src/core/protocols/qwen3coder-call-parsing.ts
+++ b/src/core/protocols/qwen3coder-call-parsing.ts
@@ -280,7 +280,7 @@ export function sanitizePartialParamValueForProgress(
   if (!partial) {
     return null;
   }
-  let value = partial.value;
+  let { value } = partial;
   const cut = trailingPotentialTagStartIndex(value.toLowerCase(), [
     ...QWEN3CODER_PROGRESS_HOLDBACK_TAG_PREFIXES,
     ...extraHoldbackTags,
@@ -858,7 +858,7 @@ export function parseQwen3CoderToolParserParamTagAt(
     return { kind: "partial", start: startIndex, openEnd: null };
   }
 
-  const tagNameLower = tagNameParse.tagNameLower;
+  const { tagNameLower } = tagNameParse;
 
   const openEnd = findTagEndIndex(text, startIndex);
   if (openEnd == null) {
@@ -1147,7 +1147,7 @@ function extractToolCallInnerXml(segment: string): {
   }
 
   const openIndex = openMatch.index;
-  const openTag = openMatch[0];
+  const [openTag] = openMatch;
   const openEnd = openIndex + openTag.length;
 
   // Prefer the last closing tag to avoid early matches if nested content

--- a/src/core/protocols/qwen3coder-protocol.ts
+++ b/src/core/protocols/qwen3coder-protocol.ts
@@ -380,7 +380,7 @@ export const qwen3CoderProtocol = (): TCMProtocol => ({
     ): boolean => {
       let index = 0;
       for (const match of matches) {
-        const full = match[0];
+        const [full] = match;
         const startIndex = match.index ?? -1;
         if (!full || startIndex < 0) {
           continue;
@@ -479,7 +479,7 @@ export const qwen3CoderProtocol = (): TCMProtocol => ({
 
       let index = 0;
       for (const match of matches) {
-        const full = match[0];
+        const [full] = match;
         const startIndex = match.index ?? -1;
         if (!full || startIndex < 0) {
           continue;
@@ -637,7 +637,7 @@ export const qwen3CoderProtocol = (): TCMProtocol => ({
       if (callState.hasEmittedStart) {
         return;
       }
-      const toolName = callState.toolName;
+      const { toolName } = callState;
       if (!toolName || toolName.trim().length === 0) {
         return;
       }
@@ -657,7 +657,7 @@ export const qwen3CoderProtocol = (): TCMProtocol => ({
       if (!callState.hasEmittedStart) {
         return;
       }
-      const toolName = callState.toolName;
+      const { toolName } = callState;
       if (!toolName) {
         return;
       }
@@ -1653,7 +1653,7 @@ export const qwen3CoderProtocol = (): TCMProtocol => ({
         handlePassthroughChunk(controller, chunk);
         return;
       }
-      const delta = chunk.delta;
+      const { delta } = chunk;
       if (!delta) {
         return;
       }

--- a/src/core/protocols/yaml-xml-protocol.ts
+++ b/src/core/protocols/yaml-xml-protocol.ts
@@ -308,16 +308,16 @@ function findClosingTagEnd(
 
       let p = ltIdx + 2;
       while (p < gtIdx && WHITESPACE_REGEX.test(text[p])) {
-        p++;
+        p += 1;
       }
       const nameStart = p;
       while (p < gtIdx && NAME_CHAR_RE.test(text.charAt(p))) {
-        p++;
+        p += 1;
       }
       const name = text.slice(nameStart, p);
 
       if (name === toolName) {
-        depth--;
+        depth -= 1;
         if (depth === 0) {
           return gtIdx + 1;
         }
@@ -329,11 +329,11 @@ function findClosingTagEnd(
     } else {
       let p = ltIdx + 1;
       while (p < text.length && WHITESPACE_REGEX.test(text[p])) {
-        p++;
+        p += 1;
       }
       const nameStart = p;
       while (p < text.length && NAME_CHAR_RE.test(text.charAt(p))) {
-        p++;
+        p += 1;
       }
       const name = text.slice(nameStart, p);
 
@@ -344,12 +344,12 @@ function findClosingTagEnd(
 
       let r = gtIdx - 1;
       while (r >= nameStart && WHITESPACE_REGEX.test(text[r])) {
-        r--;
+        r -= 1;
       }
       const selfClosing = text[r] === "/";
 
       if (name === toolName && !selfClosing) {
-        depth++;
+        depth += 1;
       }
       pos = gtIdx + 1;
     }
@@ -382,8 +382,8 @@ function collectToolCallsForName(
       break;
     }
 
-    const tagStart = match.tagStart;
-    const isSelfClosing = match.isSelfClosing;
+    const { tagStart } = match;
+    const { isSelfClosing } = match;
 
     if (isSelfClosing) {
       const endIndex = tagStart + match.tagLength;
@@ -501,7 +501,7 @@ function parseXmlChildrenAsArgs(
     if (!match) {
       return null;
     }
-    const key = match[1];
+    const [, key] = match;
     if (PROTOTYPE_SENSITIVE_PARAM_KEYS.has(key)) {
       return null;
     }
@@ -570,7 +570,7 @@ function parseSchemaKeyedRawStrings(
     const match = SCHEMA_KEYED_LINE_RE.exec(line);
     if (match?.[1] && schemaPropNames.has(match[1])) {
       flush();
-      currentKey = match[1];
+      [, currentKey] = match;
       currentLines = match[2] ? [match[2]] : [];
       matchedKeys += 1;
     } else if (currentKey !== null) {

--- a/src/core/utils/debug.ts
+++ b/src/core/utils/debug.ts
@@ -10,7 +10,6 @@ function normalizeBooleanString(value: string): boolean | undefined {
   if (normalized === "0" || normalized === "false" || normalized === "no") {
     return false;
   }
-  return;
 }
 
 export function getDebugLevel(): DebugLevel {

--- a/src/core/utils/finish-reason.ts
+++ b/src/core/utils/finish-reason.ts
@@ -19,7 +19,7 @@ export function normalizeToolCallsFinishReason(
     "raw" in finishReason &&
     typeof (finishReason as { raw?: unknown }).raw === "string"
   ) {
-    raw = (finishReason as { raw: string }).raw;
+    ({ raw } = finishReason as { raw: string });
   } else if (
     finishReason &&
     typeof finishReason === "object" &&
@@ -48,7 +48,7 @@ export function shouldRewriteFinishReasonToToolCalls(
   if (!finishReason || typeof finishReason !== "object") {
     return false;
   }
-  const unified = (finishReason as { unified?: unknown }).unified;
+  const { unified } = finishReason as { unified?: unknown };
   return unified === "stop" || unified === "other";
 }
 
@@ -71,7 +71,7 @@ export function normalizeForcedToolChoiceFinishReason(
     };
   }
   if (finishReason && typeof finishReason === "object") {
-    const unified = (finishReason as { unified?: unknown }).unified;
+    const { unified } = finishReason as { unified?: unknown };
     if (typeof unified === "string" && TERMINAL_FINISH_REASONS.has(unified)) {
       return finishReason as LanguageModelV4FinishReason;
     }

--- a/src/core/utils/generated-text-json-recovery.ts
+++ b/src/core/utils/generated-text-json-recovery.ts
@@ -93,7 +93,7 @@ function parseJsonCandidate(candidateText: string): unknown {
   try {
     return parseRJSON(candidateText);
   } catch {
-    return;
+    // swallow parse failures and return undefined
   }
 }
 
@@ -355,7 +355,7 @@ function isLikelyArgumentsShapeForTool(
     return false;
   }
 
-  const properties = unwrapped.properties;
+  const { properties } = unwrapped;
   if (!isRecord(properties)) {
     return false;
   }
@@ -405,7 +405,7 @@ function parseAsArgumentsOnly(
     return null;
   }
 
-  const tool = tools[0];
+  const [tool] = tools;
   if (
     !isLikelyArgumentsShapeForTool(payload, tool) ||
     containsPrototypeSensitiveKey(payload)
@@ -525,7 +525,7 @@ function findQwenCallCloseTag(
   let match = tagRegex.exec(body);
   while (match) {
     const tag = match[0] ?? "";
-    const parameterTagName = match[2];
+    const [, , parameterTagName] = match;
     if (parameterTagName) {
       const isClosingTag = (match[1] ?? "").length > 0;
       if (isClosingTag) {

--- a/src/core/utils/get-potential-start-index.ts
+++ b/src/core/utils/get-potential-start-index.ts
@@ -31,11 +31,11 @@ export function getPotentialStartIndex(
   //    for streaming overlapping patterns (e.g., text "ababa", search "ababax").
   const startAt = Math.max(0, textLength - searchedTextLength + 1);
 
-  for (let i = startAt; i < textLength; i++) {
+  for (let i = startAt; i < textLength; i += 1) {
     let match = true;
     const currentSuffixLength = textLength - i;
 
-    for (let j = 0; j < currentSuffixLength; j++) {
+    for (let j = 0; j < currentSuffixLength; j += 1) {
       if (text[i + j] !== searchedText[j]) {
         match = false;
         break;

--- a/src/core/utils/on-error.ts
+++ b/src/core/utils/on-error.ts
@@ -17,5 +17,4 @@ export function extractOnErrorOption(
       .toolCallMiddleware?.onError;
     return onError ? { onError } : undefined;
   }
-  return;
 }

--- a/src/core/utils/provider-options.ts
+++ b/src/core/utils/provider-options.ts
@@ -156,7 +156,7 @@ export function getToolCallMiddlewareOptions(
     return {};
   }
 
-  const toolCallMiddleware = providerOptions.toolCallMiddleware;
+  const { toolCallMiddleware } = providerOptions;
   if (!isRecord(toolCallMiddleware)) {
     return {};
   }

--- a/src/core/utils/xml-root-repair.ts
+++ b/src/core/utils/xml-root-repair.ts
@@ -15,7 +15,7 @@ export function tryRepairXmlSelfClosingRootWithBody(
     return null;
   }
 
-  const rootTag = match[1];
+  const [, rootTag] = match;
   if (!toolNames.includes(rootTag)) {
     return null;
   }

--- a/src/rjson/index.ts
+++ b/src/rjson/index.ts
@@ -185,14 +185,13 @@ function makeLexer(tokenSpecs: TokenSpec[]): (contents: string) => Token[] {
       const result = some(tokenSpecs, (tokenSpec) => {
         const m = tokenSpec.re.exec(remainingContents); // Try to match the regex at the current position
         if (m) {
-          const raw = m[0]; // The matched raw string
+          const [raw] = m; // The matched raw string
           remainingContents = remainingContents.slice(raw.length); // Consume the matched part from the input
           return {
             raw,
             matched: tokenSpec.f(m), // Process the match using the spec's function
           };
         }
-        return; // No match for this spec
       });
       return result === false ? undefined : result;
     }
@@ -273,7 +272,7 @@ function fStringDouble(m: RegExpExecArray): RawToken {
 // :: tuple string -> rawToken
 function fIdentifier(m: RegExpExecArray): RawToken {
   // Transforms unquoted identifiers into JSON strings
-  const value = m[0];
+  const [value] = m;
   const match =
     '"' +
     value.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + // Escape backslashes and quotes
@@ -400,7 +399,6 @@ function previousNWSToken(tokens: Token[], index: number): number | undefined {
       return currentIndex; // Return index of the non-whitespace token
     }
   }
-  return; // Not found
 }
 
 // Removes trailing commas from arrays and objects in a token stream
@@ -824,7 +822,6 @@ function parseManyInitialElement<T>(
 
   state.pos -= 1;
   opts.elementParser(tokens, state, result);
-  return; // Signal to continue parsing
 }
 
 // Helper to process a token in parseMany loop
@@ -862,7 +859,6 @@ function parseManyProcessToken<T>(params: {
   }
 
   opts.elementParser(tokens, state, result);
-  return; // Continue loop
 }
 
 // Generic function to parse comma-separated elements within enclosing symbols (like objects or arrays)

--- a/src/rxml/builders/stringify.ts
+++ b/src/rxml/builders/stringify.ts
@@ -46,6 +46,7 @@ export function stringify(
 
     return result;
   } catch (error) {
+    // biome-ignore lint/style/useErrorCause: RXML errors carry the original error via their positional cause parameter.
     throw new RXMLStringifyError("Failed to stringify XML", error);
   }
 }

--- a/src/rxml/core/parser.ts
+++ b/src/rxml/core/parser.ts
@@ -172,7 +172,7 @@ function extractPartialXmlResults(
   match = xmlPattern.exec(xmlString);
   while (match !== null) {
     try {
-      const elementXml = match[0];
+      const [elementXml] = match;
       const tokenizer = new XMLTokenizer(elementXml, options);
       const parsed = tokenizer.parseChildren();
       partialResults.push(...parsed);
@@ -449,6 +449,7 @@ export function parse(
     // Extract content from root wrapper
     parsedNodes = rootNode.children;
   } catch (cause) {
+    // biome-ignore lint/style/useErrorCause: RXML errors carry the original error via their positional cause parameter.
     throw new RXMLParseError("Failed to parse XML", cause);
   }
 
@@ -476,7 +477,7 @@ export function parse(
     // Handle duplicates when throwOnDuplicateStringTags is false
     if (propType === "string" && duplicateKeys.has(k) && Array.isArray(v)) {
       // For duplicates, use the first occurrence
-      const firstValue = v[0];
+      const [firstValue] = v;
       if (
         typeof firstValue === "string" &&
         firstValue.startsWith("__RXML_PLACEHOLDER_")
@@ -611,7 +612,7 @@ export function parse(
   let dataToCoerce = args;
   const keys = Object.keys(args);
   if (keys.length === 1) {
-    const rootKey = keys[0];
+    const [rootKey] = keys;
     const rootValue = args[rootKey];
 
     // Check if schema expects the root key
@@ -636,6 +637,7 @@ export function parse(
     >;
     return decoded;
   } catch (error) {
+    // biome-ignore lint/style/useErrorCause: RXML errors carry the original error via their positional cause parameter.
     throw new RXMLCoercionError("Failed to coerce by schema", error);
   }
 }
@@ -654,6 +656,7 @@ export function parseWithoutSchema(
     // Check if this is a specific type of error that should be re-thrown
     if (shouldRethrowParseError(error, xmlString)) {
       // Preserve the original error message and line/column information
+      // biome-ignore lint/style/useErrorCause: RXML errors carry the original error via their positional cause parameter.
       throw new RXMLParseError(
         error.message,
         error.cause,
@@ -693,6 +696,7 @@ export function parseNode(
     const tokenizer = new XMLTokenizer(xmlString, options);
     return tokenizer.parseNode();
   } catch (error) {
+    // biome-ignore lint/style/useErrorCause: RXML errors carry the original error via their positional cause parameter.
     throw new RXMLParseError("Failed to parse XML node", error);
   }
 }

--- a/src/rxml/heuristics/engine.ts
+++ b/src/rxml/heuristics/engine.ts
@@ -29,10 +29,10 @@ export interface HeuristicResult {
 }
 
 export interface ToolCallHeuristic {
-  applies(ctx: IntermediateCall): boolean;
+  applies: (ctx: IntermediateCall) => boolean;
   id: string;
   phase: HeuristicPhase;
-  run(ctx: IntermediateCall): HeuristicResult;
+  run: (ctx: IntermediateCall) => HeuristicResult;
 }
 
 export interface PipelineConfig {

--- a/src/rxml/parse.ts
+++ b/src/rxml/parse.ts
@@ -32,6 +32,6 @@ export function parse(
     return result.parsed as Record<string, unknown>;
   }
 
-  const error = result.errors[0];
+  const [error] = result.errors;
   throw new RXMLParseError("Failed to parse XML with repair heuristics", error);
 }

--- a/src/rxml/schema/coercion.ts
+++ b/src/rxml/schema/coercion.ts
@@ -24,7 +24,6 @@ export function getPropertySchema(toolSchema: unknown, key: string): unknown {
   if (props && Object.hasOwn(props, key)) {
     return (props as Record<string, unknown>)[key];
   }
-  return;
 }
 
 /**
@@ -136,7 +135,7 @@ function processChildElement(
     child.children.length === 1 &&
     typeof child.children[0] === "string"
   ) {
-    childValue = child.children[0];
+    [childValue] = child.children;
   } else {
     childValue = processComplexContent(
       child.children,
@@ -210,6 +209,7 @@ export function coerceDomBySchema(
   try {
     return baseCoerceBySchema(domObject, schema) as Record<string, unknown>;
   } catch (error) {
+    // biome-ignore lint/style/useErrorCause: RXML errors carry the original error via their positional cause parameter.
     throw new RXMLCoercionError("Failed to coerce DOM object by schema", error);
   }
 }

--- a/src/rxml/schema/extraction.ts
+++ b/src/rxml/schema/extraction.ts
@@ -311,7 +311,7 @@ function processOpeningTagInExtract(options: {
   const tagInfo = parseTagName(xmlContent, i, len);
   const tagEndInfo = skipToTagEnd(xmlContent, tagInfo.pos, len);
   const tagEnd = tagEndInfo.pos;
-  const isSelfClosing = tagEndInfo.isSelfClosing;
+  const { isSelfClosing } = tagEndInfo;
 
   let bestMatch: { start: number; end: number; depth: number } | null = null;
   if (tagInfo.name === target) {
@@ -391,7 +391,6 @@ export function extractRawInner(
   if (bestStart !== -1) {
     return xmlContent.slice(bestStart, bestEnd);
   }
-  return;
 }
 
 /**
@@ -473,7 +472,7 @@ export function findAllInnerRanges(
     const tagInfo = parseTagName(xmlContent, i, len);
     const tagEndInfo = skipToTagEnd(xmlContent, tagInfo.pos, len);
     const tagEnd = tagEndInfo.pos;
-    const isSelfClosing = tagEndInfo.isSelfClosing;
+    const { isSelfClosing } = tagEndInfo;
 
     if (tagInfo.name !== target) {
       // Advance over this tag
@@ -521,7 +520,6 @@ function findTopLevelTargetRange(options: {
   if (closePos !== -1) {
     return { start: contentStart, end: closePos };
   }
-  return;
 }
 
 /**
@@ -577,7 +575,7 @@ export function findFirstTopLevelRange(
     const tagInfo = parseTagName(xmlContent, i, len);
     const tagEndInfo = skipToTagEnd(xmlContent, tagInfo.pos, len);
     const tagEnd = tagEndInfo.pos;
-    const isSelfClosing = tagEndInfo.isSelfClosing;
+    const { isSelfClosing } = tagEndInfo;
 
     if (depth === 0 && tagInfo.name === target) {
       return findTopLevelTargetRange({
@@ -591,7 +589,6 @@ export function findFirstTopLevelRange(
     i = tagEnd + 1;
     depth += isSelfClosing ? 0 : 1;
   }
-  return;
 }
 
 /**

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -62,7 +62,6 @@ export function getSchemaType(schema: unknown): string | undefined {
   ) {
     return "array";
   }
-  return;
 }
 
 /**
@@ -139,7 +138,7 @@ function schemaHasPropertyDirectly(
   ) {
     return true;
   }
-  const required = s.required;
+  const { required } = s;
   if (Array.isArray(required) && required.includes(key)) {
     return true;
   }
@@ -177,7 +176,7 @@ function schemaHasPropertyViaAdditional(s: Record<string, unknown>): boolean {
   if (Object.hasOwn(s, "additionalProperties")) {
     return false;
   }
-  const type = s.type;
+  const { type } = s;
   const isObjectType =
     type === "object" || (Array.isArray(type) && type.includes("object"));
   const hasObjectKeywords =
@@ -816,7 +815,6 @@ function parseLooseStructuredString(s: string): unknown {
   } catch {
     // not parseable as a structured value
   }
-  return;
 }
 
 /**
@@ -840,7 +838,7 @@ function parseXmlChildrenValue(s: string): Record<string, unknown> | null {
     if (!match) {
       return null;
     }
-    const key = match[1];
+    const [, key] = match;
     if (COERCE_PROTOTYPE_SENSITIVE_KEYS.has(key)) {
       return null;
     }
@@ -939,7 +937,7 @@ function getStrictObjectSchemaInfo(
     return null;
   }
 
-  const properties = unwrapped.properties;
+  const { properties } = unwrapped;
   if (
     !properties ||
     typeof properties !== "object" ||
@@ -1057,8 +1055,8 @@ function applySingularPluralRequiredKeyRename(
     return null;
   }
 
-  const targetKey = missingRequired[0];
-  const sourceKey = unexpectedKeys[0];
+  const [targetKey] = missingRequired;
+  const [sourceKey] = unexpectedKeys;
   if (!Object.hasOwn(schemaInfo.properties, targetKey)) {
     return null;
   }
@@ -1094,8 +1092,8 @@ function applyCaseStyleRequiredKeyRename(
     return null;
   }
 
-  const targetKey = missingRequired[0];
-  const sourceKey = unexpectedKeys[0];
+  const [targetKey] = missingRequired;
+  const [sourceKey] = unexpectedKeys;
   if (!Object.hasOwn(schemaInfo.properties, targetKey)) {
     return null;
   }
@@ -1262,7 +1260,7 @@ function coerceParallelArraysObjectToArray(
     return null;
   }
 
-  const properties = itemSchema.properties;
+  const { properties } = itemSchema;
   if (
     !properties ||
     typeof properties !== "object" ||
@@ -1297,7 +1295,7 @@ function coerceParallelArraysObjectToArray(
   if (lengths.length !== 1) {
     return null;
   }
-  const length = lengths[0];
+  const [length] = lengths;
   if (length < 2) {
     return null;
   }
@@ -1368,7 +1366,7 @@ function coerceObjectToArray(
   // Check for single field that contains an array or object (common XML pattern)
   // This handles both: { user: [{ name: "A" }, { name: "B" }] } and { user: { name: "A" } }
   if (keys.length === 1) {
-    const singleKey = keys[0];
+    const [singleKey] = keys;
     if (
       !(
         schemaIsUnconstrained(itemsSchema) ||
@@ -1506,7 +1504,7 @@ function unwrapMatchingQuotes(value: string): string | null {
   if (value.length < 2) {
     return null;
   }
-  const first = value[0];
+  const first = value.charAt(0);
   const last = value.at(-1);
   const isQuote =
     (first === SINGLE_QUOTE || first === DOUBLE_QUOTE) && first === last;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,9 @@
 import { readFileSync } from "node:fs";
 import { defineConfig } from "vitest/config";
 
-const version = JSON.parse(
+const { version } = JSON.parse(
   readFileSync(new URL("./package.json", import.meta.url), "utf-8")
-).version;
+);
 
 export default defineConfig({
   define: {


### PR DESCRIPTION
Follow-up to #361, which disabled all rules newly enabled by ultracite 7.9.0 to keep the dependency bump unblocked. This PR adopts the ones that fit the codebase and documents why the rest stay off.

## Adopted (all violations fixed, 50 files, +165/−183)

| Rule | Sites | How |
|---|---|---|
| `complexity/noUselessReturn` | 16 | safe autofix |
| `complexity/noDivRegex` | 2 | safe autofix |
| `style/noIncrementDecrement` | 16 | `++`/`--` → `+= 1`/`-= 1` (one prefix-increment-in-expression rewritten as a statement) |
| `style/useConsistentMethodSignatures` | 6 | interface methods → property style (`TCMProtocol`, `ToolCallHeuristic`) |
| `style/useDestructuring` | 95 | codemod for simple cases + manual conversion for casts/multiline/assignments |
| `suspicious/noShadow` | 6 | renamed shadowing bindings |
| `style/useErrorCause` | 6 | rule enabled; RXML errors carry the original error via their positional `cause` parameter, so those throw sites get targeted `biome-ignore`s (changing the constructors would break the public API) |

One deliberate deviation during conversion: `unwrapMatchingQuotes` uses `value.charAt(0)` instead of string destructuring, because destructuring iterates by code point while `[0]`/`charAt` read code units — not equivalent for astral characters.

## Kept off (rationale documented in biome.jsonc)

- **`assist/source/useSortedKeys`** (~3.4k sites): would reorder object literals that tests compare against `JSON.stringify` output, plus massive churn.
- **`performance/noAwaitInLoops`** (35): stream parsing and chunk-replay tests are inherently sequential.
- **`suspicious/noEqualsToNull`** (52): `== null` is the deliberate null-or-undefined idiom here; the autofix is semantics-changing.
- **`suspicious/noUnnecessaryConditions`** (173): type-driven rule that flags intentional runtime guards against malformed LLM output and `while (true)` scan loops; poor fit for a defensive parser.

Verified: `pnpm check` clean, 2,103 tests + vitest typecheck pass, `pnpm build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts `ultracite` 7.9.0 lint rules that fit our codebase, fixes violations, and documents why others stay off. No behavior changes; all checks and builds pass.

- **Refactors**
  - Enabled and fixed: `complexity/noDivRegex`, `complexity/noUselessReturn`, `style/noIncrementDecrement`, `style/useConsistentMethodSignatures`, `style/useDestructuring`, `suspicious/noShadow`, `style/useErrorCause` (RXML throw sites use targeted `biome-ignore` to preserve API).
  - Conversions: `++`/`--` to `+= 1`/`-= 1`; interface methods → property-style functions (`TCMProtocol`, `ToolCallHeuristic`); 95 destructurings; minor shadowed names renamed.
  - Kept disabled in `biome.jsonc` with rationale: `assist/source/useSortedKeys` (JSON order churn), `performance/noAwaitInLoops` (sequential streams), `suspicious/noEqualsToNull` (intentional null-or-undefined), `suspicious/noUnnecessaryConditions` (defensive checks).
  - Verified: `pnpm check` clean; 2,103 tests + vitest typecheck pass; `pnpm build` succeeds.

<sup>Written for commit 78db4aaacd8b4cb388d8bd8d7d114f9d6f170f2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

