### PR TITLE
chore: add changeset for maintenance release

### DIFF
--- a/.changeset/tidy-lint-and-deps.md
+++ b/.changeset/tidy-lint-and-deps.md
@@ -1,0 +1,5 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+Maintenance release: adopt ultracite 7.9.0 lint rules via mechanical refactors (destructuring, `+= 1` counters, property-style interface signatures — no behavior changes), refresh dev dependencies (`ai`, `@ai-sdk/openai`, `ultracite`), and force patched `js-yaml` transitives to clear security advisories.


### PR DESCRIPTION
Patch release covering the ultracite 7.9.0 rule adoption (#363), dev dependency refresh (#361), and js-yaml security overrides (#362). Merging this lets the changesets action open the Version Packages PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a changeset for a patch maintenance release of `@ai-sdk-tool/parser`.

It adopts `ultracite` 7.9.0 lint rules (mechanical refactors only, no behavior change), refreshes dev deps (`ai`, `@ai-sdk/openai`, `ultracite`), and enforces patched `js-yaml` transitives to resolve security advisories. Merging will trigger the Version Packages PR.

<sup>Written for commit 059e529babc3c632f85f39e03adcc2b4503cd92e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

