### PR TITLE
[codex] Preserve key normalization with extra args

### DIFF
--- a/.changeset/soft-suits-talk.md
+++ b/.changeset/soft-suits-talk.md
@@ -2,4 +2,4 @@
 "@ai-sdk-tool/parser": patch
 ---
 
-Drop schema-unknown tool-call arguments consistently across parser middleware while preserving prototype-sensitive key rejection.
+Drop schema-unknown tool-call arguments consistently across parser middleware while preserving prototype-sensitive key rejection and strict required-key normalization.

--- a/src/__tests__/core/utils/tool-call-coercion.regression.test.ts
+++ b/src/__tests__/core/utils/tool-call-coercion.regression.test.ts
@@ -147,6 +147,95 @@ describe("tool-call coercion regression coverage", () => {
     expect(input).toBe('{"safe":1}');
   });
 
+  it("preserves strict key normalization before dropping schema-unknown keys", () => {
+    const input = coerceToolCallInput(
+      "translate",
+      {
+        text: "ship it",
+        target_language: "ko",
+        formality: "casual",
+        extra: "drop",
+      },
+      [
+        {
+          type: "function",
+          name: "translate",
+          inputSchema: {
+            type: "object",
+            properties: {
+              text: { type: "string" },
+              targetLanguage: { type: "string" },
+              formality: { type: "string" },
+            },
+            required: ["text", "targetLanguage"],
+            additionalProperties: false,
+          },
+        },
+      ]
+    );
+
+    expect(JSON.parse(input ?? "null")).toEqual({
+      text: "ship it",
+      targetLanguage: "ko",
+      formality: "casual",
+    });
+  });
+
+  it("does not let a similar unknown key override an already-present declared key", () => {
+    const input = coerceToolCallInput(
+      "translate",
+      {
+        text: "ship it",
+        targetLanguage: "ko",
+        target_language: "ja",
+      },
+      [
+        {
+          type: "function",
+          name: "translate",
+          inputSchema: {
+            type: "object",
+            properties: {
+              text: { type: "string" },
+              targetLanguage: { type: "string" },
+            },
+            required: ["text", "targetLanguage"],
+            additionalProperties: false,
+          },
+        },
+      ]
+    );
+
+    expect(input).toBe('{"text":"ship it","targetLanguage":"ko"}');
+  });
+
+  it("does not normalize optional-only similar keys into optional declared keys", () => {
+    const input = coerceToolCallInput(
+      "get_weather",
+      {
+        city: "Seoul",
+        temperature_unit: "celsius",
+      },
+      [
+        {
+          type: "function",
+          name: "get_weather",
+          inputSchema: {
+            type: "object",
+            properties: {
+              city: { type: "string" },
+              temperatureUnit: { type: "string" },
+            },
+            required: ["city"],
+            additionalProperties: false,
+          },
+        },
+      ]
+    );
+
+    expect(input).toBe('{"city":"Seoul"}');
+  });
+
   it("preserves additionalProperties true keys with unsafe false patterns", () => {
     const input = coerceToolCallInput("metadata", { safe: "1", aaaa: "2" }, [
       {

--- a/src/__tests__/protocols/cross-protocol/tool-args-sanitization.test.ts
+++ b/src/__tests__/protocols/cross-protocol/tool-args-sanitization.test.ts
@@ -105,6 +105,39 @@ mood: sunny
   },
 ];
 
+const reorderedArgsProtocolCases: readonly ProtocolCase[] = [
+  {
+    name: "Hermes",
+    protocol: hermesProtocol(),
+    text: `<tool_call>{"name":"get_weather","arguments":{"mood":"sunny","unit":"celsius","city":"Seoul"}}</tool_call>`,
+  },
+  {
+    name: "Morph XML",
+    protocol: morphXmlProtocol(),
+    text: "<get_weather><mood>sunny</mood><unit>celsius</unit><city>Seoul</city></get_weather>",
+  },
+  {
+    name: "YAML XML",
+    protocol: yamlXmlProtocol(),
+    text: `<get_weather>
+mood: sunny
+unit: celsius
+city: Seoul
+</get_weather>`,
+  },
+  {
+    name: "Qwen3Coder",
+    protocol: qwen3CoderProtocol(),
+    text: `<tool_call>
+  <function=get_weather>
+    <parameter=mood>sunny</parameter>
+    <parameter=unit>celsius</parameter>
+    <parameter=city>Seoul</parameter>
+  </function>
+</tool_call>`,
+  },
+];
+
 const emptyPropertiesProtocolCases: readonly ProtocolCase[] = [
   {
     name: "Hermes",
@@ -246,6 +279,25 @@ describe("cross-protocol tool arg sanitization", () => {
   it.each(
     protocolCases
   )("$name parseGeneratedText drops schema-unknown top-level args and emits the tool call", ({
+    protocol,
+    text,
+  }) => {
+    const parts = protocol.parseGeneratedText({
+      text,
+      tools: weatherTools,
+      options: {},
+    });
+
+    const toolCall = extractSingleToolCall(parts);
+    const input: unknown = JSON.parse(toolCall.input);
+
+    expect(toolCall.toolName).toBe("get_weather");
+    expect(input).toEqual({ city: "Seoul", unit: "celsius" });
+  });
+
+  it.each(
+    reorderedArgsProtocolCases
+  )("$name parseGeneratedText keeps declared args when optional args precede required args", ({
     protocol,
     text,
   }) => {

--- a/src/__tests__/schema-coerce/heuristics.strict-key-normalization.unit.test.ts
+++ b/src/__tests__/schema-coerce/heuristics.strict-key-normalization.unit.test.ts
@@ -79,6 +79,34 @@ describe("Coercion Heuristic Handling", () => {
       });
     });
 
+    it("renames case-style required keys even when unrelated extra keys are present", () => {
+      const input = {
+        text: "Let's ship this today.",
+        target_language: "fr",
+        formality: "casual",
+        extra: "drop later",
+      };
+
+      const schema = {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+          targetLanguage: { type: "string" },
+          formality: { type: "string", enum: ["casual", "formal"] },
+        },
+        required: ["text", "targetLanguage", "formality"],
+        additionalProperties: false,
+      };
+
+      const result = coerceBySchema(input, schema) as any;
+      expect(result).toEqual({
+        text: "Let's ship this today.",
+        targetLanguage: "fr",
+        formality: "casual",
+        extra: "drop later",
+      });
+    });
+
     it("normalizes leading underscores when matching snake_case keys", () => {
       const input = {
         _target_language: "es",
@@ -185,6 +213,52 @@ describe("Coercion Heuristic Handling", () => {
       const result = coerceBySchema(input, schema) as any;
       expect(result).toEqual({
         filter: ["paid"],
+      });
+    });
+
+    it("renames singular required array keys even when unrelated extra keys are present", () => {
+      const input = {
+        filter: [
+          {
+            field: "status",
+            op: "=",
+            value: "paid",
+          },
+        ],
+        extra: "drop later",
+      };
+
+      const schema = {
+        type: "object",
+        properties: {
+          filters: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                field: { type: "string" },
+                op: { type: "string" },
+                value: { type: "string" },
+              },
+              required: ["field", "op", "value"],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ["filters"],
+        additionalProperties: false,
+      };
+
+      const result = coerceBySchema(input, schema) as any;
+      expect(result).toEqual({
+        filters: [
+          {
+            field: "status",
+            op: "=",
+            value: "paid",
+          },
+        ],
+        extra: "drop later",
       });
     });
   });

--- a/src/schema-coerce/index.ts
+++ b/src/schema-coerce/index.ts
@@ -1042,6 +1042,14 @@ function computeMissingAndUnexpectedKeys(
   return { missingRequired, unexpectedKeys };
 }
 
+function findSingleMatchingUnexpectedKey(
+  unexpectedKeys: string[],
+  matches: (key: string) => boolean
+): string | null {
+  const matchingKeys = unexpectedKeys.filter(matches);
+  return matchingKeys.length === 1 ? (matchingKeys[0] ?? null) : null;
+}
+
 function applySingularPluralRequiredKeyRename(
   input: Record<string, unknown>,
   schemaInfo: StrictObjectSchemaInfo
@@ -1051,16 +1059,18 @@ function applySingularPluralRequiredKeyRename(
     schemaInfo
   );
 
-  if (missingRequired.length !== 1 || unexpectedKeys.length !== 1) {
+  if (missingRequired.length !== 1) {
     return null;
   }
 
   const [targetKey] = missingRequired;
-  const [sourceKey] = unexpectedKeys;
   if (!Object.hasOwn(schemaInfo.properties, targetKey)) {
     return null;
   }
-  if (!isSingularPluralPair(targetKey, sourceKey)) {
+  const sourceKey = findSingleMatchingUnexpectedKey(unexpectedKeys, (key) =>
+    isSingularPluralPair(targetKey, key)
+  );
+  if (sourceKey === null) {
     return null;
   }
   if (getSchemaType(schemaInfo.properties[targetKey]) !== "array") {
@@ -1088,16 +1098,18 @@ function applyCaseStyleRequiredKeyRename(
     schemaInfo
   );
 
-  if (missingRequired.length !== 1 || unexpectedKeys.length !== 1) {
+  if (missingRequired.length !== 1) {
     return null;
   }
 
   const [targetKey] = missingRequired;
-  const [sourceKey] = unexpectedKeys;
   if (!Object.hasOwn(schemaInfo.properties, targetKey)) {
     return null;
   }
-  if (!isCaseStylePair(targetKey, sourceKey)) {
+  const sourceKey = findSingleMatchingUnexpectedKey(unexpectedKeys, (key) =>
+    isCaseStylePair(targetKey, key)
+  );
+  if (sourceKey === null) {
     return null;
   }
   if (!Object.hasOwn(input, sourceKey) || Object.hasOwn(input, targetKey)) {


### PR DESCRIPTION
## Summary

- Preserve strict required-key normalization when unrelated schema-unknown args are present.
- Add regression coverage for reordered optional/extra args across Hermes, Morph XML, YAML XML, and Qwen3Coder.
- Extend the existing changeset note to include strict required-key normalization.

## Why

Follow-up validation for #367 found that `target_language -> targetLanguage` style strict key normalization could be skipped when an unrelated extra key was also present. The extra key should be handled by schema sanitization, not prevent the intended required-key recovery.

## Validation

- `pnpm check`
- `pnpm test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves strict required-key normalization during tool-call argument sanitization, even when extra schema-unknown args are present. Ensures declared keys are recovered and stable across protocols and input order.

- **Bug Fixes**
  - Normalize required keys (case-style and singular/plural) before dropping unknown args, so `target_language` -> `targetLanguage` and `filter` -> `filters` still occur with extra args.
  - Prevent lookalike unknown keys from overriding declared keys and avoid normalizing optional-only lookalikes; add cross-protocol regression tests (Hermes, Morph XML, YAML XML, Qwen3Coder) and reordered-args cases; release as a patch to `@ai-sdk-tool/parser`.

<sup>Written for commit ffdf94337fd4e2851033cfbf9ac1db542ddcef07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

