### PR TITLE
fix: pass tool-result media as real file parts by default

### DIFF
--- a/.changeset/tool-result-media-default-model.md
+++ b/.changeset/tool-result-media-default-model.md
@@ -7,3 +7,4 @@ Default tool-result media handling now passes real AI SDK v4/v7 `file` parts (`m
 - Canonical `{ type: "file", data: SharedV4FileData }` content is forwarded as model file parts; non-canonical content becomes placeholders.
 - Protocol formatters (Hermes, Morph XML, Qwen3-Coder, YAML XML) emit hybrid user content (`text` wrapper + adjacent `file` parts) when media is present.
 - Opt into the old text-only path with `mediaStrategy: { mode: "placeholder" }` on tool-response formatter factories.
+- Remove the `raw` media strategy mode (use `model`, `placeholder`, or capability-gated `auto`).

--- a/.changeset/tool-result-media-default-model.md
+++ b/.changeset/tool-result-media-default-model.md
@@ -1,0 +1,9 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+Default tool-result media handling now passes real AI SDK v4/v7 `file` parts (`mode: "model"`) instead of text placeholders.
+
+- Convert deprecated `image-*` / `file-*` content aliases into canonical `{ type: "file", data: SharedV4FileData }` shapes (`data` / `url` / `reference`).
+- Protocol formatters (Hermes, Morph XML, Qwen3-Coder, YAML XML) emit hybrid user content (`text` wrapper + adjacent `file` parts) when tool results include media.
+- Opt into the old text-only path with `mediaStrategy: { mode: "placeholder" }` on tool-response formatter factories.

--- a/.changeset/tool-result-media-default-model.md
+++ b/.changeset/tool-result-media-default-model.md
@@ -4,6 +4,6 @@
 
 Default tool-result media handling now passes real AI SDK v4/v7 `file` parts (`mode: "model"`) instead of text placeholders.
 
-- Convert deprecated `image-*` / `file-*` content aliases into canonical `{ type: "file", data: SharedV4FileData }` shapes (`data` / `url` / `reference`).
-- Protocol formatters (Hermes, Morph XML, Qwen3-Coder, YAML XML) emit hybrid user content (`text` wrapper + adjacent `file` parts) when tool results include media.
+- Canonical `{ type: "file", data: SharedV4FileData }` content is forwarded as model file parts; non-canonical content becomes placeholders.
+- Protocol formatters (Hermes, Morph XML, Qwen3-Coder, YAML XML) emit hybrid user content (`text` wrapper + adjacent `file` parts) when media is present.
 - Opt into the old text-only path with `mediaStrategy: { mode: "placeholder" }` on tool-response formatter factories.

--- a/.changeset/tool-result-media-default-model.md
+++ b/.changeset/tool-result-media-default-model.md
@@ -5,6 +5,7 @@
 Default tool-result media handling now passes real AI SDK v4/v7 `file` parts (`mode: "model"`) instead of text placeholders.
 
 - Canonical `{ type: "file", data: SharedV4FileData }` content is forwarded as model file parts; non-canonical content becomes placeholders.
-- Protocol formatters (Hermes, Morph XML, Qwen3-Coder, YAML XML) emit hybrid user content (`text` wrapper + adjacent `file` parts) when media is present.
-- Opt into the old text-only path with `mediaStrategy: { mode: "placeholder" }` on tool-response formatter factories.
+- Hermes, Morph XML, and Qwen3-Coder formatters emit hybrid user content (`text` wrapper + adjacent `file` parts) when media is present. YAML XML tool responses reuse the Morph XML response formatter (same hybrid behavior by default).
+- Opt into the old text-only path with `mediaStrategy: { mode: "placeholder" }` via `createHermesToolResponseFormatter` / `createMorphXmlToolResponseFormatter` / `createQwen3CoderXmlToolResponseFormatter` (YAML XML apps should use the Morph factory for response formatting options).
+- URL-backed file parts only forward `http:` / `https:` URLs; other schemes degrade to placeholders. String URLs are intentionally reparsed to `URL` (JSON-deserialized payloads).
 - Remove the `raw` media strategy mode (use `model`, `placeholder`, or capability-gated `auto`).

--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ const textOnlyMiddleware = createToolMiddleware({
     mediaStrategy: { mode: "placeholder" },
   }),
 });
+
+// YAML XML tool *responses* reuse Morph's response formatter — use the Morph
+// factory when you need mediaStrategy options with yamlXmlProtocol.
 ```
+
+Only `http:` / `https:` file URLs are forwarded as model file parts; other schemes become placeholders. String URLs from JSON-deserialized tool results are reparsed to `URL` objects intentionally.
 
 User-message images are unchanged — they pass through as-is.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ When a tool returns multimodal `output: { type: "content", value: [...] }`, the 
 
 | `mediaStrategy.mode` | Behavior |
 |---|---|
-| `model` (**default**) | Convert media into model-recognizable `file` parts (AI SDK v4/v7 tagged `data` / `url` / `reference`). Protocol wrappers stay as adjacent `text`. |
+| `model` (**default**) | Forward canonical `{ type: "file", data }` content as model file parts. Protocol wrappers stay as adjacent `text`. |
 | `placeholder` | Text-only fallback (`[Image: image/png]`, `[File URL: ...]`, …) for non-vision models. |
 | `raw` / `auto` | Keep or selectively keep original tool content parts as JSON values. |
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,37 @@ pnpm add @ai-sdk-tool/parser
 - **Node.js `>=22` is required** (Node 18 is end-of-life).
 - Tool-result file parts now use the v4 tagged file shape (`{ type: "data", data }`) instead of a bare `data` string. This only affects code that constructs tool-result file parts directly.
 
+### Tool-result media (images / files)
+
+When a tool returns multimodal `output: { type: "content", value: [...] }`, the middleware projects that into the next model turn:
+
+| `mediaStrategy.mode` | Behavior |
+|---|---|
+| `model` (**default**) | Convert media into model-recognizable `file` parts (AI SDK v4/v7 tagged `data` / `url` / `reference`). Protocol wrappers stay as adjacent `text`. |
+| `placeholder` | Text-only fallback (`[Image: image/png]`, `[File URL: ...]`, …) for non-vision models. |
+| `raw` / `auto` | Keep or selectively keep original tool content parts as JSON values. |
+
+```ts
+import {
+  createHermesToolResponseFormatter,
+  createToolMiddleware,
+  hermesProtocol,
+  hermesSystemPromptTemplate,
+} from "@ai-sdk-tool/parser";
+
+// Default preconfigured middleware already uses model media mode.
+// For text-only models, opt into placeholders:
+const textOnlyMiddleware = createToolMiddleware({
+  protocol: hermesProtocol(),
+  toolSystemPromptTemplate: hermesSystemPromptTemplate,
+  toolResponsePromptTemplate: createHermesToolResponseFormatter({
+    mediaStrategy: { mode: "placeholder" },
+  }),
+});
+```
+
+User-message images are unchanged — they pass through as-is.
+
 **Status:** `5.0.0` is the stable release line. Pin an exact version if you need reproducible installs.
 
 ## Package map

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ When a tool returns multimodal `output: { type: "content", value: [...] }`, the 
 |---|---|
 | `model` (**default**) | Forward canonical `{ type: "file", data }` content as model file parts. Protocol wrappers stay as adjacent `text`. |
 | `placeholder` | Text-only fallback (`[Image: image/png]`, `[File URL: ...]`, …) for non-vision models. |
-| `raw` / `auto` | Keep or selectively keep original tool content parts as JSON values. |
+| `auto` | Keep original tool content parts when `capabilities` enable that media kind; otherwise placeholder. |
 
 ```ts
 import {

--- a/src/__tests__/core/prompts/hermes-prompt.unit.test.ts
+++ b/src/__tests__/core/prompts/hermes-prompt.unit.test.ts
@@ -396,10 +396,11 @@ describe("formatToolResponseAsHermes", () => {
     expect(result).toContain('"content":"simple string"');
   });
 
-  it("factory supports raw media strategy", () => {
+  it("factory supports auto media strategy with enabled image capability", () => {
     const formatter = createHermesToolResponseFormatter({
       mediaStrategy: {
-        mode: "raw",
+        mode: "auto",
+        capabilities: { image: true },
       },
     });
 

--- a/src/__tests__/core/prompts/hermes-prompt.unit.test.ts
+++ b/src/__tests__/core/prompts/hermes-prompt.unit.test.ts
@@ -330,7 +330,7 @@ describe("formatToolResponseAsHermes", () => {
     expect(result).toContain("Network timeout");
   });
 
-  it("handles content type with images", () => {
+  it("emits real file parts for content images by default", () => {
     const result = formatToolResponseAsHermes({
       type: "tool-result",
       toolCallId: "tc1",
@@ -343,6 +343,37 @@ describe("formatToolResponseAsHermes", () => {
         ],
       },
     } satisfies ToolResultPart);
+
+    expect(result).toEqual([
+      {
+        type: "text",
+        text: '<tool_response>{"name":"screenshot","content":"Screenshot captured"}</tool_response>',
+      },
+      {
+        type: "file",
+        data: { type: "data", data: "base64..." },
+        mediaType: "image/png",
+      },
+    ]);
+  });
+
+  it("falls back to image placeholders when media strategy is placeholder", () => {
+    const formatter = createHermesToolResponseFormatter({
+      mediaStrategy: { mode: "placeholder" },
+    });
+    const result = formatter({
+      type: "tool-result",
+      toolCallId: "tc1",
+      toolName: "screenshot",
+      output: {
+        type: "content",
+        value: [
+          { type: "text", text: "Screenshot captured" },
+          { type: "image-data", data: "base64...", mediaType: "image/png" },
+        ],
+      },
+    } satisfies ToolResultPart);
+
     expect(result).toContain("Screenshot captured");
     expect(result).toContain("[Image: image/png]");
   });

--- a/src/__tests__/core/prompts/hermes-prompt.unit.test.ts
+++ b/src/__tests__/core/prompts/hermes-prompt.unit.test.ts
@@ -330,7 +330,7 @@ describe("formatToolResponseAsHermes", () => {
     expect(result).toContain("Network timeout");
   });
 
-  it("emits real file parts for content images by default", () => {
+  it("emits real file parts for canonical file content by default", () => {
     const result = formatToolResponseAsHermes({
       type: "tool-result",
       toolCallId: "tc1",
@@ -339,7 +339,11 @@ describe("formatToolResponseAsHermes", () => {
         type: "content",
         value: [
           { type: "text", text: "Screenshot captured" },
-          { type: "image-data", data: "base64...", mediaType: "image/png" },
+          {
+            type: "file",
+            data: { type: "data", data: "base64..." },
+            mediaType: "image/png",
+          },
         ],
       },
     } satisfies ToolResultPart);
@@ -357,7 +361,7 @@ describe("formatToolResponseAsHermes", () => {
     ]);
   });
 
-  it("falls back to image placeholders when media strategy is placeholder", () => {
+  it("falls back to file placeholders when media strategy is placeholder", () => {
     const formatter = createHermesToolResponseFormatter({
       mediaStrategy: { mode: "placeholder" },
     });
@@ -369,7 +373,11 @@ describe("formatToolResponseAsHermes", () => {
         type: "content",
         value: [
           { type: "text", text: "Screenshot captured" },
-          { type: "image-data", data: "base64...", mediaType: "image/png" },
+          {
+            type: "file",
+            data: { type: "data", data: "base64..." },
+            mediaType: "image/png",
+          },
         ],
       },
     } satisfies ToolResultPart);

--- a/src/__tests__/core/prompts/morph-xml-prompt.unit.test.ts
+++ b/src/__tests__/core/prompts/morph-xml-prompt.unit.test.ts
@@ -169,7 +169,7 @@ describe("morphFormatToolResponseAsXml", () => {
     expect(result).not.toContain('"type":"json"');
   });
 
-  it("emits real file parts for content images by default", () => {
+  it("emits real file parts for canonical file content by default", () => {
     const result = morphFormatToolResponseAsXml({
       type: "tool-result",
       toolCallId: "tc1",
@@ -178,7 +178,11 @@ describe("morphFormatToolResponseAsXml", () => {
         type: "content",
         value: [
           { type: "text", text: "Screenshot captured" },
-          { type: "image-data", data: "base64...", mediaType: "image/png" },
+          {
+            type: "file",
+            data: { type: "data", data: "base64..." },
+            mediaType: "image/png",
+          },
         ],
       },
     } satisfies ToolResultPart);
@@ -201,7 +205,7 @@ describe("morphFormatToolResponseAsXml", () => {
     ]);
   });
 
-  it("falls back to image placeholders when media strategy is placeholder", () => {
+  it("falls back to file placeholders when media strategy is placeholder", () => {
     const formatter = createMorphXmlToolResponseFormatter({
       mediaStrategy: { mode: "placeholder" },
     });
@@ -213,7 +217,11 @@ describe("morphFormatToolResponseAsXml", () => {
         type: "content",
         value: [
           { type: "text", text: "Screenshot captured" },
-          { type: "image-data", data: "base64...", mediaType: "image/png" },
+          {
+            type: "file",
+            data: { type: "data", data: "base64..." },
+            mediaType: "image/png",
+          },
         ],
       },
     } satisfies ToolResultPart);

--- a/src/__tests__/core/prompts/morph-xml-prompt.unit.test.ts
+++ b/src/__tests__/core/prompts/morph-xml-prompt.unit.test.ts
@@ -169,7 +169,7 @@ describe("morphFormatToolResponseAsXml", () => {
     expect(result).not.toContain('"type":"json"');
   });
 
-  it("handles content type with images gracefully", () => {
+  it("emits real file parts for content images by default", () => {
     const result = morphFormatToolResponseAsXml({
       type: "tool-result",
       toolCallId: "tc1",
@@ -182,6 +182,42 @@ describe("morphFormatToolResponseAsXml", () => {
         ],
       },
     } satisfies ToolResultPart);
+
+    expect(result).toEqual([
+      {
+        type: "text",
+        text: [
+          "<tool_response>",
+          "  <tool_name>screenshot</tool_name>",
+          "  <result>Screenshot captured</result>",
+          "</tool_response>",
+        ].join("\n"),
+      },
+      {
+        type: "file",
+        data: { type: "data", data: "base64..." },
+        mediaType: "image/png",
+      },
+    ]);
+  });
+
+  it("falls back to image placeholders when media strategy is placeholder", () => {
+    const formatter = createMorphXmlToolResponseFormatter({
+      mediaStrategy: { mode: "placeholder" },
+    });
+    const result = formatter({
+      type: "tool-result",
+      toolCallId: "tc1",
+      toolName: "screenshot",
+      output: {
+        type: "content",
+        value: [
+          { type: "text", text: "Screenshot captured" },
+          { type: "image-data", data: "base64...", mediaType: "image/png" },
+        ],
+      },
+    } satisfies ToolResultPart);
+
     expect(result).toContain("Screenshot captured");
     expect(result).toContain("[Image: image/png]");
   });

--- a/src/__tests__/core/prompts/qwen3coder-prompt.unit.test.ts
+++ b/src/__tests__/core/prompts/qwen3coder-prompt.unit.test.ts
@@ -142,10 +142,11 @@ describe("formatToolResponseAsQwen3CoderXml", () => {
     expect(result).toBe("<tool_response>\nok\n</tool_response>");
   });
 
-  it("factory supports raw media strategy", () => {
+  it("factory supports auto media strategy with enabled image capability", () => {
     const formatter = createQwen3CoderXmlToolResponseFormatter({
       mediaStrategy: {
-        mode: "raw",
+        mode: "auto",
+        capabilities: { image: true },
       },
     });
 

--- a/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
+++ b/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
@@ -418,10 +418,16 @@ describe("unwrapToolResult", () => {
 });
 
 describe("normalizeToolResultForUserContent", () => {
-  it("converts image-url content into a v4 url-tagged file part by default", () => {
+  it("passes canonical file content through by default", () => {
     const result = normalizeToolResultForUserContent({
       type: "content",
-      value: [{ type: "image-url", url: "https://example.com/a.png" }],
+      value: [
+        {
+          type: "file",
+          data: { type: "url", url: new URL("https://example.com/a.png") },
+          mediaType: "image",
+        },
+      ],
     });
 
     expect(result).toEqual([
@@ -433,14 +439,14 @@ describe("normalizeToolResultForUserContent", () => {
     ]);
   });
 
-  it("converts file-data content into model-recognizable file part in model mode", () => {
+  it("passes data-tagged file content through in model mode", () => {
     const result = normalizeToolResultForUserContent(
       {
         type: "content",
         value: [
           {
-            type: "file-data",
-            data: "YWJj",
+            type: "file",
+            data: { type: "data", data: "YWJj" },
             mediaType: "application/pdf",
             filename: "report.pdf",
           },
@@ -461,7 +467,7 @@ describe("normalizeToolResultForUserContent", () => {
     ]);
   });
 
-  it("falls back to text placeholder for bare string file-id in model mode", () => {
+  it("falls back to text placeholder for non-canonical content parts in model mode", () => {
     const result = normalizeToolResultForUserContent(
       {
         type: "content",
@@ -480,29 +486,17 @@ describe("normalizeToolResultForUserContent", () => {
     ]);
   });
 
-  it("converts provider-keyed file-id into a reference-tagged file part", () => {
-    const result = normalizeToolResultForUserContent({
-      type: "content",
-      value: [{ type: "file-id", fileId: { openai: "file-123" } }],
-    });
-
-    expect(result).toEqual([
-      {
-        type: "file",
-        data: {
-          type: "reference",
-          reference: { openai: "file-123" },
-        },
-        mediaType: "application/octet-stream",
-      },
-    ]);
-  });
-
   it("returns text part output when mode is placeholder", () => {
     const result = normalizeToolResultForUserContent(
       {
         type: "content",
-        value: [{ type: "image-url", url: "https://example.com/a.png" }],
+        value: [
+          {
+            type: "file",
+            data: { type: "url", url: new URL("https://example.com/a.png") },
+            mediaType: "image/png",
+          },
+        ],
       },
       {
         mode: "placeholder",

--- a/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
+++ b/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
@@ -615,4 +615,95 @@ describe("canonical v4 file content parts", () => {
       },
     ]);
   });
+
+  it("falls back to placeholders for unknown file data tags", () => {
+    const out = normalizeToolResultForUserContent({
+      type: "content",
+      value: [
+        {
+          type: "file",
+          data: { type: "nope" },
+          mediaType: "image/png",
+        },
+      ],
+    } as unknown as Parameters<typeof normalizeToolResultForUserContent>[0]);
+
+    expect(out).toEqual([
+      {
+        type: "text",
+        text: "[Image: image/png]",
+      },
+    ]);
+  });
+
+  it("falls back to placeholders when tagged data payload is missing", () => {
+    const out = normalizeToolResultForUserContent({
+      type: "content",
+      value: [
+        {
+          type: "file",
+          data: { type: "data" },
+          mediaType: "application/pdf",
+          filename: "report.pdf",
+        },
+      ],
+    } as unknown as Parameters<typeof normalizeToolResultForUserContent>[0]);
+
+    expect(out).toEqual([
+      {
+        type: "text",
+        text: "[File: report.pdf (application/pdf)]",
+      },
+    ]);
+  });
+
+  it("falls back to placeholders when mediaType is missing", () => {
+    const out = normalizeToolResultForUserContent({
+      type: "content",
+      value: [
+        {
+          type: "file",
+          data: { type: "data", data: "aGVsbG8=" },
+        },
+      ],
+    } as unknown as Parameters<typeof normalizeToolResultForUserContent>[0]);
+
+    expect(out).toEqual([
+      {
+        type: "text",
+        text: "[File: application/octet-stream]",
+      },
+    ]);
+  });
+
+  it("passes reference and text tagged file parts through", () => {
+    const out = normalizeToolResultForUserContent({
+      type: "content",
+      value: [
+        {
+          type: "file",
+          data: { type: "reference", reference: { openai: "file-123" } },
+          mediaType: "application/pdf",
+        },
+        {
+          type: "file",
+          data: { type: "text", text: "inline doc" },
+          mediaType: "text/plain",
+        },
+      ],
+    } as unknown as Parameters<typeof normalizeToolResultForUserContent>[0]);
+
+    expect(out).toEqual([
+      {
+        type: "file",
+        data: { type: "reference", reference: { openai: "file-123" } },
+        mediaType: "application/pdf",
+      },
+      {
+        type: "file",
+        data: { type: "text", text: "inline doc" },
+        mediaType: "text/plain",
+      },
+    ]);
+  });
 });

--- a/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
+++ b/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
@@ -418,22 +418,17 @@ describe("unwrapToolResult", () => {
 });
 
 describe("normalizeToolResultForUserContent", () => {
-  it("converts image-url content into model-recognizable file part in model mode", () => {
-    const result = normalizeToolResultForUserContent(
-      {
-        type: "content",
-        value: [{ type: "image-url", url: "https://example.com/a.png" }],
-      },
-      {
-        mode: "model",
-      }
-    );
+  it("converts image-url content into a v4 url-tagged file part by default", () => {
+    const result = normalizeToolResultForUserContent({
+      type: "content",
+      value: [{ type: "image-url", url: "https://example.com/a.png" }],
+    });
 
     expect(result).toEqual([
       {
         type: "file",
-        data: { type: "data", data: "https://example.com/a.png" },
-        mediaType: "image/*",
+        data: { type: "url", url: new URL("https://example.com/a.png") },
+        mediaType: "image",
       },
     ]);
   });
@@ -466,7 +461,7 @@ describe("normalizeToolResultForUserContent", () => {
     ]);
   });
 
-  it("falls back to text placeholder for file-id in model mode", () => {
+  it("falls back to text placeholder for bare string file-id in model mode", () => {
     const result = normalizeToolResultForUserContent(
       {
         type: "content",
@@ -485,7 +480,25 @@ describe("normalizeToolResultForUserContent", () => {
     ]);
   });
 
-  it("returns text part output when mode is not model", () => {
+  it("converts provider-keyed file-id into a reference-tagged file part", () => {
+    const result = normalizeToolResultForUserContent({
+      type: "content",
+      value: [{ type: "file-id", fileId: { openai: "file-123" } }],
+    });
+
+    expect(result).toEqual([
+      {
+        type: "file",
+        data: {
+          type: "reference",
+          reference: { openai: "file-123" },
+        },
+        mediaType: "application/octet-stream",
+      },
+    ]);
+  });
+
+  it("returns text part output when mode is placeholder", () => {
     const result = normalizeToolResultForUserContent(
       {
         type: "content",
@@ -614,5 +627,26 @@ describe("canonical v4 file content parts", () => {
     );
 
     expect(out).toEqual([filePart]);
+  });
+
+  it("normalizes string urls on canonical file parts to URL objects", () => {
+    const out = normalizeToolResultForUserContent({
+      type: "content",
+      value: [
+        {
+          type: "file",
+          data: { type: "url", url: "https://example.com/cat.png" },
+          mediaType: "image/png",
+        },
+      ],
+    } as unknown as Parameters<typeof normalizeToolResultForUserContent>[0]);
+
+    expect(out).toEqual([
+      {
+        type: "file",
+        data: { type: "url", url: new URL("https://example.com/cat.png") },
+        mediaType: "image/png",
+      },
+    ]);
   });
 });

--- a/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
+++ b/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
@@ -312,34 +312,6 @@ describe("unwrapToolResult", () => {
       );
     });
 
-    it("returns raw content when media strategy is raw", () => {
-      const result = unwrapToolResult(
-        {
-          type: "content",
-          value: [
-            { type: "text", text: "visual" },
-            {
-              type: "image-data",
-              data: "base64...",
-              mediaType: "image/png",
-            },
-          ],
-        },
-        {
-          mode: "raw",
-        }
-      );
-
-      expect(result).toEqual([
-        { type: "text", text: "visual" },
-        {
-          type: "image-data",
-          data: "base64...",
-          mediaType: "image/png",
-        },
-      ]);
-    });
-
     it("returns raw content in auto mode when media capability is enabled", () => {
       const result = unwrapToolResult(
         {

--- a/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
+++ b/src/__tests__/core/prompts/shared/tool-result-normalizer.normalization.unit.test.ts
@@ -596,6 +596,8 @@ describe("canonical v4 file content parts", () => {
   });
 
   it("normalizes string urls on canonical file parts to URL objects", () => {
+    // JSON-deserialized tool results often carry url as a string; repair to URL
+    // is intentional so model mode can still forward http(s) file parts.
     const out = normalizeToolResultForUserContent({
       type: "content",
       value: [
@@ -613,6 +615,35 @@ describe("canonical v4 file content parts", () => {
         data: { type: "url", url: new URL("https://example.com/cat.png") },
         mediaType: "image/png",
       },
+    ]);
+  });
+
+  it("rejects non-http(s) file urls as placeholders", () => {
+    const out = normalizeToolResultForUserContent({
+      type: "content",
+      value: [
+        {
+          type: "file",
+          data: { type: "url", url: new URL("file:///etc/passwd") },
+          mediaType: "text/plain",
+        },
+        {
+          type: "file",
+          data: { type: "url", url: "javascript:alert(1)" },
+          mediaType: "text/html",
+        },
+        {
+          type: "file",
+          data: { type: "url", url: "ftp://files.example.com/a.png" },
+          mediaType: "image/png",
+        },
+      ],
+    } as unknown as Parameters<typeof normalizeToolResultForUserContent>[0]);
+
+    expect(out).toEqual([
+      { type: "text", text: "[File URL: file:///etc/passwd]" },
+      { type: "text", text: "[File URL: javascript:alert(1)]" },
+      { type: "text", text: "[Image URL: ftp://files.example.com/a.png]" },
     ]);
   });
 

--- a/src/__tests__/core/prompts/shared/tool-role-to-user-message.conversion.unit.test.ts
+++ b/src/__tests__/core/prompts/shared/tool-role-to-user-message.conversion.unit.test.ts
@@ -37,7 +37,7 @@ describe("toolRoleContentToUserTextMessage", () => {
     });
   });
 
-  it("supports model media mode and emits file parts for user content", () => {
+  it("defaults to model media mode and emits file parts for user content", () => {
     const result = toolRoleContentToUserTextMessage({
       toolContent: [
         {
@@ -50,11 +50,7 @@ describe("toolRoleContentToUserTextMessage", () => {
           },
         },
       ] as ToolContent,
-      toolResponsePromptTemplate: createUserContentToolResponseTemplate({
-        mediaStrategy: {
-          mode: "model",
-        },
-      }),
+      toolResponsePromptTemplate: createUserContentToolResponseTemplate(),
     });
 
     expect(result).toEqual({
@@ -62,8 +58,8 @@ describe("toolRoleContentToUserTextMessage", () => {
       content: [
         {
           type: "file",
-          data: { type: "data", data: "https://example.com/a.png" },
-          mediaType: "image/*",
+          data: { type: "url", url: new URL("https://example.com/a.png") },
+          mediaType: "image",
         },
       ],
     });

--- a/src/__tests__/core/prompts/shared/tool-role-to-user-message.conversion.unit.test.ts
+++ b/src/__tests__/core/prompts/shared/tool-role-to-user-message.conversion.unit.test.ts
@@ -46,7 +46,16 @@ describe("toolRoleContentToUserTextMessage", () => {
           toolName: "vision",
           output: {
             type: "content",
-            value: [{ type: "image-url", url: "https://example.com/a.png" }],
+            value: [
+              {
+                type: "file",
+                data: {
+                  type: "url",
+                  url: new URL("https://example.com/a.png"),
+                },
+                mediaType: "image",
+              },
+            ],
           },
         },
       ] as ToolContent,

--- a/src/__tests__/entry/exports.surface.test.ts
+++ b/src/__tests__/entry/exports.surface.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  createHermesToolResponseFormatter,
+  createMorphXmlToolResponseFormatter,
+  createQwen3CoderXmlToolResponseFormatter,
   createToolMiddleware,
+  createUserContentToolResponseTemplate,
+  formatToolResponseAsYaml,
   hermesProtocol,
+  hermesSystemPromptTemplate,
   hermesToolMiddleware,
+  morphXmlSystemPromptTemplate,
   morphXmlToolMiddleware,
+  qwen3coderSystemPromptTemplate,
+  yamlXmlSystemPromptTemplate,
 } from "../../index";
 
 describe("entry exports surface", () => {
@@ -23,6 +32,18 @@ describe("entry exports surface", () => {
   it("exports createToolMiddleware as callable function", () => {
     expect(createToolMiddleware).toBeDefined();
     expect(typeof createToolMiddleware).toBe("function");
+  });
+
+  it("exports tool-response formatter factories and system prompts", () => {
+    expect(typeof createHermesToolResponseFormatter).toBe("function");
+    expect(typeof createMorphXmlToolResponseFormatter).toBe("function");
+    expect(typeof createQwen3CoderXmlToolResponseFormatter).toBe("function");
+    expect(typeof createUserContentToolResponseTemplate).toBe("function");
+    expect(typeof formatToolResponseAsYaml).toBe("function");
+    expect(typeof hermesSystemPromptTemplate).toBe("function");
+    expect(typeof morphXmlSystemPromptTemplate).toBe("function");
+    expect(typeof qwen3coderSystemPromptTemplate).toBe("function");
+    expect(typeof yamlXmlSystemPromptTemplate).toBe("function");
   });
 
   it("creates custom middleware with v3 specification", () => {

--- a/src/core/prompts/hermes-prompt.ts
+++ b/src/core/prompts/hermes-prompt.ts
@@ -4,10 +4,9 @@ import {
   renderInputExamplesSection,
   stringifyInputExampleAsJsonLiteral,
 } from "./shared/input-examples";
-import {
-  type ToolResponseMediaStrategy,
-  unwrapToolResult,
-} from "./shared/tool-result-normalizer";
+import { formatToolResponseWithMedia } from "./shared/tool-response-with-media";
+import type { ToolResponseMediaStrategy } from "./shared/tool-result-normalizer";
+import type { ToolResponsePromptTemplateResult } from "./shared/tool-result-user-content";
 
 interface HermesToolResponseFormatterOptions {
   mediaStrategy?: ToolResponseMediaStrategy;
@@ -16,25 +15,28 @@ interface HermesToolResponseFormatterOptions {
 function formatToolResponseAsHermesWithOptions(
   toolResult: ToolResultPart,
   options?: HermesToolResponseFormatterOptions
-): string {
-  const unwrappedResult = unwrapToolResult(
-    toolResult.output,
-    options?.mediaStrategy
-  );
-  return `<tool_response>${JSON.stringify({
-    name: toolResult.toolName,
-    content: unwrappedResult,
-  })}</tool_response>`;
+): ToolResponsePromptTemplateResult {
+  return formatToolResponseWithMedia({
+    toolResult,
+    mediaStrategy: options?.mediaStrategy,
+    wrapContent: (content) =>
+      `<tool_response>${JSON.stringify({
+        name: toolResult.toolName,
+        content,
+      })}</tool_response>`,
+  });
 }
 
 export function createHermesToolResponseFormatter(
   options?: HermesToolResponseFormatterOptions
-): (toolResult: ToolResultPart) => string {
+): (toolResult: ToolResultPart) => ToolResponsePromptTemplateResult {
   return (toolResult) =>
     formatToolResponseAsHermesWithOptions(toolResult, options);
 }
 
-export function formatToolResponseAsHermes(toolResult: ToolResultPart): string {
+export function formatToolResponseAsHermes(
+  toolResult: ToolResultPart
+): ToolResponsePromptTemplateResult {
   return formatToolResponseAsHermesWithOptions(toolResult);
 }
 

--- a/src/core/prompts/morph-xml-prompt.ts
+++ b/src/core/prompts/morph-xml-prompt.ts
@@ -11,10 +11,9 @@ import {
   renderInputExamplesSection,
   safeStringifyInputExample,
 } from "./shared/input-examples";
-import {
-  type ToolResponseMediaStrategy,
-  unwrapToolResult,
-} from "./shared/tool-result-normalizer";
+import { formatToolResponseWithMedia } from "./shared/tool-response-with-media";
+import type { ToolResponseMediaStrategy } from "./shared/tool-result-normalizer";
+import type { ToolResponsePromptTemplateResult } from "./shared/tool-result-user-content";
 
 export function morphXmlSystemPromptTemplate(
   tools: LanguageModelV4FunctionTool[]
@@ -397,31 +396,32 @@ function formatXmlNode(
 function morphFormatToolResponseAsXmlWithOptions(
   toolResult: ToolResultPart,
   options?: MorphXmlToolResponseFormatterOptions
-): string {
-  const unwrappedResult = unwrapToolResult(
-    toolResult.output,
-    options?.mediaStrategy
-  );
-  const toolNameXml = `<tool_name>${toolResult.toolName}</tool_name>`;
-  const resultLines = formatXmlNode("result", unwrappedResult, 1);
-
-  return [
-    "<tool_response>",
-    `  ${toolNameXml}`,
-    ...resultLines,
-    "</tool_response>",
-  ].join("\n");
+): ToolResponsePromptTemplateResult {
+  return formatToolResponseWithMedia({
+    toolResult,
+    mediaStrategy: options?.mediaStrategy,
+    wrapContent: (content) => {
+      const toolNameXml = `<tool_name>${toolResult.toolName}</tool_name>`;
+      const resultLines = formatXmlNode("result", content, 1);
+      return [
+        "<tool_response>",
+        `  ${toolNameXml}`,
+        ...resultLines,
+        "</tool_response>",
+      ].join("\n");
+    },
+  });
 }
 
 export function createMorphXmlToolResponseFormatter(
   options?: MorphXmlToolResponseFormatterOptions
-): (toolResult: ToolResultPart) => string {
+): (toolResult: ToolResultPart) => ToolResponsePromptTemplateResult {
   return (toolResult) =>
     morphFormatToolResponseAsXmlWithOptions(toolResult, options);
 }
 
 export function morphFormatToolResponseAsXml(
   toolResult: ToolResultPart
-): string {
+): ToolResponsePromptTemplateResult {
   return morphFormatToolResponseAsXmlWithOptions(toolResult);
 }

--- a/src/core/prompts/qwen3coder-prompt.ts
+++ b/src/core/prompts/qwen3coder-prompt.ts
@@ -8,10 +8,9 @@ import {
   renderInputExamplesSection,
   safeStringifyInputExample,
 } from "./shared/input-examples";
-import {
-  type ToolResponseMediaStrategy,
-  unwrapToolResult,
-} from "./shared/tool-result-normalizer";
+import { formatToolResponseWithMedia } from "./shared/tool-response-with-media";
+import type { ToolResponseMediaStrategy } from "./shared/tool-result-normalizer";
+import type { ToolResponsePromptTemplateResult } from "./shared/tool-result-user-content";
 
 const QWEN3CODER_TOOL_HEADER =
   "# Tools\n\nYou have access to the following functions:\n\n";
@@ -241,24 +240,24 @@ function stringifyToolResponseContent(value: JSONValue): string {
 function formatToolResponseAsQwen3CoderXmlWithOptions(
   toolResult: ToolResultPart,
   options?: Qwen3CoderToolResponseFormatterOptions
-): string {
-  const unwrappedResult = unwrapToolResult(
-    toolResult.output,
-    options?.mediaStrategy
-  );
-  const content = stringifyToolResponseContent(unwrappedResult);
-  return `<tool_response>\n${content}\n</tool_response>`;
+): ToolResponsePromptTemplateResult {
+  return formatToolResponseWithMedia({
+    toolResult,
+    mediaStrategy: options?.mediaStrategy,
+    wrapContent: (content) =>
+      `<tool_response>\n${stringifyToolResponseContent(content)}\n</tool_response>`,
+  });
 }
 
 export function createQwen3CoderXmlToolResponseFormatter(
   options?: Qwen3CoderToolResponseFormatterOptions
-): (toolResult: ToolResultPart) => string {
+): (toolResult: ToolResultPart) => ToolResponsePromptTemplateResult {
   return (toolResult) =>
     formatToolResponseAsQwen3CoderXmlWithOptions(toolResult, options);
 }
 
 export function formatToolResponseAsQwen3CoderXml(
   toolResult: ToolResultPart
-): string {
+): ToolResponsePromptTemplateResult {
   return formatToolResponseAsQwen3CoderXmlWithOptions(toolResult);
 }

--- a/src/core/prompts/shared/tool-response-with-media.ts
+++ b/src/core/prompts/shared/tool-response-with-media.ts
@@ -19,7 +19,7 @@ import type {
  *
  * Default media strategy (`model`) projects tool `content` media into real
  * `file` parts while keeping protocol wrappers as adjacent text. Opt into
- * `placeholder` / `raw` / `auto` via `mediaStrategy` for text-only or raw
+ * `placeholder` or `auto` via `mediaStrategy` for text-only or capability-gated
  * paths.
  */
 export function formatToolResponseWithMedia(options: {

--- a/src/core/prompts/shared/tool-response-with-media.ts
+++ b/src/core/prompts/shared/tool-response-with-media.ts
@@ -1,0 +1,63 @@
+import type { JSONValue, LanguageModelV4FilePart } from "@ai-sdk/provider";
+import type { ToolResultPart } from "@ai-sdk/provider-utils";
+import { toTextPart } from "./text-part";
+import {
+  getMediaMode,
+  type ToolResponseMediaStrategy,
+} from "./tool-result-media-strategy";
+import {
+  normalizeToolResultForUserContent,
+  unwrapToolResult,
+} from "./tool-result-normalizer";
+import type {
+  ToolResponsePromptTemplateResult,
+  ToolResponseUserContentPart,
+} from "./tool-result-user-content";
+
+/**
+ * Format a tool result for the next model turn.
+ *
+ * Default media strategy (`model`) projects tool `content` media into real
+ * `file` parts while keeping protocol wrappers as adjacent text. Opt into
+ * `placeholder` / `raw` / `auto` via `mediaStrategy` for text-only or raw
+ * paths.
+ */
+export function formatToolResponseWithMedia(options: {
+  toolResult: ToolResultPart;
+  mediaStrategy?: ToolResponseMediaStrategy;
+  wrapContent: (content: JSONValue) => string;
+}): ToolResponsePromptTemplateResult {
+  const { toolResult, mediaStrategy, wrapContent } = options;
+  const mode = getMediaMode(mediaStrategy);
+
+  if (toolResult.output.type === "content" && mode === "model") {
+    const parts = normalizeToolResultForUserContent(
+      toolResult.output,
+      mediaStrategy
+    );
+    const fileParts = parts.filter(
+      (part): part is LanguageModelV4FilePart => part.type === "file"
+    );
+    const textBody = parts
+      .filter(
+        (
+          part
+        ): part is Extract<ToolResponseUserContentPart, { type: "text" }> =>
+          part.type === "text"
+      )
+      .map((part) => part.text)
+      .filter((text) => text.length > 0)
+      .join("\n");
+
+    const wrapped = wrapContent(textBody);
+
+    if (fileParts.length === 0) {
+      return wrapped;
+    }
+
+    return [toTextPart(wrapped), ...fileParts];
+  }
+
+  const unwrapped = unwrapToolResult(toolResult.output, mediaStrategy);
+  return wrapContent(unwrapped);
+}

--- a/src/core/prompts/shared/tool-result-media-strategy.ts
+++ b/src/core/prompts/shared/tool-result-media-strategy.ts
@@ -11,12 +11,12 @@ export interface ToolResponseMediaCapabilities {
  * How tool-result media (`content` parts) is projected into the next model
  * prompt.
  *
- * - `model` (default): convert to model-recognizable `text` / `file` parts
+ * - `model` (default): forward canonical `text` / `file` parts to the model
  * - `placeholder`: degrade media to text placeholders (text-only fallback)
- * - `raw`: keep original tool-result content parts as a JSON value
- * - `auto`: pass raw when `capabilities` enable the media kind; else placeholder
+ * - `auto`: keep original content parts when `capabilities` enable the media
+ *   kind; otherwise placeholder
  */
-export type ToolResponseMediaMode = "placeholder" | "raw" | "auto" | "model";
+export type ToolResponseMediaMode = "placeholder" | "auto" | "model";
 
 export interface ToolResponseMediaStrategy {
   capabilities?: ToolResponseMediaCapabilities;
@@ -49,10 +49,7 @@ export function shouldPassRawByStrategy(
   strategy?: ToolResponseMediaStrategy
 ): boolean {
   const mode = getMediaMode(strategy);
-  if (mode === "raw") {
-    return true;
-  }
-  if (mode === "placeholder" || mode === "model") {
+  if (mode !== "auto") {
     return false;
   }
 

--- a/src/core/prompts/shared/tool-result-media-strategy.ts
+++ b/src/core/prompts/shared/tool-result-media-strategy.ts
@@ -1,0 +1,60 @@
+export type ToolResponseMediaType = "image" | "audio" | "video" | "file";
+
+export interface ToolResponseMediaCapabilities {
+  audio?: boolean;
+  file?: boolean;
+  image?: boolean;
+  video?: boolean;
+}
+
+/**
+ * How tool-result media (`content` parts) is projected into the next model
+ * prompt.
+ *
+ * - `model` (default): convert to model-recognizable `text` / `file` parts
+ * - `placeholder`: degrade media to text placeholders (text-only fallback)
+ * - `raw`: keep original tool-result content parts as a JSON value
+ * - `auto`: pass raw when `capabilities` enable the media kind; else placeholder
+ */
+export type ToolResponseMediaMode = "placeholder" | "raw" | "auto" | "model";
+
+export interface ToolResponseMediaStrategy {
+  capabilities?: ToolResponseMediaCapabilities;
+  mode?: ToolResponseMediaMode;
+}
+
+export function getMediaMode(
+  strategy?: ToolResponseMediaStrategy
+): ToolResponseMediaMode {
+  return strategy?.mode ?? "model";
+}
+
+export function getMediaKindFromMediaType(
+  mediaType: string
+): ToolResponseMediaType {
+  if (mediaType.startsWith("image/") || mediaType === "image") {
+    return "image";
+  }
+  if (mediaType.startsWith("audio/") || mediaType === "audio") {
+    return "audio";
+  }
+  if (mediaType.startsWith("video/") || mediaType === "video") {
+    return "video";
+  }
+  return "file";
+}
+
+export function shouldPassRawByStrategy(
+  mediaKind: ToolResponseMediaType,
+  strategy?: ToolResponseMediaStrategy
+): boolean {
+  const mode = getMediaMode(strategy);
+  if (mode === "raw") {
+    return true;
+  }
+  if (mode === "placeholder" || mode === "model") {
+    return false;
+  }
+
+  return strategy?.capabilities?.[mediaKind] === true;
+}

--- a/src/core/prompts/shared/tool-result-normalizer.ts
+++ b/src/core/prompts/shared/tool-result-normalizer.ts
@@ -1,102 +1,25 @@
-import type {
-  JSONValue,
-  LanguageModelV4FilePart,
-  LanguageModelV4TextPart,
-} from "@ai-sdk/provider";
+import type { JSONValue, LanguageModelV4TextPart } from "@ai-sdk/provider";
 import type { ToolResultOutput } from "@ai-sdk/provider-utils";
 import { toTextPart } from "./text-part";
+import {
+  getMediaMode,
+  shouldPassRawByStrategy,
+  type ToolResponseMediaStrategy,
+} from "./tool-result-media-strategy";
+import {
+  formatContentPartPlaceholder,
+  getContentPartMediaKind,
+} from "./tool-result-placeholders";
+import { toModelContentPart } from "./tool-result-to-model-content";
+import type { ToolResponseUserContentPart } from "./tool-result-user-content";
 
-type ToolResponseMediaType = "image" | "audio" | "video" | "file";
-
-interface ToolResponseMediaCapabilities {
-  audio?: boolean;
-  file?: boolean;
-  image?: boolean;
-  video?: boolean;
-}
-
-type ToolResponseMediaMode = "placeholder" | "raw" | "auto" | "model";
-
-export interface ToolResponseMediaStrategy {
-  capabilities?: ToolResponseMediaCapabilities;
-  mode?: ToolResponseMediaMode;
-}
-
-export type ToolResponseUserContentPart =
-  | LanguageModelV4TextPart
-  | LanguageModelV4FilePart;
-
-function isMapping(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function getMediaKindFromMediaType(mediaType: string): ToolResponseMediaType {
-  if (mediaType.startsWith("image/")) {
-    return "image";
-  }
-  if (mediaType.startsWith("audio/")) {
-    return "audio";
-  }
-  if (mediaType.startsWith("video/")) {
-    return "video";
-  }
-  return "file";
-}
-
-function getContentPartMediaKind(part: unknown): ToolResponseMediaType | null {
-  const contentPart = isMapping(part) ? part : undefined;
-  const type = contentPart?.type;
-
-  switch (type) {
-    case "image-data":
-    case "image-url":
-    case "image-file-id":
-      return "image";
-    case "file":
-    case "file-data":
-    case "file-url":
-    case "file-id": {
-      const mediaType = contentPart?.mediaType;
-      if (typeof mediaType === "string") {
-        return getMediaKindFromMediaType(mediaType);
-      }
-      return "file";
-    }
-    case "media": {
-      const mediaType = contentPart?.mediaType;
-      if (typeof mediaType === "string") {
-        return getMediaKindFromMediaType(mediaType);
-      }
-      return "file";
-    }
-    default:
-      return null;
-  }
-}
-
-function shouldPassRawByStrategy(
-  mediaKind: ToolResponseMediaType,
-  strategy?: ToolResponseMediaStrategy
-): boolean {
-  const mode = getMediaMode(strategy);
-  if (mode === "raw") {
-    return true;
-  }
-  if (mode === "placeholder") {
-    return false;
-  }
-  if (mode === "model") {
-    return false;
-  }
-
-  return strategy?.capabilities?.[mediaKind] === true;
-}
-
-function getMediaMode(
-  strategy?: ToolResponseMediaStrategy
-): ToolResponseMediaMode {
-  return strategy?.mode ?? "placeholder";
-}
+export type {
+  ToolResponseMediaCapabilities,
+  ToolResponseMediaMode,
+  ToolResponseMediaStrategy,
+  ToolResponseMediaType,
+} from "./tool-result-media-strategy";
+export type { ToolResponseUserContentPart } from "./tool-result-user-content";
 
 function shouldPassRawContent(
   contentParts: unknown[],
@@ -106,10 +29,7 @@ function shouldPassRawContent(
   if (mode === "raw") {
     return true;
   }
-  if (mode === "placeholder") {
-    return false;
-  }
-  if (mode === "model") {
+  if (mode === "placeholder" || mode === "model") {
     return false;
   }
 
@@ -127,186 +47,6 @@ function shouldPassRawContent(
   }
 
   return hasSupportedMediaContent;
-}
-
-function formatIdPlaceholder(
-  label: "Image ID" | "File ID",
-  fileId: unknown
-): string {
-  const displayId =
-    typeof fileId === "string" ? fileId : JSON.stringify(fileId);
-  return `[${label}: ${displayId}]`;
-}
-
-interface TaggedFileData {
-  data?: unknown;
-  reference?: unknown;
-  text?: string;
-  type?: string;
-  url?: string;
-}
-
-/**
- * Placeholder for the canonical v4 `type: 'file'` content part whose `data`
- * is a tagged union (`data` / `url` / `reference` / `text`).
- */
-function formatTaggedFilePartPlaceholder(contentPart: {
-  data?: unknown;
-  mediaType?: string;
-  filename?: string;
-}): string {
-  const fileData = isMapping(contentPart.data)
-    ? (contentPart.data as TaggedFileData)
-    : undefined;
-  const mediaType = contentPart.mediaType ?? "application/octet-stream";
-  const isImage = mediaType.startsWith("image");
-
-  switch (fileData?.type) {
-    case "url":
-      return isImage
-        ? `[Image URL: ${fileData.url}]`
-        : `[File URL: ${fileData.url}]`;
-    case "reference":
-      return formatIdPlaceholder(
-        isImage ? "Image ID" : "File ID",
-        fileData.reference
-      );
-    case "text":
-      // Inline text documents are readable content; surface the text itself.
-      return fileData.text ?? "";
-    default: {
-      if (isImage) {
-        return `[Image: ${mediaType}]`;
-      }
-      if (contentPart.filename) {
-        return `[File: ${contentPart.filename} (${mediaType})]`;
-      }
-      return `[File: ${mediaType}]`;
-    }
-  }
-}
-
-function formatContentPartPlaceholder(part: unknown): string {
-  const contentPart = part as { type?: string };
-  switch (contentPart.type) {
-    case "text":
-      return (contentPart as { text?: string }).text ?? "";
-    case "file":
-      return formatTaggedFilePartPlaceholder(
-        contentPart as { data?: unknown; mediaType?: string; filename?: string }
-      );
-    case "image-data":
-      return `[Image: ${(contentPart as { mediaType?: string }).mediaType}]`;
-    case "image-url":
-      return `[Image URL: ${(contentPart as { url?: string }).url}]`;
-    case "image-file-id": {
-      const { fileId } = contentPart as { fileId?: unknown };
-      return formatIdPlaceholder("Image ID", fileId);
-    }
-    case "file-data": {
-      const filePart = contentPart as {
-        filename?: string;
-        mediaType?: string;
-      };
-      if (filePart.filename) {
-        return `[File: ${filePart.filename} (${filePart.mediaType})]`;
-      }
-      return `[File: ${filePart.mediaType}]`;
-    }
-    case "file-url":
-      return `[File URL: ${(contentPart as { url?: string }).url}]`;
-    case "file-id": {
-      const { fileId } = contentPart as { fileId?: unknown };
-      return formatIdPlaceholder("File ID", fileId);
-    }
-    case "media":
-      return `[Media: ${(contentPart as { mediaType?: string }).mediaType}]`;
-    case "custom":
-      return "[Custom content]";
-    default:
-      return "[Unknown content]";
-  }
-}
-
-function toFilePart(options: {
-  data: string;
-  mediaType: string;
-  filename?: string;
-  providerOptions?: LanguageModelV4FilePart["providerOptions"];
-}): LanguageModelV4FilePart {
-  return {
-    type: "file",
-    data: { type: "data", data: options.data },
-    mediaType: options.mediaType,
-    ...(options.filename === undefined ? {} : { filename: options.filename }),
-    ...(options.providerOptions === undefined
-      ? {}
-      : { providerOptions: options.providerOptions }),
-  };
-}
-
-function toModelContentPart(part: unknown): ToolResponseUserContentPart {
-  const contentPart = part as {
-    type?: string;
-    text?: string;
-    data?: string;
-    mediaType?: string;
-    url?: string;
-    filename?: string;
-    providerOptions?: LanguageModelV4TextPart["providerOptions"];
-  };
-
-  switch (contentPart.type) {
-    case "text":
-      return toTextPart(contentPart.text ?? "", contentPart.providerOptions);
-    case "file":
-      // Canonical v4 file part — already in LanguageModelV4FilePart shape
-      // (tagged `data` union, mediaType, optional filename).
-      return part as LanguageModelV4FilePart;
-    case "image-data":
-      return toFilePart({
-        data: contentPart.data ?? "",
-        mediaType: contentPart.mediaType ?? "image/*",
-        providerOptions: contentPart.providerOptions,
-      });
-    case "image-url":
-      return toFilePart({
-        data: contentPart.url ?? "",
-        mediaType: "image/*",
-        providerOptions: contentPart.providerOptions,
-      });
-    case "file-data":
-      return toFilePart({
-        data: contentPart.data ?? "",
-        mediaType: contentPart.mediaType ?? "application/octet-stream",
-        filename: contentPart.filename,
-        providerOptions: contentPart.providerOptions,
-      });
-    case "file-url":
-      return toFilePart({
-        data: contentPart.url ?? "",
-        mediaType: "application/octet-stream",
-        providerOptions: contentPart.providerOptions,
-      });
-    case "media":
-      return toFilePart({
-        data: contentPart.data ?? "",
-        mediaType: contentPart.mediaType ?? "application/octet-stream",
-        providerOptions: contentPart.providerOptions,
-      });
-    case "image-file-id":
-    case "file-id":
-    case "custom":
-      return toTextPart(
-        formatContentPartPlaceholder(part),
-        contentPart.providerOptions
-      );
-    default:
-      return toTextPart(
-        formatContentPartPlaceholder(part),
-        contentPart.providerOptions
-      );
-  }
 }
 
 function stringifyJsonValue(value: JSONValue): string {
@@ -340,6 +80,8 @@ export function unwrapToolResult(
         return parts as JSONValue;
       }
 
+      // model mode is handled by normalizeToolResultForUserContent; string
+      // serializers always degrade media to placeholders here.
       return parts.map(formatContentPartPlaceholder).join("\n");
     }
     default: {
@@ -353,7 +95,7 @@ export function normalizeToolResultForUserContent(
   result: ToolResultOutput,
   mediaStrategy?: ToolResponseMediaStrategy
 ): ToolResponseUserContentPart[] {
-  if (result.type === "content" && mediaStrategy?.mode === "model") {
+  if (result.type === "content" && getMediaMode(mediaStrategy) === "model") {
     return (result.value as unknown[]).map(toModelContentPart);
   }
 

--- a/src/core/prompts/shared/tool-result-normalizer.ts
+++ b/src/core/prompts/shared/tool-result-normalizer.ts
@@ -25,11 +25,7 @@ function shouldPassRawContent(
   contentParts: unknown[],
   strategy?: ToolResponseMediaStrategy
 ): boolean {
-  const mode = getMediaMode(strategy);
-  if (mode === "raw") {
-    return true;
-  }
-  if (mode === "placeholder" || mode === "model") {
+  if (getMediaMode(strategy) !== "auto") {
     return false;
   }
 

--- a/src/core/prompts/shared/tool-result-placeholders.ts
+++ b/src/core/prompts/shared/tool-result-placeholders.ts
@@ -1,0 +1,159 @@
+import {
+  getMediaKindFromMediaType,
+  type ToolResponseMediaType,
+} from "./tool-result-media-strategy";
+
+function isMapping(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatIdPlaceholder(
+  label: "Image ID" | "File ID",
+  fileId: unknown
+): string {
+  const displayId =
+    typeof fileId === "string" ? fileId : JSON.stringify(fileId);
+  return `[${label}: ${displayId}]`;
+}
+
+interface TaggedFileData {
+  data?: unknown;
+  reference?: unknown;
+  text?: string;
+  type?: string;
+  url?: unknown;
+}
+
+/**
+ * Placeholder for the canonical v4 `type: 'file'` content part whose `data`
+ * is a tagged union (`data` / `url` / `reference` / `text`).
+ */
+function formatTaggedFilePartPlaceholder(contentPart: {
+  data?: unknown;
+  mediaType?: string;
+  filename?: string;
+}): string {
+  const fileData = isMapping(contentPart.data)
+    ? (contentPart.data as TaggedFileData)
+    : undefined;
+  const mediaType = contentPart.mediaType ?? "application/octet-stream";
+  const isImage = getMediaKindFromMediaType(mediaType) === "image";
+
+  switch (fileData?.type) {
+    case "url":
+      return isImage
+        ? `[Image URL: ${String(fileData.url)}]`
+        : `[File URL: ${String(fileData.url)}]`;
+    case "reference":
+      return formatIdPlaceholder(
+        isImage ? "Image ID" : "File ID",
+        fileData.reference
+      );
+    case "text":
+      // Inline text documents are readable content; surface the text itself.
+      return fileData.text ?? "";
+    default: {
+      if (isImage) {
+        return `[Image: ${mediaType}]`;
+      }
+      if (contentPart.filename) {
+        return `[File: ${contentPart.filename} (${mediaType})]`;
+      }
+      return `[File: ${mediaType}]`;
+    }
+  }
+}
+
+export function formatContentPartPlaceholder(part: unknown): string {
+  const contentPart = part as { type?: string };
+  switch (contentPart.type) {
+    case "text":
+      return (contentPart as { text?: string }).text ?? "";
+    case "file":
+      return formatTaggedFilePartPlaceholder(
+        contentPart as { data?: unknown; mediaType?: string; filename?: string }
+      );
+    case "image-data":
+      return `[Image: ${(contentPart as { mediaType?: string }).mediaType}]`;
+    case "image-url":
+      return `[Image URL: ${(contentPart as { url?: string }).url}]`;
+    case "image-file-id": {
+      const { fileId } = contentPart as { fileId?: unknown };
+      return formatIdPlaceholder("Image ID", fileId);
+    }
+    case "image-file-reference": {
+      const { providerReference } = contentPart as {
+        providerReference?: unknown;
+      };
+      return formatIdPlaceholder("Image ID", providerReference);
+    }
+    case "file-data": {
+      const filePart = contentPart as {
+        filename?: string;
+        mediaType?: string;
+      };
+      if (filePart.filename) {
+        return `[File: ${filePart.filename} (${filePart.mediaType})]`;
+      }
+      return `[File: ${filePart.mediaType}]`;
+    }
+    case "file-url":
+      return `[File URL: ${(contentPart as { url?: string }).url}]`;
+    case "file-id": {
+      const { fileId } = contentPart as { fileId?: unknown };
+      return formatIdPlaceholder("File ID", fileId);
+    }
+    case "file-reference": {
+      const { providerReference } = contentPart as {
+        providerReference?: unknown;
+      };
+      return formatIdPlaceholder("File ID", providerReference);
+    }
+    case "media":
+      return `[Media: ${(contentPart as { mediaType?: string }).mediaType}]`;
+    case "custom":
+      return "[Custom content]";
+    default:
+      return "[Unknown content]";
+  }
+}
+
+const IMAGE_PART_TYPES = new Set([
+  "image-data",
+  "image-url",
+  "image-file-id",
+  "image-file-reference",
+]);
+
+const FILE_LIKE_PART_TYPES = new Set([
+  "file",
+  "file-data",
+  "file-url",
+  "file-id",
+  "file-reference",
+  "media",
+]);
+
+export function getContentPartMediaKind(
+  part: unknown
+): ToolResponseMediaType | null {
+  const contentPart = isMapping(part) ? part : undefined;
+  const type = contentPart?.type;
+  if (typeof type !== "string") {
+    return null;
+  }
+
+  if (IMAGE_PART_TYPES.has(type)) {
+    return "image";
+  }
+
+  if (!FILE_LIKE_PART_TYPES.has(type)) {
+    return null;
+  }
+
+  const mediaType = contentPart?.mediaType;
+  if (typeof mediaType === "string") {
+    return getMediaKindFromMediaType(mediaType);
+  }
+  return "file";
+}

--- a/src/core/prompts/shared/tool-result-to-model-content.ts
+++ b/src/core/prompts/shared/tool-result-to-model-content.ts
@@ -1,0 +1,216 @@
+import type {
+  LanguageModelV4FilePart,
+  SharedV4FileData,
+  SharedV4ProviderReference,
+} from "@ai-sdk/provider";
+import { toTextPart } from "./text-part";
+import { formatContentPartPlaceholder } from "./tool-result-placeholders";
+import type { ToolResponseUserContentPart } from "./tool-result-user-content";
+
+interface ToolContentPartLike {
+  data?: string;
+  fileId?: unknown;
+  filename?: string;
+  mediaType?: string;
+  providerOptions?: LanguageModelV4FilePart["providerOptions"];
+  providerReference?: unknown;
+  text?: string;
+  type?: string;
+  url?: string;
+}
+
+function isMapping(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isProviderReference(
+  value: unknown
+): value is SharedV4ProviderReference {
+  if (!isMapping(value) || "type" in value) {
+    return false;
+  }
+  const entries = Object.entries(value);
+  if (entries.length === 0) {
+    return false;
+  }
+  return entries.every(
+    ([, entryValue]) => typeof entryValue === "string" && entryValue.length > 0
+  );
+}
+
+function parseUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+function toFilePart(options: {
+  data: SharedV4FileData;
+  mediaType: string;
+  filename?: string;
+  providerOptions?: LanguageModelV4FilePart["providerOptions"];
+}): LanguageModelV4FilePart {
+  return {
+    type: "file",
+    data: options.data,
+    mediaType: options.mediaType,
+    ...(options.filename === undefined ? {} : { filename: options.filename }),
+    ...(options.providerOptions === undefined
+      ? {}
+      : { providerOptions: options.providerOptions }),
+  };
+}
+
+function asPlaceholder(
+  part: unknown,
+  providerOptions?: LanguageModelV4FilePart["providerOptions"]
+): ToolResponseUserContentPart {
+  return toTextPart(formatContentPartPlaceholder(part), providerOptions);
+}
+
+function toUrlFilePart(
+  part: unknown,
+  url: string | undefined,
+  mediaType: string,
+  providerOptions?: LanguageModelV4FilePart["providerOptions"]
+): ToolResponseUserContentPart {
+  const parsed = parseUrl(url ?? "");
+  if (!parsed) {
+    return asPlaceholder(part, providerOptions);
+  }
+  return toFilePart({
+    data: { type: "url", url: parsed },
+    mediaType,
+    providerOptions,
+  });
+}
+
+function toReferenceFilePart(
+  part: unknown,
+  reference: unknown,
+  mediaType: string,
+  providerOptions?: LanguageModelV4FilePart["providerOptions"]
+): ToolResponseUserContentPart {
+  if (!isProviderReference(reference)) {
+    return asPlaceholder(part, providerOptions);
+  }
+  return toFilePart({
+    data: { type: "reference", reference },
+    mediaType,
+    providerOptions,
+  });
+}
+
+function normalizeCanonicalFilePart(
+  part: unknown,
+  providerOptions?: LanguageModelV4FilePart["providerOptions"]
+): ToolResponseUserContentPart {
+  const filePart = part as LanguageModelV4FilePart;
+  const data = filePart.data as SharedV4FileData | undefined;
+
+  if (!data || typeof data !== "object" || !("type" in data)) {
+    return asPlaceholder(part, providerOptions);
+  }
+
+  if (data.type !== "url") {
+    return filePart;
+  }
+
+  const rawUrl = data.url as unknown;
+  if (rawUrl instanceof URL) {
+    return filePart;
+  }
+  if (typeof rawUrl !== "string") {
+    return asPlaceholder(part, providerOptions);
+  }
+
+  const parsed = parseUrl(rawUrl);
+  if (!parsed) {
+    return asPlaceholder(part, providerOptions);
+  }
+  return {
+    ...filePart,
+    data: { type: "url", url: parsed },
+  };
+}
+
+/**
+ * Convert a tool-result content part into a model prompt part.
+ *
+ * Prefer AI SDK v4/v7 canonical `{ type: "file", data: SharedV4FileData }`.
+ * Deprecated image/file aliases are upgraded when possible; otherwise they
+ * fall back to a text placeholder.
+ */
+export function toModelContentPart(part: unknown): ToolResponseUserContentPart {
+  const contentPart = part as ToolContentPartLike;
+  const { providerOptions } = contentPart;
+
+  switch (contentPart.type) {
+    case "text":
+      return toTextPart(contentPart.text ?? "", providerOptions);
+    case "file":
+      return normalizeCanonicalFilePart(part, providerOptions);
+    case "image-data":
+      return toFilePart({
+        data: { type: "data", data: contentPart.data ?? "" },
+        mediaType: contentPart.mediaType ?? "image",
+        providerOptions,
+      });
+    case "image-url":
+      return toUrlFilePart(part, contentPart.url, "image", providerOptions);
+    case "file-data":
+      return toFilePart({
+        data: { type: "data", data: contentPart.data ?? "" },
+        mediaType: contentPart.mediaType ?? "application/octet-stream",
+        filename: contentPart.filename,
+        providerOptions,
+      });
+    case "file-url":
+      return toUrlFilePart(
+        part,
+        contentPart.url,
+        contentPart.mediaType ?? "application/octet-stream",
+        providerOptions
+      );
+    case "media":
+      return toFilePart({
+        data: { type: "data", data: contentPart.data ?? "" },
+        mediaType: contentPart.mediaType ?? "application/octet-stream",
+        providerOptions,
+      });
+    case "image-file-id":
+      return toReferenceFilePart(
+        part,
+        contentPart.fileId,
+        "image",
+        providerOptions
+      );
+    case "file-id":
+      return toReferenceFilePart(
+        part,
+        contentPart.fileId,
+        contentPart.mediaType ?? "application/octet-stream",
+        providerOptions
+      );
+    case "image-file-reference":
+      return toReferenceFilePart(
+        part,
+        contentPart.providerReference,
+        "image",
+        providerOptions
+      );
+    case "file-reference":
+      return toReferenceFilePart(
+        part,
+        contentPart.providerReference,
+        contentPart.mediaType ?? "application/octet-stream",
+        providerOptions
+      );
+    case "custom":
+      return asPlaceholder(part, providerOptions);
+    default:
+      return asPlaceholder(part, providerOptions);
+  }
+}

--- a/src/core/prompts/shared/tool-result-to-model-content.ts
+++ b/src/core/prompts/shared/tool-result-to-model-content.ts
@@ -1,6 +1,7 @@
 import type {
   LanguageModelV4FilePart,
   SharedV4FileData,
+  SharedV4ProviderReference,
 } from "@ai-sdk/provider";
 import { toTextPart } from "./text-part";
 import { formatContentPartPlaceholder } from "./tool-result-placeholders";
@@ -21,11 +22,55 @@ function parseUrl(url: string): URL | null {
   }
 }
 
+function isMapping(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isInlineFileData(value: unknown): value is string | Uint8Array {
+  return typeof value === "string" || value instanceof Uint8Array;
+}
+
+function isProviderReference(
+  value: unknown
+): value is SharedV4ProviderReference {
+  if (!isMapping(value) || "type" in value) {
+    return false;
+  }
+  const entries = Object.entries(value);
+  if (entries.length === 0) {
+    return false;
+  }
+  return entries.every(([, entryValue]) => typeof entryValue === "string");
+}
+
+function toValidatedFilePart(options: {
+  data: SharedV4FileData;
+  mediaType: string;
+  filename?: unknown;
+  providerOptions?: LanguageModelV4FilePart["providerOptions"];
+}): LanguageModelV4FilePart {
+  return {
+    type: "file",
+    data: options.data,
+    mediaType: options.mediaType,
+    ...(typeof options.filename === "string"
+      ? { filename: options.filename }
+      : {}),
+    ...(options.providerOptions === undefined
+      ? {}
+      : { providerOptions: options.providerOptions }),
+  };
+}
+
 /**
  * Pass through canonical tool-result content parts for model prompts.
  *
- * Only `text` and v4/v7 `{ type: "file", data: SharedV4FileData }` are kept as
- * structured parts. Anything else becomes a text placeholder.
+ * Only `text` and valid v4/v7 `{ type: "file", data: SharedV4FileData }` parts
+ * are kept as structured content. Anything else becomes a text placeholder.
  */
 export function toModelContentPart(part: unknown): ToolResponseUserContentPart {
   const contentPart = part as {
@@ -49,32 +94,82 @@ function normalizeCanonicalFilePart(
   part: unknown,
   providerOptions?: LanguageModelV4FilePart["providerOptions"]
 ): ToolResponseUserContentPart {
-  const filePart = part as LanguageModelV4FilePart;
-  const data = filePart.data as SharedV4FileData | undefined;
-
-  if (!data || typeof data !== "object" || !("type" in data)) {
-    return asPlaceholder(part, providerOptions);
-  }
-
-  if (data.type !== "url") {
-    return filePart;
-  }
-
-  // Accept string urls from JSON-deserialized payloads and normalize to URL.
-  const rawUrl = data.url as unknown;
-  if (rawUrl instanceof URL) {
-    return filePart;
-  }
-  if (typeof rawUrl !== "string") {
-    return asPlaceholder(part, providerOptions);
-  }
-
-  const parsed = parseUrl(rawUrl);
-  if (!parsed) {
-    return asPlaceholder(part, providerOptions);
-  }
-  return {
-    ...filePart,
-    data: { type: "url", url: parsed },
+  const { mediaType, filename, data } = part as {
+    mediaType?: unknown;
+    filename?: unknown;
+    data?: unknown;
   };
+
+  if (!isNonEmptyString(mediaType)) {
+    return asPlaceholder(part, providerOptions);
+  }
+
+  if (!(isMapping(data) && "type" in data)) {
+    return asPlaceholder(part, providerOptions);
+  }
+
+  switch (data.type) {
+    case "data": {
+      const { data: payload } = data;
+      if (!isInlineFileData(payload)) {
+        return asPlaceholder(part, providerOptions);
+      }
+      return toValidatedFilePart({
+        data: { type: "data", data: payload },
+        mediaType,
+        filename,
+        providerOptions,
+      });
+    }
+    case "url": {
+      const { url: rawUrl } = data;
+      if (rawUrl instanceof URL) {
+        return toValidatedFilePart({
+          data: { type: "url", url: rawUrl },
+          mediaType,
+          filename,
+          providerOptions,
+        });
+      }
+      if (typeof rawUrl !== "string") {
+        return asPlaceholder(part, providerOptions);
+      }
+      const parsed = parseUrl(rawUrl);
+      if (!parsed) {
+        return asPlaceholder(part, providerOptions);
+      }
+      return toValidatedFilePart({
+        data: { type: "url", url: parsed },
+        mediaType,
+        filename,
+        providerOptions,
+      });
+    }
+    case "reference": {
+      const { reference } = data;
+      if (!isProviderReference(reference)) {
+        return asPlaceholder(part, providerOptions);
+      }
+      return toValidatedFilePart({
+        data: { type: "reference", reference },
+        mediaType,
+        filename,
+        providerOptions,
+      });
+    }
+    case "text": {
+      const { text } = data;
+      if (typeof text !== "string") {
+        return asPlaceholder(part, providerOptions);
+      }
+      return toValidatedFilePart({
+        data: { type: "text", text },
+        mediaType,
+        filename,
+        providerOptions,
+      });
+    }
+    default:
+      return asPlaceholder(part, providerOptions);
+  }
 }

--- a/src/core/prompts/shared/tool-result-to-model-content.ts
+++ b/src/core/prompts/shared/tool-result-to-model-content.ts
@@ -7,6 +7,9 @@ import { toTextPart } from "./text-part";
 import { formatContentPartPlaceholder } from "./tool-result-placeholders";
 import type { ToolResponseUserContentPart } from "./tool-result-user-content";
 
+/** Only network-fetchable schemes are forwarded as model file URL parts. */
+const ALLOWED_FILE_URL_PROTOCOLS = new Set(["http:", "https:"]);
+
 function asPlaceholder(
   part: unknown,
   providerOptions?: LanguageModelV4FilePart["providerOptions"]
@@ -20,6 +23,33 @@ function parseUrl(url: string): URL | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Normalize and validate a file-part URL for model forwarding.
+ *
+ * Accepts either a `URL` instance or a string (JSON-deserialized tool results
+ * often lose the `URL` class). Only `http:` / `https:` with a non-empty host
+ * are allowed; everything else degrades to a placeholder.
+ */
+function toSafeFileUrl(rawUrl: unknown): URL | null {
+  let url: URL | null = null;
+  if (rawUrl instanceof URL) {
+    url = rawUrl;
+  } else if (typeof rawUrl === "string") {
+    url = parseUrl(rawUrl);
+  }
+
+  if (!url) {
+    return null;
+  }
+  if (!ALLOWED_FILE_URL_PROTOCOLS.has(url.protocol)) {
+    return null;
+  }
+  if (url.hostname.length === 0) {
+    return null;
+  }
+  return url;
 }
 
 function isMapping(value: unknown): value is Record<string, unknown> {
@@ -123,23 +153,12 @@ function normalizeCanonicalFilePart(
     }
     case "url": {
       const { url: rawUrl } = data;
-      if (rawUrl instanceof URL) {
-        return toValidatedFilePart({
-          data: { type: "url", url: rawUrl },
-          mediaType,
-          filename,
-          providerOptions,
-        });
-      }
-      if (typeof rawUrl !== "string") {
-        return asPlaceholder(part, providerOptions);
-      }
-      const parsed = parseUrl(rawUrl);
-      if (!parsed) {
+      const safeUrl = toSafeFileUrl(rawUrl);
+      if (!safeUrl) {
         return asPlaceholder(part, providerOptions);
       }
       return toValidatedFilePart({
-        data: { type: "url", url: parsed },
+        data: { type: "url", url: safeUrl },
         mediaType,
         filename,
         providerOptions,

--- a/src/core/prompts/shared/tool-result-to-model-content.ts
+++ b/src/core/prompts/shared/tool-result-to-model-content.ts
@@ -1,41 +1,16 @@
 import type {
   LanguageModelV4FilePart,
   SharedV4FileData,
-  SharedV4ProviderReference,
 } from "@ai-sdk/provider";
 import { toTextPart } from "./text-part";
 import { formatContentPartPlaceholder } from "./tool-result-placeholders";
 import type { ToolResponseUserContentPart } from "./tool-result-user-content";
 
-interface ToolContentPartLike {
-  data?: string;
-  fileId?: unknown;
-  filename?: string;
-  mediaType?: string;
-  providerOptions?: LanguageModelV4FilePart["providerOptions"];
-  providerReference?: unknown;
-  text?: string;
-  type?: string;
-  url?: string;
-}
-
-function isMapping(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isProviderReference(
-  value: unknown
-): value is SharedV4ProviderReference {
-  if (!isMapping(value) || "type" in value) {
-    return false;
-  }
-  const entries = Object.entries(value);
-  if (entries.length === 0) {
-    return false;
-  }
-  return entries.every(
-    ([, entryValue]) => typeof entryValue === "string" && entryValue.length > 0
-  );
+function asPlaceholder(
+  part: unknown,
+  providerOptions?: LanguageModelV4FilePart["providerOptions"]
+): ToolResponseUserContentPart {
+  return toTextPart(formatContentPartPlaceholder(part), providerOptions);
 }
 
 function parseUrl(url: string): URL | null {
@@ -46,61 +21,28 @@ function parseUrl(url: string): URL | null {
   }
 }
 
-function toFilePart(options: {
-  data: SharedV4FileData;
-  mediaType: string;
-  filename?: string;
-  providerOptions?: LanguageModelV4FilePart["providerOptions"];
-}): LanguageModelV4FilePart {
-  return {
-    type: "file",
-    data: options.data,
-    mediaType: options.mediaType,
-    ...(options.filename === undefined ? {} : { filename: options.filename }),
-    ...(options.providerOptions === undefined
-      ? {}
-      : { providerOptions: options.providerOptions }),
+/**
+ * Pass through canonical tool-result content parts for model prompts.
+ *
+ * Only `text` and v4/v7 `{ type: "file", data: SharedV4FileData }` are kept as
+ * structured parts. Anything else becomes a text placeholder.
+ */
+export function toModelContentPart(part: unknown): ToolResponseUserContentPart {
+  const contentPart = part as {
+    type?: string;
+    text?: string;
+    providerOptions?: LanguageModelV4FilePart["providerOptions"];
   };
-}
 
-function asPlaceholder(
-  part: unknown,
-  providerOptions?: LanguageModelV4FilePart["providerOptions"]
-): ToolResponseUserContentPart {
-  return toTextPart(formatContentPartPlaceholder(part), providerOptions);
-}
-
-function toUrlFilePart(
-  part: unknown,
-  url: string | undefined,
-  mediaType: string,
-  providerOptions?: LanguageModelV4FilePart["providerOptions"]
-): ToolResponseUserContentPart {
-  const parsed = parseUrl(url ?? "");
-  if (!parsed) {
-    return asPlaceholder(part, providerOptions);
+  if (contentPart.type === "text") {
+    return toTextPart(contentPart.text ?? "", contentPart.providerOptions);
   }
-  return toFilePart({
-    data: { type: "url", url: parsed },
-    mediaType,
-    providerOptions,
-  });
-}
 
-function toReferenceFilePart(
-  part: unknown,
-  reference: unknown,
-  mediaType: string,
-  providerOptions?: LanguageModelV4FilePart["providerOptions"]
-): ToolResponseUserContentPart {
-  if (!isProviderReference(reference)) {
-    return asPlaceholder(part, providerOptions);
+  if (contentPart.type === "file") {
+    return normalizeCanonicalFilePart(part, contentPart.providerOptions);
   }
-  return toFilePart({
-    data: { type: "reference", reference },
-    mediaType,
-    providerOptions,
-  });
+
+  return asPlaceholder(part, contentPart.providerOptions);
 }
 
 function normalizeCanonicalFilePart(
@@ -118,6 +60,7 @@ function normalizeCanonicalFilePart(
     return filePart;
   }
 
+  // Accept string urls from JSON-deserialized payloads and normalize to URL.
   const rawUrl = data.url as unknown;
   if (rawUrl instanceof URL) {
     return filePart;
@@ -134,83 +77,4 @@ function normalizeCanonicalFilePart(
     ...filePart,
     data: { type: "url", url: parsed },
   };
-}
-
-/**
- * Convert a tool-result content part into a model prompt part.
- *
- * Prefer AI SDK v4/v7 canonical `{ type: "file", data: SharedV4FileData }`.
- * Deprecated image/file aliases are upgraded when possible; otherwise they
- * fall back to a text placeholder.
- */
-export function toModelContentPart(part: unknown): ToolResponseUserContentPart {
-  const contentPart = part as ToolContentPartLike;
-  const { providerOptions } = contentPart;
-
-  switch (contentPart.type) {
-    case "text":
-      return toTextPart(contentPart.text ?? "", providerOptions);
-    case "file":
-      return normalizeCanonicalFilePart(part, providerOptions);
-    case "image-data":
-      return toFilePart({
-        data: { type: "data", data: contentPart.data ?? "" },
-        mediaType: contentPart.mediaType ?? "image",
-        providerOptions,
-      });
-    case "image-url":
-      return toUrlFilePart(part, contentPart.url, "image", providerOptions);
-    case "file-data":
-      return toFilePart({
-        data: { type: "data", data: contentPart.data ?? "" },
-        mediaType: contentPart.mediaType ?? "application/octet-stream",
-        filename: contentPart.filename,
-        providerOptions,
-      });
-    case "file-url":
-      return toUrlFilePart(
-        part,
-        contentPart.url,
-        contentPart.mediaType ?? "application/octet-stream",
-        providerOptions
-      );
-    case "media":
-      return toFilePart({
-        data: { type: "data", data: contentPart.data ?? "" },
-        mediaType: contentPart.mediaType ?? "application/octet-stream",
-        providerOptions,
-      });
-    case "image-file-id":
-      return toReferenceFilePart(
-        part,
-        contentPart.fileId,
-        "image",
-        providerOptions
-      );
-    case "file-id":
-      return toReferenceFilePart(
-        part,
-        contentPart.fileId,
-        contentPart.mediaType ?? "application/octet-stream",
-        providerOptions
-      );
-    case "image-file-reference":
-      return toReferenceFilePart(
-        part,
-        contentPart.providerReference,
-        "image",
-        providerOptions
-      );
-    case "file-reference":
-      return toReferenceFilePart(
-        part,
-        contentPart.providerReference,
-        contentPart.mediaType ?? "application/octet-stream",
-        providerOptions
-      );
-    case "custom":
-      return asPlaceholder(part, providerOptions);
-    default:
-      return asPlaceholder(part, providerOptions);
-  }
 }

--- a/src/core/prompts/shared/tool-result-user-content.ts
+++ b/src/core/prompts/shared/tool-result-user-content.ts
@@ -1,0 +1,12 @@
+import type {
+  LanguageModelV4FilePart,
+  LanguageModelV4TextPart,
+} from "@ai-sdk/provider";
+
+export type ToolResponseUserContentPart =
+  | LanguageModelV4TextPart
+  | LanguageModelV4FilePart;
+
+export type ToolResponsePromptTemplateResult =
+  | string
+  | ToolResponseUserContentPart[];

--- a/src/core/prompts/shared/tool-role-to-user-message.ts
+++ b/src/core/prompts/shared/tool-role-to-user-message.ts
@@ -12,12 +12,16 @@ import { toTextPart } from "./text-part";
 import {
   normalizeToolResultForUserContent,
   type ToolResponseMediaStrategy,
-  type ToolResponseUserContentPart,
 } from "./tool-result-normalizer";
+import type {
+  ToolResponsePromptTemplateResult,
+  ToolResponseUserContentPart,
+} from "./tool-result-user-content";
 
-export type ToolResponsePromptTemplateResult =
-  | string
-  | ToolResponseUserContentPart[];
+export type {
+  ToolResponsePromptTemplateResult,
+  ToolResponseUserContentPart,
+} from "./tool-result-user-content";
 
 function formatApprovalResponse(part: ToolApprovalResponse): string {
   const status = part.approved ? "Approved" : "Denied";

--- a/src/core/prompts/yaml-xml-prompt.ts
+++ b/src/core/prompts/yaml-xml-prompt.ts
@@ -80,6 +80,8 @@ function renderYamlXmlInputExample(toolName: string, input: unknown): string {
   return `<${safeToolName}>\n${escapedYamlBody}\n</${safeToolName}>`;
 }
 
-export function formatToolResponseAsYaml(toolResult: ToolResultPart): string {
+export function formatToolResponseAsYaml(
+  toolResult: ToolResultPart
+): ReturnType<typeof morphFormatToolResponseAsXml> {
   return morphFormatToolResponseAsXml(toolResult);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,38 @@
 
 // Core Protocols (Agnostic)
 
+// Tool-response formatters + media strategy
+export {
+  createHermesToolResponseFormatter,
+  formatToolResponseAsHermes,
+  hermesSystemPromptTemplate,
+} from "./core/prompts/hermes-prompt";
+export {
+  createMorphXmlToolResponseFormatter,
+  morphFormatToolResponseAsXml,
+  morphXmlSystemPromptTemplate,
+} from "./core/prompts/morph-xml-prompt";
+export {
+  createQwen3CoderXmlToolResponseFormatter,
+  formatToolResponseAsQwen3CoderXml,
+  qwen3coderSystemPromptTemplate,
+} from "./core/prompts/qwen3coder-prompt";
+export type {
+  ToolResponseMediaCapabilities,
+  ToolResponseMediaMode,
+  ToolResponseMediaStrategy,
+  ToolResponseMediaType,
+  ToolResponseUserContentPart,
+} from "./core/prompts/shared/tool-result-normalizer";
+export type { ToolResponsePromptTemplateResult } from "./core/prompts/shared/tool-result-user-content";
+export {
+  createUserContentToolResponseTemplate,
+  toolRoleContentToUserTextMessage,
+} from "./core/prompts/shared/tool-role-to-user-message";
+export {
+  formatToolResponseAsYaml,
+  yamlXmlSystemPromptTemplate,
+} from "./core/prompts/yaml-xml-prompt";
 export * from "./core/protocols/hermes-protocol";
 export type { MorphXmlProtocolOptions } from "./core/protocols/morph-xml-protocol";
 export { morphXmlProtocol } from "./core/protocols/morph-xml-protocol";
@@ -13,6 +45,7 @@ export {
 } from "./core/protocols/qwen3coder-protocol";
 export type { YamlXmlProtocolOptions } from "./core/protocols/yaml-xml-protocol";
 export { yamlXmlProtocol } from "./core/protocols/yaml-xml-protocol";
+
 // Utilities (Agnostic)
 export * from "./core/utils/debug";
 export * from "./core/utils/dynamic-tool-schema";


### PR DESCRIPTION
## Summary

- Default `mediaStrategy.mode` is now `model`: tool-result images/files are projected as AI SDK v4/v7 canonical `file` parts (`data` / `url` / `reference`) instead of text placeholders.
- Protocol tool-response formatters (Hermes, Morph XML, Qwen3-Coder, YAML XML) emit hybrid user content: protocol text wrappers plus adjacent `file` parts when media is present.
- Text-only fallback remains available via `mediaStrategy: { mode: "placeholder" }`.
- Public exports for formatter factories and media strategy types; README documents the new default.
- Patch changeset included.

## Test plan

- [x] `pnpm check` (types + biome)
- [x] `pnpm test` (2357 tests)
- [ ] CI green on PR
- [ ] Spot-check a vision tool loop if available (screenshot tool → next turn receives real file parts)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tool-result media now passes to the next turn as real v4/v7 `file` parts by default. Protocol formatters output hybrid content: protocol text plus adjacent `file` parts when media exists.

- New Features
  - Default `mediaStrategy.mode` is `model`; use `mediaStrategy: { mode: "placeholder" }` for text-only, or `auto` with capabilities; removed `raw`.
  - Only canonical `{ type: "file", data: ... }` parts pass through; malformed/unknown shapes fall back to placeholders. String URLs are normalized to `URL` objects, and only `http`/`https` URLs are forwarded; other schemes become placeholders.
  - Public exports include formatter factories, system prompt templates, and a user-content template; YAML XML tool responses reuse the Morph formatter. README updated.

- Migration
  - Formatter functions may return a string or an array of parts. For string-only output, pass `mediaStrategy: { mode: "placeholder" }`.
  - User-message images are unchanged and pass through as-is.

<sup>Written for commit 9f21c11b1326711d5f3eeb40413100dd942a30e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

