### PR TITLE
perf: cache tool/property tag regexes in morph-xml hot paths

### DIFF
--- a/.changeset/perf-regex-caching.md
+++ b/.changeset/perf-regex-caching.md
@@ -1,0 +1,6 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+Cache tool end-tag and schema property tag regexes in the morph-xml
+streaming hot paths instead of recompiling them on every chunk.

--- a/src/core/protocols/morph-xml-progress-analysis.ts
+++ b/src/core/protocols/morph-xml-progress-analysis.ts
@@ -3,6 +3,54 @@ import { unwrapJsonSchema } from "../../schema-coerce";
 import { escapeRegExp } from "../utils/regex";
 import { NAME_CHAR_RE, WHITESPACE_REGEX } from "../utils/regex-constants";
 
+// Module-level regex caches keyed by schema property name, mirroring
+// selfClosingTagCache in xml-tool-tag-scanner.ts. These patterns are rebuilt
+// on every streaming progress emission otherwise (once per chunk per
+// property). The keyspace is bounded by schema property names seen by the
+// process, so eviction is unnecessary. `lastIndex` is reset on every lookup
+// so cached global-flag patterns always scan from the start.
+function getCachedPattern(
+  cache: Map<string, RegExp>,
+  key: string,
+  build: (escapedKey: string) => RegExp
+): RegExp {
+  let pattern = cache.get(key);
+  if (!pattern) {
+    pattern = build(escapeRegExp(key));
+    cache.set(key, pattern);
+  }
+  pattern.lastIndex = 0;
+  return pattern;
+}
+
+const propertyOpenOrSelfClosingTagCache = new Map<string, RegExp>();
+const propertyOpenTagCache = new Map<string, RegExp>();
+const propertyCloseTagCache = new Map<string, RegExp>();
+
+function getPropertyOpenOrSelfClosingTagPattern(name: string): RegExp {
+  return getCachedPattern(
+    propertyOpenOrSelfClosingTagCache,
+    name,
+    (escaped) => new RegExp(`<${escaped}(?:\\s[^>]*)?\\s*/?>`, "i")
+  );
+}
+
+function getPropertyOpenTagPattern(name: string): RegExp {
+  return getCachedPattern(
+    propertyOpenTagCache,
+    name,
+    (escaped) => new RegExp(`<${escaped}(?:\\s[^>]*)?>`, "gi")
+  );
+}
+
+function getPropertyCloseTagPattern(name: string): RegExp {
+  return getCachedPattern(
+    propertyCloseTagCache,
+    name,
+    (escaped) => new RegExp(`</\\s*${escaped}\\s*>`, "gi")
+  );
+}
+
 function parseXmlTagName(rawTagBody: string): string {
   let index = 0;
   while (
@@ -443,10 +491,7 @@ export function plainTextBodyFallback(
     getRequiredMessageStringProperty(normalizedSchema) === propertyName;
   if (schemaProperties && !allowsPlainTextWithSchemaTags) {
     for (const name of schemaProperties) {
-      const propertyTagPattern = new RegExp(
-        `<${escapeRegExp(name)}(?:\\s[^>]*)?\\s*/?>`,
-        "i"
-      );
+      const propertyTagPattern = getPropertyOpenOrSelfClosingTagPattern(name);
       if (propertyTagPattern.test(normalized)) {
         return null;
       }
@@ -480,11 +525,8 @@ export function findTrailingUnclosedStringTag(options: {
   let bestOpenIndex = -1;
 
   for (const name of options.stringPropertyNames) {
-    const openPattern = new RegExp(
-      `<${escapeRegExp(name)}(?:\\s[^>]*)?>`,
-      "gi"
-    );
-    const closePattern = new RegExp(`</\\s*${escapeRegExp(name)}\\s*>`, "gi");
+    const openPattern = getPropertyOpenTagPattern(name);
+    const closePattern = getPropertyCloseTagPattern(name);
 
     let lastOpen = -1;
     for (const match of options.toolContent.matchAll(openPattern)) {
@@ -519,10 +561,7 @@ export function buildEmptyTrailingStringTagProgressContent(options: {
   tagName: string;
   toolContent: string;
 }): string | null {
-  const openPattern = new RegExp(
-    `<${escapeRegExp(options.tagName)}(?:\\s[^>]*)?>`,
-    "gi"
-  );
+  const openPattern = getPropertyOpenTagPattern(options.tagName);
   let lastOpenEnd = -1;
 
   for (const match of options.toolContent.matchAll(openPattern)) {

--- a/src/core/protocols/morph-xml-stream-state-machine.ts
+++ b/src/core/protocols/morph-xml-stream-state-machine.ts
@@ -27,6 +27,20 @@ export interface LinePrefixedToolCall {
 type StreamController =
   TransformStreamDefaultController<LanguageModelV4StreamPart>;
 
+// Module-level cache keyed by tool name, mirroring selfClosingTagCache in
+// xml-tool-tag-scanner.ts. The keyspace is bounded by the set of tool names
+// seen by the process, so eviction is unnecessary.
+const endTagPatternCache = new Map<string, RegExp>();
+
+function getEndTagPattern(toolName: string): RegExp {
+  let pattern = endTagPatternCache.get(toolName);
+  if (!pattern) {
+    pattern = new RegExp(`</\\s*${escapeRegExp(toolName)}\\s*>`);
+    endTagPatternCache.set(toolName, pattern);
+  }
+  return pattern;
+}
+
 export type FlushTextFn = (controller: StreamController, text?: string) => void;
 
 type HandleStreamingToolCallEnd = (params: {
@@ -73,9 +87,7 @@ function processToolCallInBuffer(params: ProcessToolCallInBufferParams): {
     emitToolInputProgress,
     handleStreamingToolCallEnd,
   } = params;
-  const endTagPattern = new RegExp(
-    `</\\s*${escapeRegExp(currentToolCall.name)}\\s*>`
-  );
+  const endTagPattern = getEndTagPattern(currentToolCall.name);
   const endMatch = endTagPattern.exec(buffer);
   if (!endMatch || endMatch.index === undefined) {
     emitToolInputProgress(controller, currentToolCall, buffer);


### PR DESCRIPTION
## Summary

Removes per-chunk `new RegExp` compilation from the morph-xml streaming hot paths by applying the existing regex-caching convention (`selfClosingTagCache` in `xml-tool-tag-scanner.ts`, `closeTagCache` in `qwen3coder-stream-call-consumption.ts`).

## Changes

- `morph-xml-stream-state-machine.ts`: `processToolCallInBuffer` compiled the tool end-tag pattern on **every streamed chunk** while inside a tool call. Now cached in a module-level `Map` keyed by tool name.
- `morph-xml-progress-analysis.ts`: `plainTextBodyFallback`, `findTrailingUnclosedStringTag`, and `buildEmptyTrailingStringTagProgressContent` rebuilt property open/close tag patterns per chunk per schema property. Now cached per property name.

## Notes

- Cached global-flag (`gi`) patterns reset `lastIndex` on every lookup, so `matchAll`/`test` always scan from position 0.
- Cache keyspaces are bounded by tool/schema property names seen by the process; no eviction needed (same rationale as existing caches).
- No behavior change; pure allocation/compile-cost removal.

## Testing

- `vitest run` — 2427 tests pass, no type errors
- `biome check` clean on touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cached regexes for tool/property tags in morph-xml streaming hot paths to remove per-chunk RegExp compilation and cut allocations. No behavior change; improves streaming throughput. Adds a patch changeset for `@ai-sdk-tool/parser`.

- **Performance**
  - `morph-xml-stream-state-machine.ts`: Cache tool end-tag pattern per tool name (used in `processToolCallInBuffer`) instead of rebuilding each chunk.
  - `morph-xml-progress-analysis.ts`: Cache property tag patterns (open/self-closing, open, close) per property name for `plainTextBodyFallback`, `findTrailingUnclosedStringTag`, and `buildEmptyTrailingStringTagProgressContent`.

<sup>Written for commit d574c5f6dc209a11e4ce8a0a0f58753030a06e46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

