### PR TITLE
perf: memoize morph-xml schema introspection by schema identity

### DIFF
--- a/.changeset/perf-schema-introspection-cache.md
+++ b/.changeset/perf-schema-introspection-cache.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+Memoize morph-xml schema introspection (property-name sets, array-type
+checks) by schema object identity so streamed chunks stop re-walking
+tool input schemas.

--- a/src/core/protocols/morph-xml-progress-analysis.ts
+++ b/src/core/protocols/morph-xml-progress-analysis.ts
@@ -227,12 +227,35 @@ export function hasNonWhitespaceTopLevelText(fragment: string): boolean {
   return false;
 }
 
+// Schema introspection results are memoized by schema object identity.
+// Tool input schemas are stable references for the lifetime of a request
+// (tools are fixed when the stream parser is created), while these helpers
+// are invoked on every streamed chunk from the tool-input progress path.
+// WeakMap keying keeps the cache GC-safe. Returned Sets are shared across
+// calls and must be treated as readonly by callers.
+const objectSchemaPropertyNamesCache = new WeakMap<
+  object,
+  Set<string> | null
+>();
+
 export function getObjectSchemaPropertyNames(
   schema: unknown
 ): Set<string> | null {
   if (!schema || typeof schema !== "object") {
     return null;
   }
+  const cached = objectSchemaPropertyNamesCache.get(schema);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const result = computeObjectSchemaPropertyNames(schema);
+  objectSchemaPropertyNamesCache.set(schema, result);
+  return result;
+}
+
+function computeObjectSchemaPropertyNames(
+  schema: object
+): Set<string> | null {
 
   const schemaObject = schema as {
     type?: unknown;
@@ -256,7 +279,22 @@ export function getObjectSchemaPropertyNames(
   );
 }
 
+const schemaAllowsArrayTypeCache = new WeakMap<object, boolean>();
+
 export function schemaAllowsArrayType(schema: unknown): boolean {
+  if (schema && typeof schema === "object") {
+    const cached = schemaAllowsArrayTypeCache.get(schema);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const result = computeSchemaAllowsArrayType(schema);
+    schemaAllowsArrayTypeCache.set(schema, result);
+    return result;
+  }
+  return computeSchemaAllowsArrayType(schema);
+}
+
+function computeSchemaAllowsArrayType(schema: unknown): boolean {
   const normalizedSchema = unwrapJsonSchema(schema);
   if (!normalizedSchema || typeof normalizedSchema !== "object") {
     return false;
@@ -312,7 +350,27 @@ function schemaAllowsStringType(schema: unknown): boolean {
   return false;
 }
 
+const objectSchemaStringPropertyNamesCache = new WeakMap<
+  object,
+  Set<string> | null
+>();
+
 export function getObjectSchemaStringPropertyNames(
+  schema: unknown
+): Set<string> | null {
+  if (schema && typeof schema === "object") {
+    const cached = objectSchemaStringPropertyNamesCache.get(schema);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const result = computeObjectSchemaStringPropertyNames(schema);
+    objectSchemaStringPropertyNamesCache.set(schema, result);
+    return result;
+  }
+  return computeObjectSchemaStringPropertyNames(schema);
+}
+
+function computeObjectSchemaStringPropertyNames(
   schema: unknown
 ): Set<string> | null {
   const propertyNames = getObjectSchemaPropertyNames(schema);

--- a/src/core/protocols/morph-xml-progress-analysis.ts
+++ b/src/core/protocols/morph-xml-progress-analysis.ts
@@ -253,10 +253,7 @@ export function getObjectSchemaPropertyNames(
   return result;
 }
 
-function computeObjectSchemaPropertyNames(
-  schema: object
-): Set<string> | null {
-
+function computeObjectSchemaPropertyNames(schema: object): Set<string> | null {
   const schemaObject = schema as {
     type?: unknown;
     properties?: unknown;


### PR DESCRIPTION
## Summary

The morph-xml streaming progress path (`parseXmlContentForStreamProgress` → `isStableXmlProgressCandidate`) re-runs schema introspection on **every streamed chunk**, and again for **every backward `>` progress candidate**:

- `getObjectSchemaPropertyNames` — rebuilds a property-name `Set` from `Object.keys`
- `getObjectSchemaStringPropertyNames` — walks every property through `unwrapJsonSchema` + union recursion
- `schemaAllowsArrayType` — recursive union walk

## Approach

Tool input schemas are stable object references for the lifetime of a request (`tools` is fixed when the stream parser is created). Instead of threading precomputed values through call signatures (original plan), results are memoized in module-level `WeakMap`s keyed by schema object identity:

- same effect as stream-lifetime caching, with minimal API churn (no signature changes)
- GC-safe: entries die with their schema objects
- returned `Set`s are shared across calls and documented as readonly — verified that all current callers only use `has`/`size`/iteration

## Testing

- full suite: 2427 tests pass, no type errors
- `biome check` clean

## Note

Complements #391 (regex caching in the same hot path). Both are independent of each other and can merge in any order (no overlapping hunks).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized schema introspection in the morph-xml streaming progress path to remove repeated work per chunk and per candidate. Uses WeakMap caches keyed by schema identity for faster streams with no API changes.

- **Refactors**
  - Memoized `getObjectSchemaPropertyNames`, `getObjectSchemaStringPropertyNames`, and `schemaAllowsArrayType` with module-level `WeakMap`s.
  - Shared readonly `Set`s across calls; caches are GC-safe and tied to request-lifetime schema objects.
  - No behavior changes; reduces CPU in the hot path.
  - Added changeset to publish a patch for `@ai-sdk-tool/parser`.
  - Applied Biome formatting to touched files.

<sup>Written for commit 75ce9b181ff1406d20d731425441fc56e9e68358. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

