### PR TITLE
perf: XML escape fast paths and charCode JSON whitespace skipping

### DIFF
--- a/.changeset/perf-micro-optimizations.md
+++ b/.changeset/perf-micro-optimizations.md
@@ -1,0 +1,7 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+Add fast paths to XML escape/unescape helpers for content without
+escapable characters, and skip JSON whitespace with charCode checks on
+the hermes streaming path.

--- a/src/core/protocols/hermes-call-boundary.ts
+++ b/src/core/protocols/hermes-call-boundary.ts
@@ -1,9 +1,22 @@
 const WHITESPACE_JSON_REGEX = /\s/;
 
+// Local copy of hermes-json-object-key-scanner's skipJsonWhitespace; that
+// module imports from this one, so importing it here would create a cycle.
 function skipJsonWhitespace(text: string, fromIndex: number): number {
   let index = fromIndex;
-  while (index < text.length && WHITESPACE_JSON_REGEX.test(text[index])) {
-    index += 1;
+  while (index < text.length) {
+    const code = text.charCodeAt(index);
+    // Fast path for ASCII whitespace: /\s/ matches \t \n \v \f \r and space.
+    if ((code >= 9 && code <= 13) || code === 32) {
+      index += 1;
+      continue;
+    }
+    // Non-ASCII whitespace (NBSP, unicode spaces, ...) still matches /\s/.
+    if (code > 127 && WHITESPACE_JSON_REGEX.test(text[index])) {
+      index += 1;
+      continue;
+    }
+    break;
   }
   return index;
 }

--- a/src/core/protocols/hermes-json-object-key-scanner.ts
+++ b/src/core/protocols/hermes-json-object-key-scanner.ts
@@ -4,8 +4,19 @@ const WHITESPACE_JSON_REGEX = /\s/;
 
 export function skipJsonWhitespace(text: string, fromIndex: number): number {
   let index = fromIndex;
-  while (index < text.length && WHITESPACE_JSON_REGEX.test(text[index])) {
-    index += 1;
+  while (index < text.length) {
+    const code = text.charCodeAt(index);
+    // Fast path for ASCII whitespace: /\s/ matches \t \n \v \f \r and space.
+    if ((code >= 9 && code <= 13) || code === 32) {
+      index += 1;
+      continue;
+    }
+    // Non-ASCII whitespace (NBSP, unicode spaces, ...) still matches /\s/.
+    if (code > 127 && WHITESPACE_JSON_REGEX.test(text[index])) {
+      index += 1;
+      continue;
+    }
+    break;
   }
   return index;
 }

--- a/src/core/protocols/hermes-streaming-progress.ts
+++ b/src/core/protocols/hermes-streaming-progress.ts
@@ -14,6 +14,7 @@ import {
   previousSignificantChar,
   readStrictJsonPropertyCandidate,
   skipJsonComment,
+  skipJsonWhitespace,
 } from "./hermes-json-object-key-scanner";
 import type { ParserOptions } from "./protocol-interface";
 
@@ -44,14 +45,6 @@ export interface TagProcessingContext {
 }
 
 const WHITESPACE_JSON_REGEX = /\s/;
-
-function skipJsonWhitespace(text: string, fromIndex: number): number {
-  let index = fromIndex;
-  while (index < text.length && WHITESPACE_JSON_REGEX.test(text[index])) {
-    index += 1;
-  }
-  return index;
-}
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Streaming JSON key/value scanning requires explicit string-depth state tracking.
 function findTopLevelPropertyValueStart(

--- a/src/rxml/utils/helpers.ts
+++ b/src/rxml/utils/helpers.ts
@@ -116,7 +116,16 @@ export function getLineColumn(
  *
  * We conservatively escape &, <, >, ", ' using the predefined entities.
  */
+const XML_ESCAPE_CANDIDATE_REGEX = /[&<>"']/;
+const XML_MINIMAL_TEXT_CANDIDATE_REGEX = /[&<>]/;
+const XML_MINIMAL_ATTR_CANDIDATE_REGEX = /[&<"']/;
+
 export function escapeXml(text: string): string {
+  // Fast path: most content has no escapable characters; skip the five
+  // replace passes (and their intermediate allocations) entirely.
+  if (!XML_ESCAPE_CANDIDATE_REGEX.test(text)) {
+    return text;
+  }
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
@@ -131,6 +140,11 @@ export function escapeXml(text: string): string {
  * - Escape only the ']]>' sequence by turning '>' into '&gt;' in that context
  */
 export function escapeXmlMinimalText(text: string): string {
+  // Fast path: no '&', '<', or '>' means neither the always-escaped
+  // characters nor the ']]>' sequence can occur.
+  if (!XML_MINIMAL_TEXT_CANDIDATE_REGEX.test(text)) {
+    return text;
+  }
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
@@ -146,6 +160,10 @@ export function escapeXmlMinimalAttr(
   value: string,
   wrapper: '"' | "'" = '"'
 ): string {
+  // Fast path: no escapable character for either wrapper quote style.
+  if (!XML_MINIMAL_ATTR_CANDIDATE_REGEX.test(value)) {
+    return value;
+  }
   let escaped = value.replace(/&/g, "&amp;").replace(/</g, "&lt;");
   if (wrapper === '"') {
     escaped = escaped.replace(/"/g, "&quot;");
@@ -178,6 +196,10 @@ function decodeXmlCharacterReference(
 }
 
 export function unescapeXml(text: string): string {
+  // Fast path: every entity and character reference starts with '&'.
+  if (!text.includes("&")) {
+    return text;
+  }
   return text
     .replace(XML_CHAR_REF_REGEX, decodeXmlCharacterReference)
     .replace(/&lt;/g, "<")


### PR DESCRIPTION
## Summary

Two low-risk micro-optimization groups on per-chunk streaming paths, plus a small dedupe.

## Changes

### 1. XML escape/unescape fast paths — `src/rxml/utils/helpers.ts`

`escapeXml` ran five chained `.replace()` passes (5 full scans + up to 5 intermediate strings) even when the text contained no escapable character — the common case for tool-call content. Each function now returns its input unchanged after a single vectorized scan:

- `escapeXml`: `/[&<>"']/` test
- `escapeXmlMinimalText`: `/[&<>]/` test (conservative: no `>` ⇒ no `]]>`)
- `escapeXmlMinimalAttr`: `/[&<"']/` test (covers both wrapper quote styles)
- `unescapeXml`: `includes("&")` (every entity starts with `&`)

### 2. charCode-based `skipJsonWhitespace` — hermes streaming path

The loop ran `/\s/.test(text[i])` per character: a one-char string allocation plus regex-engine entry per iteration. Now uses `charCodeAt` comparisons for ASCII (`\t \n \v \f \r ` — exactly the ASCII coverage of `/\s/`) with a regex fallback for non-ASCII whitespace, so **semantics are preserved exactly** (NBSP, unicode spaces still skipped).

### 3. Dedupe

`skipJsonWhitespace` was defined three times. `hermes-streaming-progress.ts` now imports the shared implementation from `hermes-json-object-key-scanner.ts`; `hermes-call-boundary.ts` keeps a local copy because the scanner module imports from it (cycle avoidance, documented inline).

## Testing

- full suite: 2427 tests pass, no type errors
- `biome check` clean on touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up streaming XML and JSON handling by adding early-out checks and charCode-based whitespace scanning. Also adds a changeset for a patch release of `@ai-sdk-tool/parser`.

- **Performance**
  - XML escaping: `escapeXml`, `escapeXmlMinimalText`, `escapeXmlMinimalAttr`, `unescapeXml` early-return when no escapable chars, avoiding multiple replace passes.
  - JSON whitespace: `skipJsonWhitespace` uses `charCodeAt` for ASCII, with regex fallback for non-ASCII to match `/\s/` exactly.
  - Dedupe: `hermes-streaming-progress` imports shared `skipJsonWhitespace`; `hermes-call-boundary` keeps a local copy to avoid an import cycle.

<sup>Written for commit 525cf148440dcd59ce73dcee0596807a39947189. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

