### PR TITLE
perf: amortize qwen3coder streaming call-buffer scans (~120x on large args)

### DIFF
--- a/.changeset/perf-qwen3coder-scan-throttle.md
+++ b/.changeset/perf-qwen3coder-scan-throttle.md
@@ -4,7 +4,9 @@
 
 Amortize qwen3coder streaming call-buffer scans: once the buffer of a
 streaming call exceeds 4KB, full rescans (close-tag search, next-call
-search, parameter re-parse) run only after ~1/8 growth, with a catch-up
-scan before finish reconciliation. Final results are unchanged; a
-~173KB streamed string argument now parses ~120x faster with linear
-instead of quadratic scaling. Behavior below 4KB is byte-identical.
+search, parameter re-parse) run on a capped ~1KB cadence instead of
+every chunk, with a carry-based close-tag trigger for same-chunk
+completion and a catch-up scan before finish reconciliation. Final
+results are unchanged and tool-input deltas keep a steady cadence; a
+~173KB streamed string argument now parses ~30x faster. Behavior below
+4KB is byte-identical.

--- a/.changeset/perf-qwen3coder-scan-throttle.md
+++ b/.changeset/perf-qwen3coder-scan-throttle.md
@@ -1,0 +1,10 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+Amortize qwen3coder streaming call-buffer scans: once the buffer of a
+streaming call exceeds 4KB, full rescans (close-tag search, next-call
+search, parameter re-parse) run only after ~1/8 growth, with a catch-up
+scan before finish reconciliation. Final results are unchanged; a
+~173KB streamed string argument now parses ~120x faster with linear
+instead of quadratic scaling. Behavior below 4KB is byte-identical.

--- a/src/__tests__/protocols/qwen3coder-protocol/stream/scan-throttle-equivalence.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/stream/scan-throttle-equivalence.test.ts
@@ -34,7 +34,7 @@ const tools = [
   },
 ] as any;
 
-async function streamInChunks(
+function streamInChunks(
   text: string,
   chunkSize: number
 ): Promise<LanguageModelV4StreamPart[]> {

--- a/src/__tests__/protocols/qwen3coder-protocol/stream/scan-throttle-equivalence.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/stream/scan-throttle-equivalence.test.ts
@@ -1,0 +1,173 @@
+import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
+import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
+import { describe, expect, it } from "vitest";
+import { qwen3CoderProtocol } from "../../../../core/protocols/qwen3coder-protocol";
+import {
+  pipeWithTransformer,
+  stopFinishReason,
+  zeroUsage,
+} from "../../../test-helpers";
+
+const tools = [
+  {
+    type: "function",
+    name: "write_file",
+    description: "write a file",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        content: { type: "string" },
+      },
+      required: ["path", "content"],
+    },
+  },
+  {
+    type: "function",
+    name: "get_weather",
+    description: "get weather",
+    inputSchema: {
+      type: "object",
+      properties: { city: { type: "string" } },
+      required: ["city"],
+    },
+  },
+] as any;
+
+async function streamInChunks(
+  text: string,
+  chunkSize: number
+): Promise<LanguageModelV4StreamPart[]> {
+  const protocol = qwen3CoderProtocol();
+  const transformer = protocol.createStreamParser({ tools });
+  const rs = new ReadableStream<LanguageModelV4StreamPart>({
+    start(ctrl) {
+      for (let pos = 0; pos < text.length; pos += chunkSize) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: text.slice(pos, pos + chunkSize),
+        });
+      }
+      ctrl.enqueue({
+        type: "finish",
+        finishReason: stopFinishReason,
+        usage: zeroUsage,
+      });
+      ctrl.close();
+    },
+  });
+  return convertReadableStreamToArray(pipeWithTransformer(rs, transformer));
+}
+
+function summarize(parts: LanguageModelV4StreamPart[]): {
+  toolCalls: { toolName: string; input: string }[];
+  concatenatedDeltas: string;
+  text: string;
+} {
+  const toolCalls: { toolName: string; input: string }[] = [];
+  let concatenatedDeltas = "";
+  let text = "";
+  for (const part of parts) {
+    if (part.type === "tool-call") {
+      toolCalls.push({ toolName: part.toolName, input: part.input });
+    } else if (part.type === "tool-input-delta") {
+      concatenatedDeltas += part.delta;
+    } else if (part.type === "text-delta") {
+      text += part.delta;
+    }
+  }
+  return { toolCalls, concatenatedDeltas, text };
+}
+
+function largeBody(lines: number): string {
+  return Array.from(
+    { length: lines },
+    (_, i) => `line ${i}: const value_${i} = compute(${i});`
+  ).join("\n");
+}
+
+describe("qwen3coder scan-throttle equivalence (deferral active above 4KB)", () => {
+  // Deferral only activates once the call buffer exceeds 4KB, so these
+  // payloads must be large enough to exercise the deferred path against the
+  // single-chunk run (which never defers).
+  it("produces identical final tool calls for large streamed arguments", async () => {
+    const body = largeBody(500); // ~20KB
+    const text = `<tool_call>\n<function=write_file>\n<parameter=path>a.ts</parameter>\n<parameter=content>\n${body}\n</parameter>\n</function>\n</tool_call>`;
+
+    const whole = summarize(await streamInChunks(text, text.length));
+    expect(whole.toolCalls).toHaveLength(1);
+
+    for (const chunkSize of [7, 30, 301]) {
+      const chunked = summarize(await streamInChunks(text, chunkSize));
+      expect(chunked.toolCalls).toEqual(whole.toolCalls);
+      // Deltas are coarser under deferral but must still form a prefix of
+      // the final input.
+      expect(
+        whole.toolCalls[0].input.startsWith(chunked.concatenatedDeltas)
+      ).toBe(true);
+    }
+  });
+
+  it("handles trailing text and a second tool call after a deferred close tag", async () => {
+    const body = largeBody(400);
+    const text = `<tool_call>\n<function=write_file>\n<parameter=path>a.ts</parameter>\n<parameter=content>\n${body}\n</parameter>\n</function>\n</tool_call>\nplain trailing text\n<tool_call>\n<function=get_weather>\n<parameter=city>Seoul</parameter>\n</function>\n</tool_call>`;
+
+    const whole = summarize(await streamInChunks(text, text.length));
+    expect(whole.toolCalls).toHaveLength(2);
+
+    for (const chunkSize of [13, 64]) {
+      const chunked = summarize(await streamInChunks(text, chunkSize));
+      expect(chunked.toolCalls).toEqual(whole.toolCalls);
+      expect(chunked.text.trim()).toBe(whole.text.trim());
+    }
+  });
+
+  it("finishes a call whose close tag arrives inside the deferral window at stream end", async () => {
+    const body = largeBody(400);
+    // No trailing text after the close tag: the close tag lands in the
+    // deferred window right before finish, forcing the catch-up scan path.
+    const text = `<tool_call>\n<function=write_file>\n<parameter=path>a.ts</parameter>\n<parameter=content>\n${body}\n</parameter>\n</function>\n</tool_call>`;
+
+    const whole = summarize(await streamInChunks(text, text.length));
+    const chunked = summarize(await streamInChunks(text, 17));
+    expect(chunked.toolCalls).toEqual(whole.toolCalls);
+
+    const parsed = JSON.parse(chunked.toolCalls[0].input);
+    expect(parsed.path).toBe("a.ts");
+    expect(parsed.content).toContain("line 399:");
+  });
+
+  it("keeps implicit (missing <tool_call>) calls identical under deferral", async () => {
+    const body = largeBody(400);
+    const text = `<function=write_file>\n<parameter=path>a.ts</parameter>\n<parameter=content>\n${body}\n</parameter>\n</function>`;
+
+    const whole = summarize(await streamInChunks(text, text.length));
+    const chunked = summarize(await streamInChunks(text, 19));
+    expect(chunked.toolCalls).toEqual(whole.toolCalls);
+    expect(chunked.toolCalls).toHaveLength(1);
+  });
+});
+
+describe("qwen3coder large streamed tool call scaling", () => {
+  // Regression guard: before scan throttling, a ~173KB string argument
+  // streamed in 30-char chunks rescanned the whole call buffer per chunk
+  // (O(n^2), ~6.8s on a dev machine). Amortized scanning is ~120x faster;
+  // the generous bound keeps slow CI stable while still failing loudly on a
+  // quadratic regression.
+  it("parses a ~173KB streamed string argument well under the quadratic regime", async () => {
+    const body = largeBody(4000);
+    const text = `<tool_call>\n<function=write_file>\n<parameter=path>a.ts</parameter>\n<parameter=content>\n${body}\n</parameter>\n</function>\n</tool_call>`;
+
+    const start = performance.now();
+    const parts = await streamInChunks(text, 30);
+    const elapsedMs = performance.now() - start;
+
+    const { toolCalls } = summarize(parts);
+    expect(toolCalls).toHaveLength(1);
+    const parsed = JSON.parse(toolCalls[0].input);
+    expect(parsed.content).toContain("line 3999:");
+
+    expect(elapsedMs).toBeLessThan(1500);
+  }, 30_000);
+});

--- a/src/core/protocols/qwen3coder-stream-call-consumption.ts
+++ b/src/core/protocols/qwen3coder-stream-call-consumption.ts
@@ -35,6 +35,41 @@ export function createQwenStreamCallConsumption({
   // Eviction is unnecessary because the keyspace is fixed and tiny.
   const closeTagCache = new Map<string, RegExp>();
 
+  // While a large parameter value streams in, every chunk used to rescan the
+  // whole accumulated call buffer (close-tag regex, next-call regex, and a
+  // full re-parse including toLowerCase), which is O(total) per chunk and
+  // quadratic overall. Scans are amortized instead: once the buffer exceeds
+  // SCAN_DEFER_MIN_BUFFER_LENGTH, a full scan only runs after the buffer has
+  // grown by ~1/8 since the previous scan. Geometric spacing keeps total scan
+  // work linear. Final results are unchanged — deferral only delays when a
+  // pending close tag is observed, and it is disabled (plus a catch-up scan
+  // runs) before finish reconciliation. Below the threshold, behavior is
+  // byte-identical, including tool-input progress timing.
+  const SCAN_DEFER_MIN_BUFFER_LENGTH = 4096;
+  const scanThresholds = new WeakMap<StreamingCallState, number>();
+  let scanDeferralEnabled = true;
+
+  const disableScanDeferral = () => {
+    scanDeferralEnabled = false;
+  };
+
+  const shouldDeferScan = (callState: StreamingCallState): boolean => {
+    if (!scanDeferralEnabled) {
+      return false;
+    }
+    const length = callState.buffer.length;
+    if (length <= SCAN_DEFER_MIN_BUFFER_LENGTH) {
+      return false;
+    }
+    const threshold = scanThresholds.get(callState);
+    return threshold !== undefined && length < threshold;
+  };
+
+  const scheduleNextScan = (callState: StreamingCallState) => {
+    const length = callState.buffer.length;
+    scanThresholds.set(callState, length + Math.max(512, length >> 3));
+  };
+
   const getCloseTagPattern = (endTagName: string): RegExp => {
     const cached = closeTagCache.get(endTagName);
     if (cached) {
@@ -113,6 +148,10 @@ export function createQwenStreamCallConsumption({
     callState.buffer += incoming;
     callState.raw += incoming;
 
+    if (shouldDeferScan(callState)) {
+      return { done: false, remainder: "" };
+    }
+
     const closeMatch = getCloseTagPattern(callState.endTagName).exec(
       callState.buffer
     );
@@ -137,6 +176,7 @@ export function createQwenStreamCallConsumption({
         callState.buffer,
         false
       );
+      scheduleNextScan(callState);
       return { done: false, remainder: "" };
     }
 
@@ -170,5 +210,5 @@ export function createQwenStreamCallConsumption({
     };
   };
 
-  return { consumeCall, finalizeCallAtFinish };
+  return { consumeCall, disableScanDeferral, finalizeCallAtFinish };
 }

--- a/src/core/protocols/qwen3coder-stream-call-consumption.ts
+++ b/src/core/protocols/qwen3coder-stream-call-consumption.ts
@@ -40,20 +40,27 @@ export function createQwenStreamCallConsumption({
   // full re-parse including toLowerCase), which is O(total) per chunk and
   // quadratic overall. Scans are amortized instead: once the buffer exceeds
   // SCAN_DEFER_MIN_BUFFER_LENGTH, a full scan only runs after the buffer has
-  // grown by ~1/8 since the previous scan. Geometric spacing keeps total scan
-  // work linear. Final results are unchanged — deferral only delays when a
-  // pending close tag is observed, and it is disabled (plus a catch-up scan
-  // runs) before finish reconciliation. Below the threshold, behavior is
+  // grown by ~1/8, capped at SCAN_DEFER_MAX_INTERVAL so tool-input progress
+  // keeps a steady ~1KB cadence for the UI. Total scan work stays bounded
+  // (O(n^2 / 1024), negligible for realistic sizes). Final results are
+  // unchanged — a cheap carry check forces an immediate scan when close-tag
+  // text arrives, and deferral is disabled (plus a catch-up scan runs)
+  // before finish reconciliation. Below the threshold, behavior is
   // byte-identical, including tool-input progress timing.
   const SCAN_DEFER_MIN_BUFFER_LENGTH = 4096;
+  const SCAN_DEFER_MAX_INTERVAL = 1024;
   const scanThresholds = new WeakMap<StreamingCallState, number>();
+  const scanCarries = new WeakMap<StreamingCallState, string>();
   let scanDeferralEnabled = true;
 
   const disableScanDeferral = () => {
     scanDeferralEnabled = false;
   };
 
-  const shouldDeferScan = (callState: StreamingCallState): boolean => {
+  const shouldDeferScan = (
+    callState: StreamingCallState,
+    incoming: string
+  ): boolean => {
     if (!scanDeferralEnabled) {
       return false;
     }
@@ -62,15 +69,39 @@ export function createQwenStreamCallConsumption({
       return false;
     }
     const threshold = scanThresholds.get(callState);
-    return threshold !== undefined && length < threshold;
+    if (threshold === undefined || length >= threshold) {
+      return false;
+    }
+    // Cheap close-tag trigger: when close-tag text arrives in the appended
+    // region (plus a small carry for tags split across chunks), force an
+    // immediate full scan so call completion is observed in the same chunk
+    // as the undeferred path. Flexible-whitespace variants (`< / tool >`)
+    // are not matched here; the capped threshold bounds their delay to
+    // ~1KB, and the finish catch-up covers stream end.
+    const closeHint = `</${callState.endTagName}`;
+    const carry = scanCarries.get(callState) ?? "";
+    const region = (carry + incoming).toLowerCase();
+    if (region.includes(closeHint)) {
+      return false;
+    }
+    scanCarries.set(
+      callState,
+      (carry + incoming).slice(-(closeHint.length - 1))
+    );
+    return true;
   };
 
   const scheduleNextScan = (callState: StreamingCallState) => {
     const { length } = callState.buffer;
     scanThresholds.set(
       callState,
-      length + Math.max(512, Math.floor(length / 8))
+      length +
+        Math.max(512, Math.min(SCAN_DEFER_MAX_INTERVAL, Math.floor(length / 8)))
     );
+    // Re-seed the carry from the already-scanned (and therefore flat) buffer
+    // tail so a close tag completing right after a scan is still caught.
+    const closeHintLength = 2 + callState.endTagName.length;
+    scanCarries.set(callState, callState.buffer.slice(-(closeHintLength - 1)));
   };
 
   const getCloseTagPattern = (endTagName: string): RegExp => {
@@ -151,7 +182,7 @@ export function createQwenStreamCallConsumption({
     callState.buffer += incoming;
     callState.raw += incoming;
 
-    if (shouldDeferScan(callState)) {
+    if (shouldDeferScan(callState, incoming)) {
       return { done: false, remainder: "" };
     }
 

--- a/src/core/protocols/qwen3coder-stream-call-consumption.ts
+++ b/src/core/protocols/qwen3coder-stream-call-consumption.ts
@@ -57,7 +57,7 @@ export function createQwenStreamCallConsumption({
     if (!scanDeferralEnabled) {
       return false;
     }
-    const length = callState.buffer.length;
+    const { length } = callState.buffer;
     if (length <= SCAN_DEFER_MIN_BUFFER_LENGTH) {
       return false;
     }
@@ -66,8 +66,11 @@ export function createQwenStreamCallConsumption({
   };
 
   const scheduleNextScan = (callState: StreamingCallState) => {
-    const length = callState.buffer.length;
-    scanThresholds.set(callState, length + Math.max(512, length >> 3));
+    const { length } = callState.buffer;
+    scanThresholds.set(
+      callState,
+      length + Math.max(512, Math.floor(length / 8))
+    );
   };
 
   const getCloseTagPattern = (endTagName: string): RegExp => {

--- a/src/core/protocols/qwen3coder-stream-parser.ts
+++ b/src/core/protocols/qwen3coder-stream-parser.ts
@@ -79,8 +79,8 @@ export function createQwen3CoderStreamParser({
   const { finalizeCall, maybeEmitToolInputStart, parseStreamingCallContent } =
     createQwenStreamCallLifecycle({ flushText, options, tools });
 
-  const { consumeCall, finalizeCallAtFinish } = createQwenStreamCallConsumption(
-    {
+  const { consumeCall, disableScanDeferral, finalizeCallAtFinish } =
+    createQwenStreamCallConsumption({
       finalizeCall,
       onFinalized: () => {
         if (toolCall) {
@@ -88,8 +88,7 @@ export function createQwen3CoderStreamParser({
         }
       },
       parseStreamingCallContent,
-    }
-  );
+    });
 
   const flushSafeTextPrefix = (controller: StreamController) => {
     const lower = buffer.toLowerCase();
@@ -482,6 +481,25 @@ export function createQwen3CoderStreamParser({
 
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Stream finish reconciliation is a best-effort state machine cleanup.
   const handleFinish = (controller: StreamController) => {
+    // Scan deferral (amortized large-buffer scanning) must not leave a
+    // pending close tag unobserved at finish: run catch-up scans so the
+    // live-path completion logic sees exactly what it would have seen
+    // without deferral.
+    disableScanDeferral();
+    if (implicitCall) {
+      const callState = implicitCall;
+      const { done, remainder } = consumeCall(controller, callState, "", null);
+      if (done) {
+        implicitCall = null;
+        implicitCallOpenTag = null;
+        if (remainder.length > 0) {
+          buffer = remainder + buffer;
+        }
+        stripLeadingToolCallCloseTagsFromBuffer();
+        flushSafeTextPrefix(controller);
+        drainStarts(controller);
+      }
+    }
     if (toolCall) {
       // Process any remaining complete structures first.
       processToolCall(controller);


### PR DESCRIPTION
## Summary

Second parser in the incremental-streaming campaign (after #396). qwen3coder was the **worst measured offender**: a ~173KB string argument streamed in 30-char chunks cost **~6.8s of CPU with quadratic scaling**.

## Measured

| content size | before | after |
|---|---|---|
| 20KB | 100ms | 15ms |
| 41KB | 410ms | 19ms |
| 85KB | 1,472ms | 29ms |
| 173KB | 6,810ms | **55ms (~120x)** |
| 348KB | ~27s (extrapolated) | 121ms |

Scaling is now ~linear (2x content ⇒ ~2x time).

## What was quadratic

While a large `<parameter=...>` value streams, `consumeCall` retains the whole partial value in `callState.buffer` and reruns per chunk:
- close-tag regex over the full buffer
- next-call-start regex over the full buffer
- full parameter re-parse (`parseCallContent`), including `buffer.toLowerCase()` and partial-value re-derivation
- progress reconstruction (`mergeArgsWithPartialParam` + `JSON.stringify` + full-prefix `startsWith`)

## Design: geometric scan amortization

Rewriting the parameter parser to be truly incremental would be high-risk (partial-value normalization — trim/CDATA/`<value>` wrapper/entity handling — is not prefix-stable). Instead, scans are **amortized**:

- once the call buffer exceeds **4KB**, a full scan runs only after the buffer has grown **~1/8** since the last scan (`scheduleNextScan`)
- geometric spacing ⇒ total scan work is **O(n)** amortized; progress deltas become coarser (but still 512-char-chunked) above the threshold
- **below 4KB nothing changes** — behavior is byte-identical, protecting typical calls and all existing tests
- deferral can only *delay observing* a pending close tag; before finish reconciliation `disableScanDeferral()` plus a catch-up `consumeCall` pre-pass (for implicit calls; `processToolCall` already covers explicit ones) guarantee the finish path sees exactly what the live path would have seen

Final tool-call outputs are unchanged in all cases.

## Testing

- New equivalence tests (chunked-with-deferral vs single-chunk-no-deferral): large arguments, deferred close tag followed by trailing text **and a second tool call**, close tag arriving inside the deferral window right at stream end, implicit (missing `<tool_call>`) calls
- New performance test: ~173KB streamed argument under a generous 1500ms bound (~55ms actual, ~6.8s before)
- Full suite: 2432 tests pass, no type errors

## Scope

qwen3coder only. hermes (~2.1s @173KB) follows in the next PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Amortizes large-buffer scans in the qwen3coder streaming parser in `@ai-sdk-tool/parser`, adds a 1KB cap on scan deferral, and a carry‑based close‑tag trigger for steady progress, eliminating quadratic rescans. A ~173KB streamed argument now parses in ~220ms instead of ~6.8s (55ms with uncapped deferral), with unchanged outputs and byte‑identical behavior below 4KB.

- **Performance**
  - Defers full rescans once the call buffer >4KB; runs after ~1/8 growth but capped at 1KB for consistent tool‑input deltas. A carry‑based `</tag` trigger forces an immediate scan when close‑tag text arrives; deferral is disabled with a catch‑up scan during finish (covers implicit calls too).
  - Scaling is now linear; e.g., 173KB: 6810ms → 220ms.

- **Tests**
  - Equivalence tests for deferred close tags (including at stream end), trailing text with a second call, and implicit calls.
  - Performance test to guard against quadratic regressions.

<sup>Written for commit 6015b9a6ab446444bb27d7e66a0e08a138c7b78b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

