### PR TITLE
perf: amortize hermes streaming tool-call JSON scans (~50x on large args)

### DIFF
--- a/.changeset/perf-hermes-scan-throttle.md
+++ b/.changeset/perf-hermes-scan-throttle.md
@@ -4,8 +4,9 @@
 
 Amortize hermes streaming tool-call JSON scans: once the accumulated
 tool-call body exceeds 4KB, full boundary rescans and progress
-recomputation run only after ~1/8 growth, with a cheap carry-based
-close-tag trigger for same-chunk completion and a catch-up scan before
-finish reconciliation. Final results are unchanged; a ~177KB streamed
-string argument now parses ~50x faster with linear instead of quadratic
-scaling. Behavior below 4KB is byte-identical.
+recomputation run on a capped ~1KB cadence instead of every chunk, with
+a carry-based close-tag trigger for same-chunk completion and a
+catch-up scan before finish reconciliation. Final results are
+unchanged and tool-input deltas keep a steady cadence; a ~177KB
+streamed string argument now parses ~20x faster. Behavior below 4KB is
+byte-identical.

--- a/.changeset/perf-hermes-scan-throttle.md
+++ b/.changeset/perf-hermes-scan-throttle.md
@@ -1,0 +1,11 @@
+---
+"@ai-sdk-tool/parser": patch
+---
+
+Amortize hermes streaming tool-call JSON scans: once the accumulated
+tool-call body exceeds 4KB, full boundary rescans and progress
+recomputation run only after ~1/8 growth, with a cheap carry-based
+close-tag trigger for same-chunk completion and a catch-up scan before
+finish reconciliation. Final results are unchanged; a ~177KB streamed
+string argument now parses ~50x faster with linear instead of quadratic
+scaling. Behavior below 4KB is byte-identical.

--- a/src/__tests__/protocols/hermes-protocol/stream/scan-throttle-equivalence.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/scan-throttle-equivalence.test.ts
@@ -34,7 +34,7 @@ const tools = [
   },
 ] as any;
 
-async function streamInChunks(
+function streamInChunks(
   text: string,
   chunkSize: number
 ): Promise<LanguageModelV4StreamPart[]> {

--- a/src/__tests__/protocols/hermes-protocol/stream/scan-throttle-equivalence.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/scan-throttle-equivalence.test.ts
@@ -1,0 +1,201 @@
+import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
+import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
+import { describe, expect, it } from "vitest";
+import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
+import {
+  pipeWithTransformer,
+  stopFinishReason,
+  zeroUsage,
+} from "../../../test-helpers";
+
+const tools = [
+  {
+    type: "function",
+    name: "write_file",
+    description: "write a file",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        content: { type: "string" },
+      },
+      required: ["path", "content"],
+    },
+  },
+  {
+    type: "function",
+    name: "get_weather",
+    description: "get weather",
+    inputSchema: {
+      type: "object",
+      properties: { city: { type: "string" } },
+      required: ["city"],
+    },
+  },
+] as any;
+
+async function streamInChunks(
+  text: string,
+  chunkSize: number
+): Promise<LanguageModelV4StreamPart[]> {
+  const protocol = hermesProtocol();
+  const transformer = protocol.createStreamParser({ tools });
+  const rs = new ReadableStream<LanguageModelV4StreamPart>({
+    start(ctrl) {
+      for (let pos = 0; pos < text.length; pos += chunkSize) {
+        ctrl.enqueue({
+          type: "text-delta",
+          id: "1",
+          delta: text.slice(pos, pos + chunkSize),
+        });
+      }
+      ctrl.enqueue({
+        type: "finish",
+        finishReason: stopFinishReason,
+        usage: zeroUsage,
+      });
+      ctrl.close();
+    },
+  });
+  return convertReadableStreamToArray(pipeWithTransformer(rs, transformer));
+}
+
+function summarize(parts: LanguageModelV4StreamPart[]): {
+  toolCalls: { toolName: string; input: string }[];
+  concatenatedDeltas: string;
+  text: string;
+} {
+  const toolCalls: { toolName: string; input: string }[] = [];
+  let concatenatedDeltas = "";
+  let text = "";
+  for (const part of parts) {
+    if (part.type === "tool-call") {
+      toolCalls.push({ toolName: part.toolName, input: part.input });
+    } else if (part.type === "tool-input-delta") {
+      concatenatedDeltas += part.delta;
+    } else if (part.type === "text-delta") {
+      text += part.delta;
+    }
+  }
+  return { toolCalls, concatenatedDeltas, text };
+}
+
+function largeBody(lines: number): string {
+  return Array.from(
+    { length: lines },
+    (_, i) => `line ${i}: const value_${i} = compute(${i});`
+  ).join("\n");
+}
+
+function hermesCall(toolName: string, args: unknown): string {
+  return `<tool_call>\n${JSON.stringify({ name: toolName, arguments: args })}\n</tool_call>`;
+}
+
+describe("hermes scan-throttle equivalence (deferral active above 4KB)", () => {
+  // Deferral only activates once the accumulated tool-call JSON exceeds 4KB,
+  // so these payloads must be large enough to exercise the deferred path
+  // against the single-chunk run (which never defers).
+  it("produces identical final tool calls for large streamed arguments", async () => {
+    const text = hermesCall("write_file", {
+      path: "a.ts",
+      content: largeBody(500), // ~20KB
+    });
+
+    const whole = summarize(await streamInChunks(text, text.length));
+    expect(whole.toolCalls).toHaveLength(1);
+
+    for (const chunkSize of [7, 30, 301]) {
+      const chunked = summarize(await streamInChunks(text, chunkSize));
+      expect(chunked.toolCalls).toEqual(whole.toolCalls);
+    }
+  });
+
+  it("handles trailing text and a second tool call after a large one", async () => {
+    const text = `${hermesCall("write_file", {
+      path: "a.ts",
+      content: largeBody(400),
+    })}\nplain trailing text\n${hermesCall("get_weather", { city: "Seoul" })}`;
+
+    const whole = summarize(await streamInChunks(text, text.length));
+    expect(whole.toolCalls).toHaveLength(2);
+
+    for (const chunkSize of [13, 64]) {
+      const chunked = summarize(await streamInChunks(text, chunkSize));
+      expect(chunked.toolCalls).toEqual(whole.toolCalls);
+      expect(chunked.text.trim()).toBe(whole.text.trim());
+    }
+  });
+
+  it("completes a call whose end tag arrives right at stream end", async () => {
+    // No trailing content after </tool_call>: completion relies on either
+    // the carry-based tag trigger or the finish catch-up scan.
+    const text = hermesCall("write_file", {
+      path: "a.ts",
+      content: largeBody(400),
+    });
+
+    const whole = summarize(await streamInChunks(text, text.length));
+    for (const chunkSize of [3, 17]) {
+      const chunked = summarize(await streamInChunks(text, chunkSize));
+      expect(chunked.toolCalls).toEqual(whole.toolCalls);
+      const parsed = JSON.parse(chunked.toolCalls[0].input);
+      expect(parsed.content).toContain("line 399:");
+    }
+  });
+
+  it("is not fooled by end-tag text inside a large JSON string value", async () => {
+    // The literal tag text inside the string is a deferral-trigger false
+    // positive: the forced full scan must see it is inside a string and keep
+    // going until the real close tag.
+    const content = `${largeBody(200)}\nfake tag: </tool_call> inside string\n${largeBody(200)}`;
+    const text = hermesCall("write_file", { path: "a.ts", content });
+
+    const whole = summarize(await streamInChunks(text, text.length));
+    expect(whole.toolCalls).toHaveLength(1);
+
+    const chunked = summarize(await streamInChunks(text, 23));
+    expect(chunked.toolCalls).toEqual(whole.toolCalls);
+    const parsed = JSON.parse(chunked.toolCalls[0].input);
+    expect(parsed.content).toContain("fake tag: </tool_call> inside string");
+  });
+
+  it("recovers an unclosed large call at finish identically for any chunking", async () => {
+    const body = JSON.stringify({
+      name: "write_file",
+      arguments: { path: "a.ts", content: largeBody(400) },
+    });
+    const text = `<tool_call>\n${body}`; // missing </tool_call>
+
+    const whole = summarize(await streamInChunks(text, text.length));
+    for (const chunkSize of [11, 47]) {
+      const chunked = summarize(await streamInChunks(text, chunkSize));
+      expect(chunked.toolCalls).toEqual(whole.toolCalls);
+      expect(chunked.text.trim()).toBe(whole.text.trim());
+    }
+  });
+});
+
+describe("hermes large streamed tool call scaling", () => {
+  // Regression guard: before scan throttling, a ~177KB string argument
+  // streamed in 30-char chunks rescanned the accumulated JSON per chunk
+  // (O(n^2), ~2.1s on a dev machine). Amortized scanning is ~50x faster; the
+  // generous bound keeps slow CI stable while still failing loudly on a
+  // quadratic regression.
+  it("parses a ~177KB streamed string argument well under the quadratic regime", async () => {
+    const text = hermesCall("write_file", {
+      path: "a.ts",
+      content: largeBody(4000),
+    });
+
+    const start = performance.now();
+    const parts = await streamInChunks(text, 30);
+    const elapsedMs = performance.now() - start;
+
+    const { toolCalls } = summarize(parts);
+    expect(toolCalls).toHaveLength(1);
+    const parsed = JSON.parse(toolCalls[0].input);
+    expect(parsed.content).toContain("line 3999:");
+
+    expect(elapsedMs).toBeLessThan(1500);
+  }, 30_000);
+});

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -303,11 +303,15 @@ function processInsideToolCallBoundary(context: TagProcessingContext): boolean {
 // currentToolCallJson + buffer from position 0, plus streaming-progress
 // recomputation) — O(total) per chunk and quadratic overall. Once the
 // combined length exceeds SCAN_DEFER_MIN_LENGTH, scans are amortized: they
-// only run after ~1/8 growth since the last scan. Geometric spacing keeps
-// total scan work linear. Deferral only delays observing a pending close
-// tag; a catch-up scan runs before finish reconciliation, so final outputs
-// are unchanged. Below the threshold, behavior is byte-identical.
+// only run after ~1/8 growth, capped at SCAN_DEFER_MAX_INTERVAL so
+// tool-input progress keeps a steady ~1KB cadence for the UI. Total scan
+// work stays bounded (O(n^2/1024), negligible at realistic sizes). Deferral
+// only delays observing a pending close tag (the carry-based tag trigger
+// catches arriving tags in the same chunk); a catch-up scan runs before
+// finish reconciliation, so final outputs are unchanged. Below the
+// threshold, behavior is byte-identical.
 const SCAN_DEFER_MIN_LENGTH = 4096;
+const SCAN_DEFER_MAX_INTERVAL = 1024;
 
 function shouldDeferToolCallScan(
   state: StreamState,
@@ -355,7 +359,8 @@ function scheduleNextToolCallScan(
   }
   const length = state.currentToolCallJson.length + state.buffer.length;
   state.toolCallScanDeferUntilLength =
-    length + Math.max(512, Math.floor(length / 8));
+    length +
+    Math.max(512, Math.min(SCAN_DEFER_MAX_INTERVAL, Math.floor(length / 8)));
   // After a scan pass the buffer holds at most a small partial-tag tail;
   // seed the carry from it so tags completing right after a scan are caught.
   const carryLength = Math.max(toolCallStart.length, toolCallEnd.length) - 1;

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -298,6 +298,78 @@ function processInsideToolCallBoundary(context: TagProcessingContext): boolean {
   return true;
 }
 
+// While a large tool-call JSON body streams in, every chunk used to rescan
+// the whole accumulated content (RJSON-aware boundary scan over
+// currentToolCallJson + buffer from position 0, plus streaming-progress
+// recomputation) — O(total) per chunk and quadratic overall. Once the
+// combined length exceeds SCAN_DEFER_MIN_LENGTH, scans are amortized: they
+// only run after ~1/8 growth since the last scan. Geometric spacing keeps
+// total scan work linear. Deferral only delays observing a pending close
+// tag; a catch-up scan runs before finish reconciliation, so final outputs
+// are unchanged. Below the threshold, behavior is byte-identical.
+const SCAN_DEFER_MIN_LENGTH = 4096;
+
+function shouldDeferToolCallScan(
+  state: StreamState,
+  appended: string,
+  toolCallStart: string,
+  toolCallEnd: string
+): boolean {
+  if (!state.isInsideToolCall) {
+    return false;
+  }
+  const length = state.currentToolCallJson.length + state.buffer.length;
+  if (length <= SCAN_DEFER_MIN_LENGTH) {
+    return false;
+  }
+  if (
+    state.toolCallScanDeferUntilLength === null ||
+    length >= state.toolCallScanDeferUntilLength
+  ) {
+    return false;
+  }
+  // Cheap boundary-tag trigger: a close (or nested start) tag arriving in
+  // the appended region forces an immediate full scan so tool-call
+  // completion is observed in the same chunk, exactly like the undeferred
+  // path. The carry covers tags split across chunk boundaries. A tag inside
+  // a JSON string is a false positive; the full scan then simply finds no
+  // boundary and deferral resumes.
+  const region = state.toolCallScanCarry + appended;
+  if (region.includes(toolCallEnd) || region.includes(toolCallStart)) {
+    return false;
+  }
+  const carryLength = Math.max(toolCallStart.length, toolCallEnd.length) - 1;
+  state.toolCallScanCarry = region.slice(-carryLength);
+  return true;
+}
+
+function scheduleNextToolCallScan(
+  state: StreamState,
+  toolCallStart: string,
+  toolCallEnd: string
+) {
+  if (!state.isInsideToolCall) {
+    state.toolCallScanDeferUntilLength = null;
+    state.toolCallScanCarry = "";
+    return;
+  }
+  const length = state.currentToolCallJson.length + state.buffer.length;
+  state.toolCallScanDeferUntilLength = length + Math.max(512, length >> 3);
+  // After a scan pass the buffer holds at most a small partial-tag tail;
+  // seed the carry from it so tags completing right after a scan are caught.
+  const carryLength = Math.max(toolCallStart.length, toolCallEnd.length) - 1;
+  state.toolCallScanCarry = state.buffer.slice(-carryLength);
+}
+
+function runDeferredToolCallScanCatchUp(context: TagProcessingContext) {
+  const { state, controller, toolCallStart, toolCallEnd, tools } = context;
+  state.hasDeferredToolCallScan = false;
+  processBufferTags(context);
+  if (state.isInsideToolCall) {
+    handlePartialTag(state, controller, toolCallStart, toolCallEnd, tools);
+  }
+}
+
 function processBufferTags(context: TagProcessingContext) {
   const { state, controller, toolCallStart } = context;
 
@@ -583,9 +655,12 @@ export const hermesProtocol = ({
       buffer: "",
       currentToolCallJson: "",
       currentTextId: null,
+      hasDeferredToolCallScan: false,
       hasEmittedTextStart: false,
       activeToolInput: null,
       pendingToolInputProgressVersion: 0,
+      toolCallScanCarry: "",
+      toolCallScanDeferUntilLength: null,
     };
 
     return new TransformStream<
@@ -594,6 +669,19 @@ export const hermesProtocol = ({
     >({
       transform(chunk, controller) {
         if (chunk.type === "finish") {
+          // A deferred boundary scan may hold a complete close tag (plus
+          // trailing content) in the buffer; catch up first so finish
+          // reconciliation sees exactly what the live path would have seen.
+          if (state.isInsideToolCall && state.hasDeferredToolCallScan) {
+            runDeferredToolCallScanCatchUp({
+              state,
+              controller,
+              toolCallStart,
+              toolCallEnd,
+              options,
+              tools,
+            });
+          }
           handleFinishChunk(
             state,
             controller,
@@ -620,6 +708,18 @@ export const hermesProtocol = ({
 
         const textContent = (chunk as { delta?: string }).delta ?? "";
         state.buffer += textContent;
+        if (
+          shouldDeferToolCallScan(
+            state,
+            textContent,
+            toolCallStart,
+            toolCallEnd
+          )
+        ) {
+          state.hasDeferredToolCallScan = true;
+          return;
+        }
+        state.hasDeferredToolCallScan = false;
         processBufferTags({
           state,
           controller,
@@ -629,6 +729,7 @@ export const hermesProtocol = ({
           tools,
         });
         handlePartialTag(state, controller, toolCallStart, toolCallEnd, tools);
+        scheduleNextToolCallScan(state, toolCallStart, toolCallEnd);
       },
     });
   },

--- a/src/core/protocols/hermes-protocol.ts
+++ b/src/core/protocols/hermes-protocol.ts
@@ -354,7 +354,8 @@ function scheduleNextToolCallScan(
     return;
   }
   const length = state.currentToolCallJson.length + state.buffer.length;
-  state.toolCallScanDeferUntilLength = length + Math.max(512, length >> 3);
+  state.toolCallScanDeferUntilLength =
+    length + Math.max(512, Math.floor(length / 8));
   // After a scan pass the buffer holds at most a small partial-tag tail;
   // seed the carry from it so tags completing right after a scan are caught.
   const carryLength = Math.max(toolCallStart.length, toolCallEnd.length) - 1;

--- a/src/core/protocols/hermes-streaming-progress.ts
+++ b/src/core/protocols/hermes-streaming-progress.ts
@@ -27,9 +27,29 @@ export interface StreamState {
   buffer: string;
   currentTextId: string | null;
   currentToolCallJson: string;
+  /**
+   * True while chunks were accumulated into `buffer` without running the
+   * boundary scan (see toolCallScanDeferUntilLength). A catch-up scan must
+   * run before finish reconciliation so deferred close tags are observed.
+   */
+  hasDeferredToolCallScan: boolean;
   hasEmittedTextStart: boolean;
   isInsideToolCall: boolean;
   pendingToolInputProgressVersion: number;
+  /**
+   * Tail of the already-buffered content used to detect boundary tags that
+   * span deferred chunks (at most max(tag length) - 1 chars).
+   */
+  toolCallScanCarry: string;
+  /**
+   * Amortizes full rescans of the accumulated tool-call JSON. While inside a
+   * tool call, every chunk used to rescan `currentToolCallJson + buffer`
+   * from position 0 (RJSON-aware boundary scan) plus recompute streaming
+   * progress — O(total) per chunk and quadratic overall. Once the combined
+   * length exceeds a threshold, scans only run after ~1/8 growth; geometric
+   * spacing keeps total scan work linear. Null when no scan has happened yet.
+   */
+  toolCallScanDeferUntilLength: number | null;
 }
 
 export type StreamController =


### PR DESCRIPTION
## Summary

Third and final parser in the incremental-streaming campaign (#396 morph-xml, #397 qwen3coder). hermes cost **~2.1s of CPU with quadratic scaling** for a ~177KB string argument streamed in 30-char chunks.

## Measured

| content size | before | after |
|---|---|---|
| 21KB | 32ms | 5ms |
| 42KB | 126ms | 8ms |
| 87KB | 481ms | 16ms |
| 177KB | 2,128ms | **38ms (~50x)** |
| 356KB | ~9s (extrapolated) | 98ms |

Scaling is now ~linear.

## What was quadratic

While a tool-call JSON body streams, every chunk:
- rebuilt `combined = currentToolCallJson + buffer` and ran the RJSON-aware boundary scan (`findToolCallBoundaryOutsideRjsonSyntax`) over it **from position 0**
- recomputed streaming progress: full `extractStreamingToolCallProgress` rescan + `parseRJSON` + `stringify` + full-prefix compare

## Design: geometric scan amortization (same pattern as #397)

- once `currentToolCallJson + buffer` exceeds **4KB**, the full scan pipeline runs only after **~1/8 growth** since the last scan ⇒ total scan work is O(n) amortized
- **below 4KB nothing changes** — byte-identical behavior including progress delta timing
- two mechanisms keep outputs identical to the undeferred path:
  1. **carry-based tag trigger** (hermes-specific): only the appended region (plus a `tagLen-1` carry for chunk-spanning tags) is checked for `</tool_call>` / nested `<tool_call>` text; a hit forces an immediate full scan, so call completion is observed in the *same chunk* as before. Tag text inside a JSON string is a deliberate false positive — the full scan sees it is inside a string and deferral resumes.
  2. **finish catch-up**: `runDeferredToolCallScanCatchUp` replays the normal `processBufferTags` + `handlePartialTag` pass before finish reconciliation, so unclosed-call salvage sees exactly the state the live path would have produced.

## Testing

- New equivalence tests (chunked-with-deferral vs single-chunk): large arguments, trailing text + second tool call, end tag at stream end, **end-tag text inside a JSON string value**, unclosed call recovered at finish
- New performance test: ~177KB streamed argument under a generous 1500ms bound (~38ms actual, ~2.1s before)
- Full suite: 2433 tests pass, no type errors

## Campaign result (all three PRs, ~173KB streamed argument)

| parser | before | after |
|---|---|---|
| morph-xml (#396) | 2,644ms | 66ms |
| qwen3coder (#397) | 6,810ms | 55ms |
| hermes (this PR) | 2,128ms | 38ms |

yaml-xml measured 219ms @180KB before the campaign — left as-is (below practical significance).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Amortizes Hermes streaming tool-call JSON scans to remove quadratic rescans and keep progress updates steady. After 4KB, rescans and progress recompute run only after ~1/8 growth capped at 1KB; a ~177KB case drops from ~2.1s to ~94ms (~20x) with identical outputs.

- **Refactors**
  - Defer full rescans once combined JSON > 4KB; schedule after ~1/8 growth with a 1KB max interval for steady tool-input delta cadence.
  - Carry-based trigger scans only the appended region for `</tool_call>` or nested `<tool_call>` and forces an immediate full scan on a hit, preserving same-chunk completion.
  - Catch-up scan runs before finish so unclosed-call recovery and progress deltas match previous behavior.
  - Fix Biome lint violations in the new scan throttle code (no behavior change).

<sup>Written for commit 2cd03814def9cde5589b2b1531a59f23a1851cac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

