### PR TITLE
docs(protocol): document qwen3coder format lineage

### DIFF
--- a/src/core/protocols/qwen3coder-protocol.ts
+++ b/src/core/protocols/qwen3coder-protocol.ts
@@ -1,3 +1,16 @@
+/**
+ * Format lineage:
+ * - `<function=name>` syntax: Llama 3.1 official prompt format
+ *   (meta-llama/llama-models, models/llama3_1/prompt_format.md)
+ * - `<parameter=key>` tags + "ONLY reply ... with NO suffix" instruction:
+ *   OpenHands fn_call_converter (now: OpenHands/software-agent-sdk,
+ *   openhands/sdk/llm/mixins/fn_call_converter.py)
+ * - `<tool_call>` wrapper + first native chat-template adoption: Qwen3-Coder
+ *   (org-wide Qwen standard since Qwen3.5)
+ *
+ * Named after Qwen3-Coder, matching vLLM's `qwen3_coder` tool parser name.
+ * The wrapper-less OpenHands original shape is covered by `uiTarsXmlProtocol`.
+ */
 import type { LanguageModelV4ToolCall } from "@ai-sdk/provider";
 import {
   escapeXmlMinimalAttr,


### PR DESCRIPTION
## Summary

Adds a lineage comment to `qwen3coder-protocol.ts` documenting where the format actually comes from, and why the protocol keeps the `qwen3coder` name.

Verified against primary sources:

- `<function=name>` syntax: Llama 3.1 official prompt format (`meta-llama/llama-models`, `models/llama3_1/prompt_format.md`)
- `<parameter=key>` tags + "ONLY reply in the following format with NO suffix" instruction: OpenHands `fn_call_converter` (still alive verbatim in `OpenHands/software-agent-sdk`)
- `<tool_call>` wrapper + first native chat-template adoption: Qwen3-Coder — confirmed org-wide standard in Qwen3.5 / Qwen3.6 chat templates on HF
- Name matches vLLM's `qwen3_coder` tool parser; the wrapper-less OpenHands original shape is what `uiTarsXmlProtocol` covers

Docs-only change, no runtime code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the qwen3coder protocol’s format lineage and naming in `src/core/protocols/qwen3coder-protocol.ts`. Clarifies sources (Llama 3.1 prompt format, OpenHands fn_call_converter, Qwen3‑Coder), alignment with vLLM’s `qwen3_coder`, and that `uiTarsXmlProtocol` covers the wrapper-less shape; no runtime changes.

<sup>Written for commit e14b2bbf05ef1ee1fdcd19daa7e3193c1215238b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

