### PR TITLE
chore: align CI coverage and publish access

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pnpm test -- -- --coverage
+          pnpm test --coverage
 
       # https://docs.codecov.com/docs/environment-specific-requirements#github-actions
       - name: Upload coverage to Codecov


### PR DESCRIPTION
## 요약
- pnpm 10에서 Vitest coverage 플래그가 실제로 전달되도록 CI 명령을 `pnpm test --coverage`로 수정합니다.
- 공개 npm 패키지의 `publishConfig.access: public` 의도에 맞춰 Changesets 기본 access를 `public`으로 정렬합니다.

## 확인
- 기존 명령은 `vitest run -- -- --coverage`, 중간 형태는 `vitest run -- --coverage`로 실행되어 coverage가 활성화되지 않음을 확인했습니다.
- 수정 명령은 `vitest run --coverage`로 실행되며 `Coverage enabled with v8` 및 coverage report 생성을 확인했습니다.
- Node.js v22.23.2 / pnpm 10.32.1에서 다음을 통과했습니다.
  - `pnpm check`
  - `pnpm typecheck`
  - `pnpm test` (224 files, 2479 tests)
  - `pnpm test --coverage` (224 files, 2479 tests)
  - `pnpm build`
  - `pnpm attw`
  - `pnpm test:package-consumers`

## 릴리스
CI/Changesets 메타 설정만 변경하며 패키지 산출물이나 런타임 동작은 바뀌지 않으므로 changeset은 추가하지 않았습니다.

기존 기능 PR #411 및 release PR #409의 코드나 상태는 변경하지 않습니다.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns CI coverage invocation for `pnpm` 10 and sets default `Changesets` publish access to `public` to match our npm packages. Previously coverage flags were ignored and `Changesets` defaulted to `restricted`; now coverage runs under `vitest` and the default access is `public`.

- CI: Use `pnpm test --coverage` in the code-quality workflow. Expect v8 coverage to generate and upload to Codecov; no other CI changes.
- Releases: `.changeset/config.json` now sets `"access": "public"`. If a package must stay private, set `publishConfig.access: restricted` or override the access in its changeset.
- No runtime or package output changes; no new changesets added.

<sup>Written for commit b5ff005acc8946f41ef5156a2e1a804c256bcc31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/ai-sdk-tool-call-middleware/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

