### PR TITLE
test: make performance guards deterministic

### DIFF
--- a/src/__tests__/protocols/hermes-protocol/stream/scan-throttle-equivalence.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/scan-throttle-equivalence.test.ts
@@ -1,12 +1,35 @@
 import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
 import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { hermesProtocol } from "../../../../core/protocols/hermes-protocol";
 import {
   pipeWithTransformer,
   stopFinishReason,
   zeroUsage,
 } from "../../../test-helpers";
+
+const boundaryScanWork = vi.hoisted(() => ({ characters: 0 }));
+
+vi.mock(
+  "../../../../core/protocols/hermes-call-boundary",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../../../core/protocols/hermes-call-boundary")
+      >();
+    return {
+      ...actual,
+      findToolCallBoundaryOutsideRjsonSyntax: (
+        ...args: Parameters<
+          typeof actual.findToolCallBoundaryOutsideRjsonSyntax
+        >
+      ) => {
+        boundaryScanWork.characters += args[0].length;
+        return actual.findToolCallBoundaryOutsideRjsonSyntax(...args);
+      },
+    };
+  }
+);
 
 const tools = [
   {
@@ -176,26 +199,20 @@ describe("hermes scan-throttle equivalence (deferral active above 4KB)", () => {
 });
 
 describe("hermes large streamed tool call scaling", () => {
-  // Regression guard: before scan throttling, a ~177KB string argument
-  // streamed in 30-char chunks rescanned the accumulated JSON per chunk
-  // (O(n^2), ~2.1s on a dev machine). Amortized scanning is ~50x faster; the
-  // generous bound keeps slow CI stable while still failing loudly on a
-  // quadratic regression.
-  it("parses a ~177KB streamed string argument well under the quadratic regime", async () => {
+  it("bounds boundary-scan work for a ~177KB streamed string argument", async () => {
     const text = hermesCall("write_file", {
       path: "a.ts",
       content: largeBody(4000),
     });
 
-    const start = performance.now();
+    boundaryScanWork.characters = 0;
     const parts = await streamInChunks(text, 30);
-    const elapsedMs = performance.now() - start;
 
     const { toolCalls } = summarize(parts);
     expect(toolCalls).toHaveLength(1);
     const parsed = JSON.parse(toolCalls[0].input);
     expect(parsed.content).toContain("line 3999:");
 
-    expect(elapsedMs).toBeLessThan(1500);
+    expect(boundaryScanWork.characters).toBeLessThan(text.length * 200);
   }, 30_000);
 });

--- a/src/__tests__/protocols/hermes-protocol/stream/scan-throttle-equivalence.test.ts
+++ b/src/__tests__/protocols/hermes-protocol/stream/scan-throttle-equivalence.test.ts
@@ -114,6 +114,20 @@ function hermesCall(toolName: string, args: unknown): string {
   return `<tool_call>\n${JSON.stringify({ name: toolName, arguments: args })}\n</tool_call>`;
 }
 
+const scalingChunkSize = 30;
+
+function naiveEveryChunkRescanCharacters(textLength: number): number {
+  let characters = 0;
+  for (
+    let length = scalingChunkSize;
+    length < textLength;
+    length += scalingChunkSize
+  ) {
+    characters += length;
+  }
+  return characters + textLength;
+}
+
 describe("hermes scan-throttle equivalence (deferral active above 4KB)", () => {
   // Deferral only activates once the accumulated tool-call JSON exceeds 4KB,
   // so these payloads must be large enough to exercise the deferred path
@@ -199,20 +213,37 @@ describe("hermes scan-throttle equivalence (deferral active above 4KB)", () => {
 });
 
 describe("hermes large streamed tool call scaling", () => {
-  it("bounds boundary-scan work for a ~177KB streamed string argument", async () => {
-    const text = hermesCall("write_file", {
-      path: "a.ts",
-      content: largeBody(4000),
-    });
+  // Before #398, every 30-character chunk rescanned the accumulated JSON:
+  // the exact arithmetic-series sum below models that O(n^2) work. Capped
+  // scan deferral intentionally remains O(n^2 / 1024), so comparing against
+  // a linear text-length budget is not scale invariant. Requiring at least a
+  // 10x reduction from naive rescanning preserves the algorithmic regression
+  // signal at every fixture size.
+  //
+  // #398 measured roughly 2.1s -> 38ms on its development setup (before the
+  // final steady-cadence cap). That plain-machine figure is not an absolute
+  // CI SLA: at this exact head the same case measured 298ms plain versus
+  // 1444ms with V8 coverage, with identical outputs and scan work. The work
+  // ratio isolates parser complexity from instrumentation and runner load.
+  it.each([1000, 2000, 4000])(
+    "reduces boundary-scan work by at least 10x for %i streamed lines",
+    async (lines) => {
+      const text = hermesCall("write_file", {
+        path: "a.ts",
+        content: largeBody(lines),
+      });
 
-    boundaryScanWork.characters = 0;
-    const parts = await streamInChunks(text, 30);
+      boundaryScanWork.characters = 0;
+      const parts = await streamInChunks(text, scalingChunkSize);
 
-    const { toolCalls } = summarize(parts);
-    expect(toolCalls).toHaveLength(1);
-    const parsed = JSON.parse(toolCalls[0].input);
-    expect(parsed.content).toContain("line 3999:");
+      const { toolCalls } = summarize(parts);
+      expect(toolCalls).toHaveLength(1);
+      const parsed = JSON.parse(toolCalls[0].input);
+      expect(parsed.content).toContain(`line ${lines - 1}:`);
 
-    expect(boundaryScanWork.characters).toBeLessThan(text.length * 200);
-  }, 30_000);
+      const naiveCharacters = naiveEveryChunkRescanCharacters(text.length);
+      expect(boundaryScanWork.characters * 10).toBeLessThan(naiveCharacters);
+    },
+    30_000
+  );
 });

--- a/src/__tests__/protocols/morph-xml-protocol/stream/large-content-scaling.performance.test.ts
+++ b/src/__tests__/protocols/morph-xml-protocol/stream/large-content-scaling.performance.test.ts
@@ -1,12 +1,35 @@
 import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
 import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { morphXmlProtocol } from "../../../../core/protocols/morph-xml-protocol";
 import {
   pipeWithTransformer,
   stopFinishReason,
   zeroUsage,
 } from "../../../test-helpers";
+
+const fullProgressParseWork = vi.hoisted(() => ({ characters: 0 }));
+
+vi.mock(
+  "../../../../core/protocols/morph-xml-stream-progress",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../../../core/protocols/morph-xml-stream-progress")
+      >();
+    return {
+      ...actual,
+      parseXmlContentForStreamProgressWithMeta: (
+        ...args: Parameters<
+          typeof actual.parseXmlContentForStreamProgressWithMeta
+        >
+      ) => {
+        fullProgressParseWork.characters += args[0].toolContent.length;
+        return actual.parseXmlContentForStreamProgressWithMeta(...args);
+      },
+    };
+  }
+);
 
 const tools = [
   {
@@ -25,8 +48,8 @@ const tools = [
 ] as any;
 
 async function streamLargeToolCall(lines: number): Promise<{
-  elapsedMs: number;
   input: string;
+  textLength: number;
 }> {
   const body = Array.from(
     { length: lines },
@@ -37,7 +60,6 @@ async function streamLargeToolCall(lines: number): Promise<{
   const protocol = morphXmlProtocol();
   const transformer = protocol.createStreamParser({ tools });
   const chunkSize = 30;
-  const start = performance.now();
   const rs = new ReadableStream<LanguageModelV4StreamPart>({
     start(ctrl) {
       for (let pos = 0; pos < text.length; pos += chunkSize) {
@@ -58,28 +80,22 @@ async function streamLargeToolCall(lines: number): Promise<{
   const parts = await convertReadableStreamToArray(
     pipeWithTransformer(rs, transformer)
   );
-  const elapsedMs = performance.now() - start;
   const toolCall = parts.find((part) => part.type === "tool-call");
   return {
-    elapsedMs,
     input: toolCall?.type === "tool-call" ? toolCall.input : "",
+    textLength: text.length,
   };
 }
 
 describe("morph-xml large streamed tool call scaling", () => {
-  // Regression guard for the incremental streaming progress path. Before the
-  // incremental shortcut, a ~173KB string argument streamed in 30-char chunks
-  // re-parsed the accumulated buffer on every chunk (O(n^2), ~2.6s on a dev
-  // machine). The incremental path is ~40x faster; the generous bound keeps
-  // the test stable on slow CI while still failing loudly on a quadratic
-  // regression.
-  it("parses a ~173KB streamed string argument well under the quadratic regime", async () => {
-    const { elapsedMs, input } = await streamLargeToolCall(4000);
+  it("bounds full progress parsing work for a ~173KB streamed string argument", async () => {
+    fullProgressParseWork.characters = 0;
+    const { input, textLength } = await streamLargeToolCall(4000);
 
     const parsed = JSON.parse(input);
     expect(parsed.path).toBe("src/out.ts");
     expect(parsed.content).toContain("line 3999:");
 
-    expect(elapsedMs).toBeLessThan(1500);
+    expect(fullProgressParseWork.characters).toBeLessThan(textLength * 3);
   }, 30_000);
 });

--- a/src/__tests__/protocols/morph-xml-protocol/stream/large-content-scaling.performance.test.ts
+++ b/src/__tests__/protocols/morph-xml-protocol/stream/large-content-scaling.performance.test.ts
@@ -88,6 +88,11 @@ async function streamLargeToolCall(lines: number): Promise<{
 }
 
 describe("morph-xml large streamed tool call scaling", () => {
+  // Before #396, each 30-character chunk reparsed the accumulated XML
+  // progress (O(n^2), roughly 2.6s on its development setup). The incremental
+  // path limits full progress parsing to about 2x input length, so this linear
+  // work budget preserves the original ~40x algorithmic regression signal
+  // without depending on coverage instrumentation or runner speed.
   it("bounds full progress parsing work for a ~173KB streamed string argument", async () => {
     fullProgressParseWork.characters = 0;
     const { input, textLength } = await streamLargeToolCall(4000);

--- a/src/__tests__/protocols/qwen3coder-protocol/stream/scan-throttle-equivalence.test.ts
+++ b/src/__tests__/protocols/qwen3coder-protocol/stream/scan-throttle-equivalence.test.ts
@@ -1,12 +1,39 @@
 import type { LanguageModelV4StreamPart } from "@ai-sdk/provider";
 import { convertReadableStreamToArray } from "@ai-sdk/provider-utils/test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { qwen3CoderProtocol } from "../../../../core/protocols/qwen3coder-protocol";
 import {
   pipeWithTransformer,
   stopFinishReason,
   zeroUsage,
 } from "../../../test-helpers";
+
+const fullCallParseWork = vi.hoisted(() => ({ characters: 0 }));
+
+vi.mock(
+  "../../../../core/protocols/qwen3coder-stream-call-consumption",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../../../core/protocols/qwen3coder-stream-call-consumption")
+      >();
+    return {
+      ...actual,
+      createQwenStreamCallConsumption: (
+        ...args: Parameters<typeof actual.createQwenStreamCallConsumption>
+      ) => {
+        const [options] = args;
+        return actual.createQwenStreamCallConsumption({
+          ...options,
+          parseStreamingCallContent: (...parseArgs) => {
+            fullCallParseWork.characters += parseArgs[2].length;
+            return options.parseStreamingCallContent(...parseArgs);
+          },
+        });
+      },
+    };
+  }
+);
 
 const tools = [
   {
@@ -87,6 +114,32 @@ function largeBody(lines: number): string {
   ).join("\n");
 }
 
+const scalingChunkSize = 30;
+
+function naiveEveryChunkRescanCharacters(textLength: number): number {
+  let characters = 0;
+  for (
+    let length = scalingChunkSize;
+    length < textLength;
+    length += scalingChunkSize
+  ) {
+    characters += length;
+  }
+  return characters + textLength;
+}
+
+function qwenCall(lines: number): string {
+  const body = largeBody(lines);
+  return `<tool_call>
+<function=write_file>
+<parameter=path>a.ts</parameter>
+<parameter=content>
+${body}
+</parameter>
+</function>
+</tool_call>`;
+}
+
 describe("qwen3coder scan-throttle equivalence (deferral active above 4KB)", () => {
   // Deferral only activates once the call buffer exceeds 4KB, so these
   // payloads must be large enough to exercise the deferred path against the
@@ -150,24 +203,29 @@ describe("qwen3coder scan-throttle equivalence (deferral active above 4KB)", () 
 });
 
 describe("qwen3coder large streamed tool call scaling", () => {
-  // Regression guard: before scan throttling, a ~173KB string argument
-  // streamed in 30-char chunks rescanned the whole call buffer per chunk
-  // (O(n^2), ~6.8s on a dev machine). Amortized scanning is ~120x faster;
-  // the generous bound keeps slow CI stable while still failing loudly on a
-  // quadratic regression.
-  it("parses a ~173KB streamed string argument well under the quadratic regime", async () => {
-    const body = largeBody(4000);
-    const text = `<tool_call>\n<function=write_file>\n<parameter=path>a.ts</parameter>\n<parameter=content>\n${body}\n</parameter>\n</function>\n</tool_call>`;
+  // Before #397, every 30-character chunk rescanned and reparsed the whole
+  // accumulated call buffer (O(n^2), roughly 6.8s -> 55ms on its development
+  // setup). As with Hermes, the capped 1KB cadence deliberately leaves
+  // O(n^2 / 1024) work. Comparing measured full-parse characters with the
+  // exact naive arithmetic-series sum remains scale invariant and avoids the
+  // same coverage/runner sensitivity that put this guard at 1272ms/1500ms in
+  // the failing main CI run.
+  it.each([1000, 2000, 4000])(
+    "reduces full call parsing work by at least 10x for %i streamed lines",
+    async (lines) => {
+      const text = qwenCall(lines);
 
-    const start = performance.now();
-    const parts = await streamInChunks(text, 30);
-    const elapsedMs = performance.now() - start;
+      fullCallParseWork.characters = 0;
+      const parts = await streamInChunks(text, scalingChunkSize);
 
-    const { toolCalls } = summarize(parts);
-    expect(toolCalls).toHaveLength(1);
-    const parsed = JSON.parse(toolCalls[0].input);
-    expect(parsed.content).toContain("line 3999:");
+      const { toolCalls } = summarize(parts);
+      expect(toolCalls).toHaveLength(1);
+      const parsed = JSON.parse(toolCalls[0].input);
+      expect(parsed.content).toContain(`line ${lines - 1}:`);
 
-    expect(elapsedMs).toBeLessThan(1500);
-  }, 30_000);
+      const naiveCharacters = naiveEveryChunkRescanCharacters(text.length);
+      expect(fullCallParseWork.characters * 10).toBeLessThan(naiveCharacters);
+    },
+    30_000
+  );
 });


### PR DESCRIPTION
## Summary
- replace Hermes, Morph, and Qwen3Coder fixed wall-clock performance limits with deterministic work budgets at their real scan/reparse seams
- make capped-scan guards scale invariant by requiring at least 10x less work than exact every-30-character naive rescanning at 1000, 2000, and 4000 lines
- preserve parser output assertions and production behavior

## Why wall-clock was retired
The original #398 development number (~38ms, before the final steady-cadence cap) is not comparable to instrumented shared CI. At the exact PR head, the same Hermes 4000-line test measured **298ms plain vs 1444ms with V8 coverage** (4.85x) with identical output and scan work; the prior whole-suite CI failure was 1638.6ms. Qwen3Coder likewise reached 1272ms/1500ms in that CI run. Fixed milliseconds therefore measure instrumentation and runner load, while character-work ratios retain the intended algorithmic regression signal.

## RED evidence
- original CI run 33306275765: Hermes `1638.575621ms < 1500ms` failed on exact main head
- Hermes deferral-disabled mutation: all three sizes failed; 4000 lines produced `5447142190 < 544780505` for `(work * 10) < naive`
- Qwen3Coder deferral-disabled mutation: all three sizes failed; 4000 lines produced `5206171640 < 521176924`
- Morph incremental-shortcut-disabled mutation: `520752604 < 530223` failed

## GREEN evidence
- focused plain: 3 files, 16 tests passed
- focused coverage: 3 files, 16 tests passed
- `pnpm check`: passed
- full `pnpm test --coverage`: 224 files, 2483 tests passed